### PR TITLE
fix(state): harden STATE.md parsing for format drift resilience

### DIFF
--- a/packages/cli/tests/unit/parsing.test.ts
+++ b/packages/cli/tests/unit/parsing.test.ts
@@ -236,11 +236,20 @@ describe('stateExtractField', () => {
     expect(stateExtractField(stateContent, 'Progress')).toBeNull();
   });
 
-  it('does NOT match non-bold "Key: value" format', () => {
-    // STATE.md sometimes has plain "Phase: 01" lines — stateExtractField should NOT match these
+  it('falls back to plain "Key: value" format when bold markers are missing', () => {
     const plainContent = 'Phase: 01\nStatus: plain value\n';
-    expect(stateExtractField(plainContent, 'Phase')).toBeNull();
-    expect(stateExtractField(plainContent, 'Status')).toBeNull();
+    expect(stateExtractField(plainContent, 'Phase')).toBe('01');
+    expect(stateExtractField(plainContent, 'Status')).toBe('plain value');
+  });
+
+  it('prefers bold format over plain when both exist', () => {
+    const mixedContent = '**Phase:** 02\nPhase: 01\n';
+    expect(stateExtractField(mixedContent, 'Phase')).toBe('02');
+  });
+
+  it('tolerates extra whitespace in bold field markers', () => {
+    const spaceyContent = '**  Current Phase :  ** 03\n';
+    expect(stateExtractField(spaceyContent, 'Current Phase')).toBe('03');
   });
 
   it('extracts value including special characters and dashes', () => {


### PR DESCRIPTION
## Summary
- **stateExtractField/stateReplaceField**: Escape `fieldName` in regex via `escapeStringRegexp()`, tolerate extra whitespace in bold markers (`**  fieldName :  **`), add plain `fieldName: value` fallback when bold markers are missing
- **Table parsing**: New `parseTableRow` helper handles escaped pipes (`\|`) in cell content; flexible separator line detection (`|---|`, `| --- |`, `|:---|`); skip blank lines between rows
- **Blocker extraction**: Match both `-` and `*` bullets, including indented bullets (`  - ` or `  * `)
- **Section matching**: Tolerate `##` and `###` heading levels and extra blank lines after section headers
- **Deduplication**: `cmdStatePatch`, `cmdStateUpdate`, `cmdStateUpdateProgress`, and `cmdStateSnapshot` now reuse `stateReplaceField`/`stateExtractField` instead of inline regex patterns
- **Efficiency**: `stateReplaceField` uses single `replace()` + string comparison instead of `test()` + `replace()` double-pass

## Test plan
- [x] All 56 unit tests pass (including 2 new tests for plain-format fallback and whitespace tolerance)
- [x] Full build (`npm run build`) succeeds
- [x] Lint (`npm run lint`) passes with no issues
- [x] No external API changes — only internal parsing logic made more tolerant

🤖 Generated with [Claude Code](https://claude.com/claude-code)