### PR TITLE
test(core): add error-path tests for state.ts and core.ts

### DIFF
--- a/packages/cli/tests/unit/core-errors.test.ts
+++ b/packages/cli/tests/unit/core-errors.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Error-path tests for core.ts
+ *
+ * Validates graceful handling of corrupted configs, nonexistent files,
+ * and edge-case inputs for the pure utility functions in core.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
+import {
+  loadConfig,
+  safeReadFile,
+  normalizePhaseName,
+  comparePhaseNum,
+  findPhaseInternal,
+  escapePhaseNum,
+  listSubDirs,
+} from '../../src/core/core.js';
+
+// ─── loadConfig — error paths ────────────────────────────────────────────────
+
+describe('loadConfig error paths', () => {
+  // loadConfig has an internal cache keyed by cwd. We use unique fake paths
+  // per test to avoid cache interference.
+
+  it('returns defaults when config.json does not exist', () => {
+    const fakeCwd = path.join(os.tmpdir(), `maxsim-test-no-config-${Date.now()}`);
+    const config = loadConfig(fakeCwd);
+    expect(config.model_profile).toBe('balanced');
+    expect(config.commit_docs).toBe(true);
+    expect(config.branching_strategy).toBe('none');
+    expect(config.research).toBe(true);
+    expect(config.plan_checker).toBe(true);
+    expect(config.verifier).toBe(true);
+    expect(config.parallelization).toBe(true);
+    expect(config.brave_search).toBe(false);
+  });
+
+  it('returns defaults when config.json contains corrupted JSON', () => {
+    const fakeCwd = path.join(os.tmpdir(), `maxsim-test-corrupt-${Date.now()}`);
+    const cfgDir = path.join(fakeCwd, '.planning');
+    fs.mkdirSync(cfgDir, { recursive: true });
+    fs.writeFileSync(path.join(cfgDir, 'config.json'), '{invalid json!!!', 'utf-8');
+
+    const config = loadConfig(fakeCwd);
+    expect(config.model_profile).toBe('balanced');
+    expect(config.commit_docs).toBe(true);
+    expect(config.branching_strategy).toBe('none');
+
+    // Cleanup
+    fs.rmSync(fakeCwd, { recursive: true, force: true });
+  });
+
+  it('returns defaults when config.json is empty', () => {
+    const fakeCwd = path.join(os.tmpdir(), `maxsim-test-empty-cfg-${Date.now()}`);
+    const cfgDir = path.join(fakeCwd, '.planning');
+    fs.mkdirSync(cfgDir, { recursive: true });
+    fs.writeFileSync(path.join(cfgDir, 'config.json'), '', 'utf-8');
+
+    const config = loadConfig(fakeCwd);
+    // Empty string is invalid JSON, so catch block returns defaults
+    expect(config.model_profile).toBe('balanced');
+
+    fs.rmSync(fakeCwd, { recursive: true, force: true });
+  });
+
+  it('merges partial config with defaults', () => {
+    const fakeCwd = path.join(os.tmpdir(), `maxsim-test-partial-${Date.now()}`);
+    const cfgDir = path.join(fakeCwd, '.planning');
+    fs.mkdirSync(cfgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cfgDir, 'config.json'),
+      JSON.stringify({ model_profile: 'quality' }),
+      'utf-8',
+    );
+
+    const config = loadConfig(fakeCwd);
+    expect(config.model_profile).toBe('quality');
+    // Other fields should be defaults
+    expect(config.commit_docs).toBe(true);
+    expect(config.branching_strategy).toBe('none');
+
+    fs.rmSync(fakeCwd, { recursive: true, force: true });
+  });
+
+  it('returns cached config on second call with same cwd', () => {
+    const fakeCwd = path.join(os.tmpdir(), `maxsim-test-cache-${Date.now()}`);
+    const config1 = loadConfig(fakeCwd);
+    const config2 = loadConfig(fakeCwd);
+    // Should be the exact same object reference (cached)
+    expect(config1).toBe(config2);
+  });
+});
+
+// ─── safeReadFile — error paths ──────────────────────────────────────────────
+
+describe('safeReadFile error paths', () => {
+  it('returns null for a nonexistent file path', () => {
+    const result = safeReadFile('/nonexistent/path/to/file.txt');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a path that is a directory, not a file', () => {
+    const result = safeReadFile(os.tmpdir());
+    // Reading a directory with readFileSync throws, so safeReadFile returns null
+    expect(result).toBeNull();
+  });
+
+  it('returns file content for a valid file', () => {
+    const tmpFile = path.join(os.tmpdir(), `maxsim-test-safe-read-${Date.now()}.txt`);
+    fs.writeFileSync(tmpFile, 'hello world', 'utf-8');
+    const result = safeReadFile(tmpFile);
+    expect(result).toBe('hello world');
+    fs.unlinkSync(tmpFile);
+  });
+
+  it('returns empty string for an empty file (not null)', () => {
+    const tmpFile = path.join(os.tmpdir(), `maxsim-test-empty-${Date.now()}.txt`);
+    fs.writeFileSync(tmpFile, '', 'utf-8');
+    const result = safeReadFile(tmpFile);
+    expect(result).toBe('');
+    fs.unlinkSync(tmpFile);
+  });
+});
+
+// ─── normalizePhaseName — edge cases ─────────────────────────────────────────
+
+describe('normalizePhaseName edge cases', () => {
+  it('returns empty string unchanged for empty input', () => {
+    expect(normalizePhaseName('')).toBe('');
+  });
+
+  it('returns input unchanged for special characters only', () => {
+    expect(normalizePhaseName('---')).toBe('---');
+    expect(normalizePhaseName('!!!')).toBe('!!!');
+    expect(normalizePhaseName('@#$')).toBe('@#$');
+  });
+
+  it('returns input unchanged for pure alphabetic input (no leading digits)', () => {
+    expect(normalizePhaseName('abc')).toBe('abc');
+    expect(normalizePhaseName('Foundation')).toBe('Foundation');
+  });
+
+  it('handles very large numbers', () => {
+    expect(normalizePhaseName('999')).toBe('999');
+    expect(normalizePhaseName('100')).toBe('100');
+  });
+
+  it('handles single digit with letter and decimal', () => {
+    // Edge case: letter + decimal not typical but let's see behavior
+    expect(normalizePhaseName('1A.1')).toBe('01A.1');
+  });
+
+  it('only matches first letter suffix (single letter)', () => {
+    // "1AB" — regex matches (\d+)([A-Z])? so captures "1" and "A", "B" is ignored
+    const result = normalizePhaseName('1AB');
+    expect(result).toBe('01A');
+  });
+
+  it('handles leading zeros beyond 2 digits', () => {
+    expect(normalizePhaseName('001')).toBe('001');
+  });
+
+  it('handles phase number with trailing text after the number part', () => {
+    // "01-Foundation" — regex /^(\d+)([A-Z])?(\.\d+)?/i matches "01" prefix
+    // The function reconstructs from captured groups: padded + letter + decimal = "01"
+    // The trailing "-Foundation" is NOT included in the result
+    const result = normalizePhaseName('01-Foundation');
+    expect(result).toBe('01');
+  });
+});
+
+// ─── comparePhaseNum — edge cases ────────────────────────────────────────────
+
+describe('comparePhaseNum edge cases', () => {
+  it('handles empty strings (falls back to localeCompare)', () => {
+    const result = comparePhaseNum('', '');
+    expect(result).toBe(0);
+  });
+
+  it('handles one empty string and one valid phase', () => {
+    // Empty string doesn't match the regex, so falls back to localeCompare
+    const result = comparePhaseNum('', '01');
+    expect(typeof result).toBe('number');
+  });
+
+  it('handles special characters (falls back to localeCompare)', () => {
+    const result = comparePhaseNum('---', '!!!');
+    expect(typeof result).toBe('number');
+  });
+
+  it('handles numeric input (number type)', () => {
+    expect(comparePhaseNum(1, 2)).toBeLessThan(0);
+    expect(comparePhaseNum(10, 3)).toBeGreaterThan(0);
+    expect(comparePhaseNum(5, 5)).toBe(0);
+  });
+
+  it('handles mixed numeric and string input', () => {
+    expect(comparePhaseNum(1, '2')).toBeLessThan(0);
+    expect(comparePhaseNum('1', 2)).toBeLessThan(0);
+  });
+
+  it('handles same integer but one with letter and one with decimal', () => {
+    // 01A vs 01.1 — letter sorts before decimal in the algorithm
+    // Letter: la='A', lb='' (no letter in 01.1), so lb is empty → la wins (return 1 for A having a letter)
+    // Actually: 01A matches (\d+)([A-Z])?(\.\d+)? → [1]='01', [2]='A', [3]=undefined
+    //           01.1 matches → [1]='01', [2]=undefined, [3]='.1'
+    // la='A', lb='' → !lb is true → return 1 (A comes AFTER no-letter)
+    // So 01A > 01.1? Let's verify:
+    const result = comparePhaseNum('01A', '01.1');
+    // The algorithm: la='A', lb=''. !la is false, !lb is true → return 1
+    // So 01A > 01.1
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('handles zero as phase number', () => {
+    expect(comparePhaseNum('0', '1')).toBeLessThan(0);
+    expect(comparePhaseNum('00', '01')).toBeLessThan(0);
+  });
+});
+
+// ─── escapePhaseNum ──────────────────────────────────────────────────────────
+
+describe('escapePhaseNum edge cases', () => {
+  it('escapes dots in phase numbers', () => {
+    expect(escapePhaseNum('01.1')).toBe('01\\.1');
+  });
+
+  it('returns plain number string unchanged', () => {
+    expect(escapePhaseNum('01')).toBe('01');
+    expect(escapePhaseNum('1')).toBe('1');
+  });
+
+  it('handles numeric input', () => {
+    expect(escapePhaseNum(1)).toBe('1');
+    expect(escapePhaseNum(10)).toBe('10');
+  });
+
+  it('handles multiple dots', () => {
+    expect(escapePhaseNum('1.2.3')).toBe('1\\.2\\.3');
+  });
+
+  it('handles empty string', () => {
+    expect(escapePhaseNum('')).toBe('');
+  });
+});
+
+// ─── findPhaseInternal / searchPhaseInDir — nonexistent directory ─────────────
+
+describe('findPhaseInternal with nonexistent directory', () => {
+  it('returns null when phases directory does not exist', () => {
+    const fakeCwd = path.join(os.tmpdir(), `maxsim-test-no-phases-${Date.now()}`);
+    const result = findPhaseInternal(fakeCwd, '01');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty phase string', () => {
+    const fakeCwd = path.join(os.tmpdir(), `maxsim-test-empty-phase-${Date.now()}`);
+    const result = findPhaseInternal(fakeCwd, '');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when phases directory exists but is empty', () => {
+    const fakeCwd = path.join(os.tmpdir(), `maxsim-test-empty-dir-${Date.now()}`);
+    const phasesDir = path.join(fakeCwd, '.planning', 'phases');
+    fs.mkdirSync(phasesDir, { recursive: true });
+
+    const result = findPhaseInternal(fakeCwd, '01');
+    expect(result).toBeNull();
+
+    fs.rmSync(fakeCwd, { recursive: true, force: true });
+  });
+
+  it('finds a phase when directory matches', () => {
+    const fakeCwd = path.join(os.tmpdir(), `maxsim-test-find-phase-${Date.now()}`);
+    const phaseDir = path.join(fakeCwd, '.planning', 'phases', '01-Foundation');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    // Create a plan file
+    fs.writeFileSync(path.join(phaseDir, '01-01-PLAN.md'), '# Plan', 'utf-8');
+
+    const result = findPhaseInternal(fakeCwd, '01');
+    expect(result).not.toBeNull();
+    expect(result!.found).toBe(true);
+    expect(result!.phase_number).toBe('01');
+    expect(result!.phase_name).toBe('Foundation');
+    expect(result!.plans).toContain('01-01-PLAN.md');
+
+    fs.rmSync(fakeCwd, { recursive: true, force: true });
+  });
+});
+
+// ─── listSubDirs — error paths ───────────────────────────────────────────────
+
+describe('listSubDirs error paths', () => {
+  it('throws when directory does not exist', () => {
+    expect(() => listSubDirs('/nonexistent/directory/path')).toThrow();
+  });
+
+  it('returns empty array for an empty directory', () => {
+    const tmpDir = path.join(os.tmpdir(), `maxsim-test-empty-subdir-${Date.now()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    expect(listSubDirs(tmpDir)).toEqual([]);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('ignores files, only returns directories', () => {
+    const tmpDir = path.join(os.tmpdir(), `maxsim-test-files-subdir-${Date.now()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'file.txt'), 'content', 'utf-8');
+    fs.mkdirSync(path.join(tmpDir, 'subdir'));
+
+    const result = listSubDirs(tmpDir);
+    expect(result).toEqual(['subdir']);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/packages/cli/tests/unit/state-errors.test.ts
+++ b/packages/cli/tests/unit/state-errors.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Error-path tests for state.ts
+ *
+ * Validates graceful handling of malformed input, missing fields, empty content,
+ * and edge cases in the pure string-processing functions exported by state.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  stateExtractField,
+  stateReplaceField,
+  appendToStateSection,
+} from '../../src/core/state.js';
+
+// ─── stateExtractField — error paths ─────────────────────────────────────────
+
+describe('stateExtractField error paths', () => {
+  it('returns null for empty string content', () => {
+    expect(stateExtractField('', 'Status')).toBeNull();
+  });
+
+  it('returns null when the field does not exist', () => {
+    const content = '**Status:** Active\n**Phase:** 01\n';
+    expect(stateExtractField(content, 'Missing')).toBeNull();
+    expect(stateExtractField(content, 'Nonexistent Field')).toBeNull();
+  });
+
+  it('returns null for malformed markdown (no bold markers)', () => {
+    const content = 'Status: Active\nPhase: 01\n';
+    expect(stateExtractField(content, 'Status')).toBeNull();
+  });
+
+  it('returns null for partial bold markers', () => {
+    const content = '**Status: Active\nStatus:** Active\n';
+    expect(stateExtractField(content, 'Status')).toBeNull();
+  });
+
+  it('returns null for bold field with no value after it', () => {
+    // The regex requires .+ (one or more chars) after the colon
+    const content = '**Status:**\n';
+    expect(stateExtractField(content, 'Status')).toBeNull();
+  });
+
+  it('returns the value when there is a space but text follows', () => {
+    const content = '**Status:** \n';
+    // .+ requires at least one non-newline char; a single space is matched
+    // but trim() produces empty string — let's document actual behavior
+    const result = stateExtractField(content, 'Status');
+    // The regex `.+` matches " " (one space), then trim() returns ""
+    expect(result).toBe('');
+  });
+
+  it('does NOT escape regex metacharacters in fieldName (known limitation)', () => {
+    // stateExtractField does NOT use escapeStringRegexp, unlike stateReplaceField.
+    // Field names containing regex metacharacters like () [] will be treated as regex.
+    const content = '**Total Plans (Phase):** 5\n';
+
+    // Parentheses are interpreted as a regex group, not literal chars.
+    // The regex becomes: \*\*Total Plans (Phase):\*\*\s*(.+)
+    // (Phase) becomes a capturing group, which shifts the capture groups so
+    // group[1] captures "Phase" instead of the value "5".
+    // This means the function returns null or the wrong value.
+    const result = stateExtractField(content, 'Total Plans (Phase)');
+    // Known bug: returns null because the regex groups are shifted
+    expect(result).toBeNull();
+  });
+
+  it('fails to match field names with brackets due to unescaped regex', () => {
+    const content = '**Status [v2]:** Active\n';
+    // [v2] is a character class matching v or 2, not literal "[v2]"
+    // This tests a known limitation: stateExtractField doesn't escape fieldName
+    const result = stateExtractField(content, 'Status [v2]');
+    // The regex \*\*Status [v2]:\*\* treats [v2] as a character class
+    // matching a single char (v or 2), so it won't match "[v2]" literally.
+    // The field content has " [v2]" which won't match. Document actual behavior:
+    expect(result).toBeNull();
+  });
+
+  it('handles content with only whitespace', () => {
+    expect(stateExtractField('   \n  \n  ', 'Status')).toBeNull();
+  });
+
+  it('handles empty fieldName', () => {
+    const content = '**Status:** Active\n';
+    // Empty fieldName creates regex: \*\*:\*\*\s*(.+)
+    // This won't match "**Status:**" since there's text between ** and :
+    const result = stateExtractField(content, '');
+    expect(result).toBeNull();
+  });
+});
+
+// ─── stateReplaceField — error paths ─────────────────────────────────────────
+
+describe('stateReplaceField error paths', () => {
+  it('returns null when field does not exist in content', () => {
+    const content = '**Status:** Active\n';
+    expect(stateReplaceField(content, 'Missing', 'value')).toBeNull();
+  });
+
+  it('returns null for empty content', () => {
+    expect(stateReplaceField('', 'Status', 'value')).toBeNull();
+  });
+
+  it('returns null for content with no bold fields', () => {
+    const content = 'Status: Active\nPhase: 01\n';
+    expect(stateReplaceField(content, 'Status', 'Done')).toBeNull();
+  });
+
+  it('properly escapes regex metacharacters in fieldName', () => {
+    // stateReplaceField uses escapeStringRegexp, so this should work correctly
+    const content = '**Total Plans (Phase):** 5\n';
+    const result = stateReplaceField(content, 'Total Plans (Phase)', '10');
+    expect(result).not.toBeNull();
+    expect(result).toContain('**Total Plans (Phase):** 10');
+  });
+
+  it('properly escapes brackets in fieldName', () => {
+    const content = '**Status [v2]:** Active\n';
+    const result = stateReplaceField(content, 'Status [v2]', 'Done');
+    expect(result).not.toBeNull();
+    expect(result).toContain('**Status [v2]:** Done');
+  });
+
+  it('handles replacement with empty string', () => {
+    const content = '**Status:** Active\n';
+    const result = stateReplaceField(content, 'Status', '');
+    expect(result).not.toBeNull();
+    expect(result).toContain('**Status:** ');
+  });
+
+  it('handles content that is just a field with no trailing newline', () => {
+    const content = '**Status:** Active';
+    const result = stateReplaceField(content, 'Status', 'Done');
+    expect(result).not.toBeNull();
+    expect(result).toBe('**Status:** Done');
+  });
+});
+
+// ─── appendToStateSection — error paths ──────────────────────────────────────
+
+describe('appendToStateSection error paths', () => {
+  const sectionPattern = /(##\s*Decisions\s*\n)([\s\S]*?)(?=\n##|$)/i;
+
+  it('returns null when the target section is missing', () => {
+    const content = '## Other Section\nSome content\n';
+    const result = appendToStateSection(content, sectionPattern, '- New decision');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty content', () => {
+    const result = appendToStateSection('', sectionPattern, '- New decision');
+    expect(result).toBeNull();
+  });
+
+  it('appends to an empty section body', () => {
+    const content = '## Decisions\n\n## Next Section\n';
+    const result = appendToStateSection(content, sectionPattern, '- New decision');
+    expect(result).not.toBeNull();
+    expect(result).toContain('- New decision');
+  });
+
+  it('strips placeholder text before appending', () => {
+    const content = '## Decisions\nNone yet.\n\n## Next Section\n';
+    const result = appendToStateSection(content, sectionPattern, '- First decision');
+    expect(result).not.toBeNull();
+    expect(result).toContain('- First decision');
+    expect(result).not.toContain('None yet');
+  });
+
+  it('strips "None." placeholder', () => {
+    const content = '## Decisions\nNone.\n\n## Next Section\n';
+    const result = appendToStateSection(content, sectionPattern, '- Entry');
+    expect(result).not.toBeNull();
+    expect(result).not.toContain('None.');
+    expect(result).toContain('- Entry');
+  });
+
+  it('strips "No decisions yet" placeholder', () => {
+    const content = '## Decisions\nNo decisions yet.\n\n## Next Section\n';
+    const result = appendToStateSection(content, sectionPattern, '- Entry');
+    expect(result).not.toBeNull();
+    expect(result).not.toContain('No decisions yet');
+  });
+
+  it('uses custom placeholder patterns when provided', () => {
+    const content = '## Decisions\nTBD\n\n## Next Section\n';
+    const customPlaceholders = [/TBD\s*\n?/gi];
+    const result = appendToStateSection(content, sectionPattern, '- Entry', customPlaceholders);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain('TBD');
+    expect(result).toContain('- Entry');
+  });
+
+  it('preserves existing entries when appending', () => {
+    const content = '## Decisions\n- Existing decision\n\n## Next Section\n';
+    const result = appendToStateSection(content, sectionPattern, '- New decision');
+    expect(result).not.toBeNull();
+    expect(result).toContain('- Existing decision');
+    expect(result).toContain('- New decision');
+  });
+
+  it('handles section at end of content (no following section)', () => {
+    const content = '## Decisions\nNone yet.\n';
+    const endPattern = /(##\s*Decisions\s*\n)([\s\S]*?)$/i;
+    const result = appendToStateSection(content, endPattern, '- Entry');
+    expect(result).not.toBeNull();
+    expect(result).toContain('- Entry');
+  });
+});
+
+// ─── Blocker extraction patterns ─────────────────────────────────────────────
+
+describe('blocker extraction edge cases', () => {
+  // The blocker extraction in cmdStateSnapshot uses:
+  //   /^-\s+(.+)$/gm
+  // Let's test the regex directly on edge-case inputs
+
+  const blockerLinePattern = /^-\s+(.+)$/gm;
+
+  it('returns no matches for empty section', () => {
+    const section = '';
+    const matches = section.match(blockerLinePattern) || [];
+    expect(matches).toEqual([]);
+  });
+
+  it('returns no matches when section has no bullet items', () => {
+    const section = 'None\nSome text without bullets\n';
+    const matches = section.match(blockerLinePattern) || [];
+    expect(matches).toEqual([]);
+  });
+
+  it('matches standard dash bullets', () => {
+    const section = '- First blocker\n- Second blocker\n';
+    const matches = section.match(blockerLinePattern) || [];
+    expect(matches).toHaveLength(2);
+  });
+
+  it('does not match asterisk bullets (only dash)', () => {
+    const section = '* Asterisk bullet\n- Dash bullet\n';
+    const matches = section.match(blockerLinePattern) || [];
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toContain('Dash bullet');
+  });
+
+  it('does not match numbered list items', () => {
+    const section = '1. Numbered item\n- Dash item\n';
+    const matches = section.match(blockerLinePattern) || [];
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toContain('Dash item');
+  });
+
+  it('handles "None" as a non-bullet value', () => {
+    const section = 'None\n';
+    const matches = section.match(blockerLinePattern) || [];
+    expect(matches).toEqual([]);
+  });
+
+  it('handles pipes in blocker text', () => {
+    const section = '- Blocker with | pipe char\n';
+    const matches = section.match(blockerLinePattern) || [];
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toContain('pipe char');
+  });
+});
+
+// ─── Table parsing edge cases (Performance Metrics) ──────────────────────────
+
+describe('Performance Metrics table parsing edge cases', () => {
+  // The metricsPattern used in cmdStateRecordMetric:
+  const metricsPattern = /(##\s*Performance Metrics[\s\S]*?\n\|[^\n]+\n\|[-|\s]+\n)([\s\S]*?)(?=\n##|\n$|$)/i;
+
+  it('does not match when table has no separator line', () => {
+    const content = '## Performance Metrics\n| Phase | Duration | Tasks | Files |\n| Phase 01 P1 | 30m | 5 tasks | 3 files |\n';
+    // The separator line |---|---|---| is missing
+    const match = content.match(metricsPattern);
+    expect(match).toBeNull();
+  });
+
+  it('matches a table with proper header and separator', () => {
+    const content = '## Performance Metrics\n| Phase | Duration | Tasks | Files |\n|-------|----------|-------|-------|\n\n## Next Section\n';
+    const match = content.match(metricsPattern);
+    expect(match).not.toBeNull();
+  });
+
+  it('matches when table body is empty (just header + separator)', () => {
+    const content = '## Performance Metrics\n| Phase | Duration | Tasks | Files |\n|-------|----------|-------|-------|\n\n## Next Section\n';
+    const match = content.match(metricsPattern);
+    expect(match).not.toBeNull();
+    // The non-greedy [\s\S]*? in group 2 captures up to the lookahead (?=\n##|\n$|$).
+    // With no data rows, the body should contain no pipe-delimited table rows.
+    const body = match![2];
+    const dataRows = body.trim().split('\n').filter(r => r.includes('|'));
+    expect(dataRows).toHaveLength(0);
+  });
+
+  it('captures existing rows in the table body', () => {
+    const content = [
+      '## Performance Metrics',
+      '| Phase | Duration | Tasks | Files |',
+      '|-------|----------|-------|-------|',
+      '| Phase 01 P1 | 30m | 5 tasks | 3 files |',
+      '',
+      '## Next Section',
+    ].join('\n');
+    const match = content.match(metricsPattern);
+    expect(match).not.toBeNull();
+    expect(match![2]).toContain('Phase 01 P1');
+  });
+
+  it('handles pipes within table cell content', () => {
+    // Pipes inside cells would confuse naive splitting but the regex just captures the body
+    const content = [
+      '## Performance Metrics',
+      '| Phase | Duration | Tasks | Files |',
+      '|-------|----------|-------|-------|',
+      '| Phase 01 P1 | 30m | 5 | 3 |',
+      '',
+      '## Next Section',
+    ].join('\n');
+    const match = content.match(metricsPattern);
+    expect(match).not.toBeNull();
+  });
+});
+
+// ─── Decisions table parsing (from cmdStateSnapshot) ─────────────────────────
+
+describe('decisions table parsing edge cases', () => {
+  const decisionsPattern = /##\s*Decisions Made[\s\S]*?\n\|[^\n]+\n\|[-|\s]+\n([\s\S]*?)(?=\n##|\n$|$)/i;
+
+  it('does not match when section has no table', () => {
+    const content = '## Decisions Made\nSome text but no table\n\n## Next\n';
+    const match = content.match(decisionsPattern);
+    expect(match).toBeNull();
+  });
+
+  it('returns empty body for table with only header and separator', () => {
+    const content = '## Decisions Made\n| Phase | Decision | Rationale |\n|-------|----------|----------|\n\n## Next\n';
+    const match = content.match(decisionsPattern);
+    expect(match).not.toBeNull();
+    // The non-greedy capture grabs content between separator and the lookahead.
+    // The lookahead (?=\n##|\n$|$) matches at end, so body may include trailing content.
+    // Just verify match exists and body has no actual table rows:
+    const body = match![1];
+    const rows = body.trim().split('\n').filter(r => r.includes('|'));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('parses rows with fewer than 3 cells', () => {
+    const content = [
+      '## Decisions Made',
+      '| Phase | Decision | Rationale |',
+      '|-------|----------|----------|',
+      '| 01 | Only two cells |',
+      '',
+      '## Next',
+    ].join('\n');
+    const match = content.match(decisionsPattern);
+    expect(match).not.toBeNull();
+    // The row has only 2 cells after splitting — the snapshot code filters for >= 3
+    const rows = match![1].trim().split('\n').filter(r => r.includes('|'));
+    for (const row of rows) {
+      const cells = row.split('|').map(c => c.trim()).filter(Boolean);
+      // This row has only 2 non-empty cells, so it would be skipped by cmdStateSnapshot
+      expect(cells.length).toBeLessThan(3);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add 77 new unit tests across two files covering error paths and edge cases in `state.ts` and `core.ts`
- Tests document current behavior of malformed inputs, missing fields, regex metacharacter handling, corrupted configs, and nonexistent filesystem paths
- Discovered and documented a known bug: `stateExtractField` does not escape regex metacharacters in field names (unlike `stateReplaceField` which uses `escapeStringRegexp`)

## Test plan
- [x] All 131 tests pass (`npm test`)
- [x] Full build succeeds (`npm run build`)
- [x] No changes to production code -- tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)