### PR TITLE
fix(core): add actionable context to catch blocks

### DIFF
--- a/packages/cli/src/core/phase.ts
+++ b/packages/cli/src/core/phase.ts
@@ -27,6 +27,7 @@ import {
   summaryId,
   listSubDirs,
   debugLog,
+  errorMsg,
   todayISO,
   escapePhaseNum,
 } from './core.js';
@@ -167,7 +168,7 @@ export function phaseInsertCore(cwd: string, afterPhase: string, description: st
       if (dm) existingDecimals.push(parseInt(dm[1], 10));
     }
   } catch (e) {
-    debugLog(e);
+    debugLog('phase-insert-decimal-scan-failed', e);
   }
 
   const nextDecimal = existingDecimals.length === 0 ? 1 : Math.max(...existingDecimals) + 1;
@@ -256,7 +257,9 @@ export function phaseCompleteCore(cwd: string, phaseNum: string): PhaseCompleteR
       `$1${summaryCount}/${planCount} plans complete`,
     );
 
+    debugLog('phase-complete-write', `writing ROADMAP.md for phase ${phaseNum}`);
     fs.writeFileSync(rmPath, roadmapContent, 'utf-8');
+    debugLog('phase-complete-write', `ROADMAP.md updated for phase ${phaseNum}`);
 
     // Update REQUIREMENTS.md
     const reqPath = planningPath(cwd, 'REQUIREMENTS.md');
@@ -280,7 +283,9 @@ export function phaseCompleteCore(cwd: string, phaseNum: string): PhaseCompleteR
           );
         }
 
+        debugLog('phase-complete-write', `writing REQUIREMENTS.md for phase ${phaseNum}`);
         fs.writeFileSync(reqPath, reqContent, 'utf-8');
+        debugLog('phase-complete-write', `REQUIREMENTS.md updated for phase ${phaseNum}`);
         requirementsUpdated = true;
       }
     }
@@ -306,7 +311,7 @@ export function phaseCompleteCore(cwd: string, phaseNum: string): PhaseCompleteR
       }
     }
   } catch (e) {
-    debugLog(e);
+    debugLog('phase-complete-next-phase-scan-failed', e);
   }
 
   // Update STATE.md
@@ -345,7 +350,9 @@ export function phaseCompleteCore(cwd: string, phaseNum: string): PhaseCompleteR
       `$1Phase ${phaseNum} complete${nextPhaseNum ? `, transitioned to Phase ${nextPhaseNum}` : ''}`,
     );
 
+    debugLog('phase-complete-write', `writing STATE.md for phase ${phaseNum}`);
     fs.writeFileSync(stPath, stateContent, 'utf-8');
+    debugLog('phase-complete-write', `STATE.md updated for phase ${phaseNum}`);
   }
 
   return {
@@ -555,8 +562,7 @@ export function cmdPhasePlanIndex(cwd: string, phase: string | undefined, raw: b
       phaseDirName = match;
     }
   } catch (e) {
-    /* optional op, ignore */
-    debugLog(e);
+    debugLog('phase-plan-index-failed', e);
   }
 
   if (!phaseDir) {
@@ -705,8 +711,7 @@ export function cmdPhaseRemove(
     const dirs = listSubDirs(phasesDirPath, true);
     targetDir = dirs.find(d => d.startsWith(normalized + '-') || d === normalized) || null;
   } catch (e) {
-    /* optional op, ignore */
-    debugLog(e);
+    debugLog('phase-remove-find-target-failed', e);
   }
 
   if (targetDir && !force) {
@@ -766,8 +771,7 @@ export function cmdPhaseRemove(
         }
       }
     } catch (e) {
-      /* optional op, ignore */
-      debugLog(e);
+      debugLog('phase-remove-decimal-rename-failed', { phase: targetPhase, error: errorMsg(e) });
     }
   } else {
     const removedInt = parseInt(normalized, 10);
@@ -822,8 +826,7 @@ export function cmdPhaseRemove(
         }
       }
     } catch (e) {
-      /* optional op, ignore */
-      debugLog(e);
+      debugLog('phase-remove-int-rename-failed', { phase: targetPhase, error: errorMsg(e) });
     }
   }
 

--- a/packages/cli/src/core/state.ts
+++ b/packages/cli/src/core/state.ts
@@ -79,8 +79,7 @@ export function cmdStateLoad(cwd: string, raw: boolean): void {
   try {
     stateRaw = fs.readFileSync(statePathUtil(cwd), 'utf-8');
   } catch (e) {
-    /* optional op, ignore */
-    debugLog(e);
+    debugLog('state-load-failed', e);
   }
 
   const configExists = fs.existsSync(configPath(cwd));


### PR DESCRIPTION
## Summary
- Extends `debugLog()` to accept an optional context label as first argument for structured debug output
- Adds `errorMsg()` utility to safely extract error messages from unknown thrown values (replaces 12 inline `e instanceof Error ? e.message : String(e)` patterns)
- Adds context strings to ~20 catch blocks across `core.ts`, `phase.ts`, `state.ts`, and `dashboard-launcher.ts`
- Fixes unsafe `as { message?: string }` type cast in `execGit` — now uses `instanceof Error` check
- Adds `console.warn` for corrupted `config.json` so users see it without `--debug` flag
- Adds trace logging around `phaseCompleteCore` multi-file write sequence (ROADMAP → REQUIREMENTS → STATE) for partial failure diagnosis

## Test plan
- [x] All unit tests pass (`npm test` — 54/54)
- [x] Full build succeeds (`npm run build`)
- [x] Lint passes (`biome check .`)
- [x] No behavior changes — errors still handled gracefully, just with better logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)