### PR TITLE
fix(install): migrate skills from agents/skills/ to skills/

### DIFF
--- a/packages/cli/src/install/hooks.ts
+++ b/packages/cli/src/install/hooks.ts
@@ -10,7 +10,7 @@ import {
   buildHookCommand,
 } from '../adapters/index.js';
 import { configureOpencodePermissions } from './adapters.js';
-import { getDirName, getConfigDirFromHome, verifyInstalled } from './shared.js';
+import { getDirName, getConfigDirFromHome, verifyInstalled, removeBuiltInSkills } from './shared.js';
 import type { InstallResult } from './shared.js';
 import * as path from 'node:path';
 import ora from 'ora';
@@ -23,6 +23,15 @@ export function cleanupOrphanedFiles(configDir: string): void {
     'hooks/maxsim-notify.sh',
     'hooks/statusline.js',
   ];
+
+  // Clean up legacy agents/skills/ directory (skills moved to skills/)
+  const legacySkillsDir = path.join(configDir, 'agents', 'skills');
+  if (fs.existsSync(legacySkillsDir)) {
+    const removed = removeBuiltInSkills(legacySkillsDir);
+    if (removed > 0) {
+      console.log(`  ${chalk.green('\u2713')} Removed ${removed} legacy skills from agents/skills/`);
+    }
+  }
 
   for (const relPath of orphanedFiles) {
     const fullPath = path.join(configDir, relPath);

--- a/packages/cli/src/install/index.ts
+++ b/packages/cli/src/install/index.ts
@@ -25,6 +25,7 @@ import {
   copyDirRecursive,
   verifyInstalled,
   verifyFileInstalled,
+  removeBuiltInSkills,
 } from './shared.js';
 import type { InstallResult } from './shared.js';
 import { getCommitAttribution } from './adapters.js';
@@ -262,21 +263,15 @@ async function install(
     }
   }
 
-  // Copy skills to agents/skills/ directory
+  // Copy skills to skills/ directory
   const skillsSrc = path.join(src, 'skills');
   if (fs.existsSync(skillsSrc)) {
     spinner = ora({ text: 'Installing skills...', color: 'cyan' }).start();
-    const skillsDest = path.join(targetDir, 'agents', 'skills');
+    const skillsDest = path.join(targetDir, 'skills');
 
     // Remove old MAXSIM built-in skills before copying new ones (preserve user custom skills)
     if (fs.existsSync(skillsDest)) {
-      const builtInSkills = ['tdd', 'systematic-debugging', 'verification-before-completion'];
-      for (const skill of builtInSkills) {
-        const skillDir = path.join(skillsDest, skill);
-        if (fs.existsSync(skillDir)) {
-          fs.rmSync(skillDir, { recursive: true });
-        }
-      }
+      removeBuiltInSkills(skillsDest);
     }
 
     // Copy skills directory recursively
@@ -300,10 +295,10 @@ async function install(
     const installedSkillDirs = fs.readdirSync(skillsDest, { withFileTypes: true })
       .filter(e => e.isDirectory()).length;
     if (installedSkillDirs > 0) {
-      spinner.succeed(chalk.green('\u2713') + ` Installed ${installedSkillDirs} skills to agents/skills/`);
+      spinner.succeed(chalk.green('\u2713') + ` Installed ${installedSkillDirs} skills to skills/`);
     } else {
       spinner.fail('Failed to install skills');
-      failures.push('agents/skills');
+      failures.push('skills');
     }
   }
 

--- a/packages/cli/src/install/manifest.ts
+++ b/packages/cli/src/install/manifest.ts
@@ -102,12 +102,12 @@ export function writeManifest(
       }
     }
   }
-  // Include skills in manifest (agents/skills/<skill-name>/*)
-  const skillsManifestDir = path.join(agentsDir, 'skills');
+  // Include skills in manifest (skills/<skill-name>/*)
+  const skillsManifestDir = path.join(configDir, 'skills');
   if (fs.existsSync(skillsManifestDir)) {
     const skillHashes = generateManifest(skillsManifestDir);
     for (const [rel, hash] of Object.entries(skillHashes)) {
-      manifest.files['agents/skills/' + rel] = hash;
+      manifest.files['skills/' + rel] = hash;
     }
   }
 

--- a/packages/cli/src/install/shared.ts
+++ b/packages/cli/src/install/shared.ts
@@ -118,6 +118,39 @@ export function verifyFileInstalled(filePath: string, description: string): bool
   return true;
 }
 
+/**
+ * Built-in MAXSIM skill names — used during install, uninstall, and orphan cleanup
+ * to identify MAXSIM-owned skill directories (preserving user custom skills).
+ */
+export const BUILT_IN_SKILLS = [
+  'tdd',
+  'systematic-debugging',
+  'verification-before-completion',
+  'code-review',
+  'simplify',
+  'memory-management',
+  'using-maxsim',
+  'batch-execution',
+  'subagent-driven-development',
+  'writing-plans',
+] as const;
+
+/**
+ * Remove MAXSIM built-in skill directories from a given parent directory.
+ * Returns the number of skill directories removed.
+ */
+export function removeBuiltInSkills(skillsParentDir: string): number {
+  let count = 0;
+  for (const skill of BUILT_IN_SKILLS) {
+    const skillDir = path.join(skillsParentDir, skill);
+    if (fs.existsSync(skillDir)) {
+      fs.rmSync(skillDir, { recursive: true });
+      count++;
+    }
+  }
+  return count;
+}
+
 export interface InstallResult {
   settingsPath: string | null;
   settings: Record<string, unknown> | null;

--- a/templates/agents/maxsim-debugger.md
+++ b/templates/agents/maxsim-debugger.md
@@ -1273,8 +1273,8 @@ When any trigger condition below applies, read the full skill file via the Read 
 
 | Skill | Read | Trigger |
 |-------|------|---------|
-| Systematic Debugging | `.agents/skills/systematic-debugging/SKILL.md` | Always — you are a debugger, this is your primary skill |
-| Verification Before Completion | `.agents/skills/verification-before-completion/SKILL.md` | Before claiming a bug is fixed or a debug session is complete |
+| Systematic Debugging | `skills/systematic-debugging/SKILL.md` | Always — you are a debugger, this is your primary skill |
+| Verification Before Completion | `skills/verification-before-completion/SKILL.md` | Before claiming a bug is fixed or a debug session is complete |
 
 **Project skills override built-in skills.**
 

--- a/templates/agents/maxsim-executor.md
+++ b/templates/agents/maxsim-executor.md
@@ -23,7 +23,7 @@ Before executing, discover project context:
 
 **Self-improvement lessons:** Read `.planning/LESSONS.md` if it exists — accumulated lessons from past executions on this codebase. Apply them proactively to avoid known mistakes before they become deviations.
 
-**Project skills:** Check `.agents/skills/` directory if it exists:
+**Project skills:** Check `skills/` directory if it exists:
 1. List available skills (subdirectories)
 2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
 3. Load specific `rules/*.md` files as needed during implementation
@@ -612,11 +612,11 @@ Do not rely on memory of the skill content — always read the file fresh.
 
 | Skill | Read | Trigger |
 |-------|------|---------|
-| TDD Enforcement | `.agents/skills/tdd/SKILL.md` | Before writing implementation code for a new feature, bug fix, or when plan type is `tdd` |
-| Systematic Debugging | `.agents/skills/systematic-debugging/SKILL.md` | When encountering any bug, test failure, or unexpected behavior during execution |
-| Verification Before Completion | `.agents/skills/verification-before-completion/SKILL.md` | Before claiming any task is done, fixed, or passing |
+| TDD Enforcement | `skills/tdd/SKILL.md` | Before writing implementation code for a new feature, bug fix, or when plan type is `tdd` |
+| Systematic Debugging | `skills/systematic-debugging/SKILL.md` | When encountering any bug, test failure, or unexpected behavior during execution |
+| Verification Before Completion | `skills/verification-before-completion/SKILL.md` | Before claiming any task is done, fixed, or passing |
 
-**Project skills override built-in skills.** If a skill with the same name exists in `.agents/skills/` in the project, load that one instead.
+**Project skills override built-in skills.** If a skill with the same name exists in `skills/` in the project, load that one instead.
 
 </available_skills>
 

--- a/templates/agents/maxsim-phase-researcher.md
+++ b/templates/agents/maxsim-phase-researcher.md
@@ -26,7 +26,7 @@ Before researching, discover project context:
 
 **Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
 
-**Project skills:** Check `.agents/skills/` directory if it exists:
+**Project skills:** Check `skills/` directory if it exists:
 1. List available skills (subdirectories)
 2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
 3. Load specific `rules/*.md` files as needed during research
@@ -559,7 +559,7 @@ When any trigger condition below applies, read the full skill file via the Read 
 
 | Skill | Read | Trigger |
 |-------|------|---------|
-| Verification Before Completion | `.agents/skills/verification-before-completion/SKILL.md` | Before concluding research with confidence ratings |
+| Verification Before Completion | `skills/verification-before-completion/SKILL.md` | Before concluding research with confidence ratings |
 
 **Project skills override built-in skills.**
 

--- a/templates/agents/maxsim-plan-checker.md
+++ b/templates/agents/maxsim-plan-checker.md
@@ -33,7 +33,7 @@ Before verifying, discover project context:
 
 **Self-improvement lessons:** Read `.planning/LESSONS.md` if it exists — accumulated lessons from past executions. Use planning insights as an additional verification dimension: flag plans that repeat known gap patterns or ignore documented codebase conventions.
 
-**Project skills:** Check `.agents/skills/` directory if it exists:
+**Project skills:** Check `skills/` directory if it exists:
 1. List available skills (subdirectories)
 2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
 3. Load specific `rules/*.md` files as needed during verification
@@ -707,7 +707,7 @@ When any trigger condition below applies, read the full skill file via the Read 
 
 | Skill | Read | Trigger |
 |-------|------|---------|
-| Verification Before Completion | `.agents/skills/verification-before-completion/SKILL.md` | Before issuing final PASS/FAIL verdict on a plan |
+| Verification Before Completion | `skills/verification-before-completion/SKILL.md` | Before issuing final PASS/FAIL verdict on a plan |
 
 **Project skills override built-in skills.**
 

--- a/templates/agents/maxsim-planner.md
+++ b/templates/agents/maxsim-planner.md
@@ -35,7 +35,7 @@ Before planning, discover project context:
 
 **Self-improvement lessons:** Read `.planning/LESSONS.md` if it exists — accumulated lessons from past executions on this codebase. Apply planning insights proactively: avoid known gaps, include wiring tasks for patterns that historically broke, reference codebase-specific conventions in task actions.
 
-**Project skills:** Check `.agents/skills/` directory if it exists:
+**Project skills:** Check `skills/` directory if it exists:
 1. List available skills (subdirectories)
 2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
 3. Load specific `rules/*.md` files as needed during planning
@@ -1199,8 +1199,8 @@ When any trigger condition below applies, read the full skill file via the Read 
 
 | Skill | Read | Trigger |
 |-------|------|---------|
-| TDD Enforcement | `.agents/skills/tdd/SKILL.md` | When identifying TDD candidates during task breakdown |
-| Verification Before Completion | `.agents/skills/verification-before-completion/SKILL.md` | When writing <verify> sections for tasks |
+| TDD Enforcement | `skills/tdd/SKILL.md` | When identifying TDD candidates during task breakdown |
+| Verification Before Completion | `skills/verification-before-completion/SKILL.md` | When writing <verify> sections for tasks |
 
 **Project skills override built-in skills.**
 

--- a/templates/workflows/execute-phase.md
+++ b/templates/workflows/execute-phase.md
@@ -152,7 +152,7 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
        - .planning/STATE.md (State)
        - .planning/config.json (Config, if exists)
        - ./CLAUDE.md (Project instructions, if exists — follow project-specific guidelines and coding conventions)
-       - .agents/skills/ (Project skills, if exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
+       - skills/ (Project skills, if exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
        </files_to_read>
 
        <success_criteria>

--- a/templates/workflows/plan-phase.md
+++ b/templates/workflows/plan-phase.md
@@ -112,7 +112,7 @@ Answer: "What do I need to know to PLAN this phase well?"
 **Phase requirement IDs (MUST address):** {phase_req_ids}
 
 **Project instructions:** Read ./CLAUDE.md if exists — follow project-specific guidelines
-**Project skills:** Check .agents/skills/ directory (if exists) — read SKILL.md files, research should account for project skill patterns
+**Project skills:** Check skills/ directory (if exists) — read SKILL.md files, research should account for project skill patterns
 </additional_context>
 
 <output>
@@ -212,7 +212,7 @@ Planner prompt:
 **Phase requirement IDs (every ID MUST appear in a plan's `requirements` field):** {phase_req_ids}
 
 **Project instructions:** Read ./CLAUDE.md if exists — follow project-specific guidelines
-**Project skills:** Check .agents/skills/ directory (if exists) — read SKILL.md files, plans should account for project skill rules
+**Project skills:** Check skills/ directory (if exists) — read SKILL.md files, plans should account for project skill rules
 </planning_context>
 
 <downstream_consumer>
@@ -277,7 +277,7 @@ Checker prompt:
 **Phase requirement IDs (MUST ALL be covered):** {phase_req_ids}
 
 **Project instructions:** Read ./CLAUDE.md if exists — verify plans honor project guidelines
-**Project skills:** Check .agents/skills/ directory (if exists) — verify plans account for project skill rules
+**Project skills:** Check skills/ directory (if exists) — verify plans account for project skill rules
 </verification_context>
 
 <expected_output>

--- a/templates/workflows/quick.md
+++ b/templates/workflows/quick.md
@@ -108,7 +108,7 @@ Task(
 - ./CLAUDE.md (if exists — follow project-specific guidelines)
 </files_to_read>
 
-**Project skills:** Check .agents/skills/ directory (if exists) — read SKILL.md files, plans should account for project skill rules
+**Project skills:** Check skills/ directory (if exists) — read SKILL.md files, plans should account for project skill rules
 
 </planning_context>
 
@@ -259,7 +259,7 @@ Execute quick task ${next_num}.
 - ${QUICK_DIR}/${next_num}-PLAN.md (Plan)
 - .planning/STATE.md (Project state)
 - ./CLAUDE.md (Project instructions, if exists)
-- .agents/skills/ (Project skills, if exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
+- skills/ (Project skills, if exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
 </files_to_read>
 
 <constraints>


### PR DESCRIPTION
## Summary
- Move MAXSIM skill install destination from `.claude/agents/skills/` to `.claude/skills/` (Claude Code's native skills directory)
- Extract shared `BUILT_IN_SKILLS` constant and `removeBuiltInSkills()` helper into `shared.ts` to eliminate 4x duplication across install, uninstall, and hooks modules
- Add legacy `agents/skills/` cleanup during both install (orphan cleanup) and uninstall for seamless upgrades from older versions
- Update all template references (agents + workflows) from `.agents/skills/` to `skills/`
- Update manifest to track skills under `skills/` instead of `agents/skills/`

## Test plan
- [x] Unit tests pass (`npx vitest run`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual test: fresh install places skills in `~/.claude/skills/`
- [ ] Manual test: upgrade from old version cleans up `~/.claude/agents/skills/`
- [ ] Manual test: uninstall removes skills from both `skills/` and legacy `agents/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)