### PR TITLE
feat(skills): add skill-list, skill-install, skill-update CLI commands

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -89,6 +89,9 @@ import {
   cmdArtefakteList,
   cmdContextLoad,
   cmdStart,
+  cmdSkillList,
+  cmdSkillInstall,
+  cmdSkillUpdate,
 } from './core/index.js';
 
 // ─── Arg parsing utilities ───────────────────────────────────────────────────
@@ -378,6 +381,9 @@ const COMMANDS: Record<string, Handler> = {
   'artefakte-append': (args, cwd, raw) => cmdArtefakteAppend(cwd, args[1], getFlag(args, '--entry') ?? undefined, getFlag(args, '--phase') ?? undefined, raw),
   'artefakte-list': (args, cwd, raw) => cmdArtefakteList(cwd, getFlag(args, '--phase') ?? undefined, raw),
   'context-load': (args, cwd, raw) => cmdContextLoad(cwd, getFlag(args, '--phase') ?? undefined, getFlag(args, '--topic') ?? undefined, hasFlag(args, 'include-history'), raw),
+  'skill-list': (_args, cwd, raw) => cmdSkillList(cwd, raw),
+  'skill-install': (args, cwd, raw) => cmdSkillInstall(cwd, args[1], raw),
+  'skill-update': (args, cwd, raw) => cmdSkillUpdate(cwd, args[1], raw),
   'start': async (args, cwd, raw) => cmdStart(cwd, { noBrowser: hasFlag(args, 'no-browser'), networkMode: hasFlag(args, 'network') }, raw),
   'dashboard': (args) => handleDashboard(args.slice(1)),
   'start-server': async () => {

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -243,6 +243,13 @@ export {
   cmdContextLoad,
 } from './context-loader.js';
 
+// Skills exports
+export {
+  cmdSkillList,
+  cmdSkillInstall,
+  cmdSkillUpdate,
+} from './skills.js';
+
 // Start command exports
 export {
   cmdStart,

--- a/packages/cli/src/core/skills.ts
+++ b/packages/cli/src/core/skills.ts
@@ -1,0 +1,170 @@
+/**
+ * Skills — List, install, and update skill templates
+ *
+ * Skills are installed to `.claude/skills/<name>/SKILL.md`.
+ * Source templates live in `templates/skills/<name>/SKILL.md`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { output, error, safeReadFile } from './core.js';
+import { extractFrontmatter } from './frontmatter.js';
+
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+/**
+ * Resolve the installed skills directory for the current project.
+ * Skills live at `.claude/skills/` relative to cwd.
+ */
+function skillsDir(cwd: string): string {
+  return path.join(cwd, '.claude', 'skills');
+}
+
+/**
+ * Resolve the templates source directory for skills.
+ * At runtime (from dist/cli.cjs), templates are bundled at dist/assets/templates/skills/.
+ */
+function skillsTemplateDir(): string {
+  return path.resolve(__dirname, 'assets', 'templates', 'skills');
+}
+
+interface SkillInfo {
+  name: string;
+  description: string;
+  directory: string;
+}
+
+/**
+ * Read a single skill's metadata from its SKILL.md frontmatter.
+ */
+function readSkillInfo(skillDir: string, dirName: string): SkillInfo | null {
+  const skillMd = path.join(skillDir, 'SKILL.md');
+  const content = safeReadFile(skillMd);
+  if (!content) return null;
+
+  const fm = extractFrontmatter(content);
+  return {
+    name: (fm.name as string) ?? dirName,
+    description: (fm.description as string) ?? '',
+    directory: dirName,
+  };
+}
+
+// ─── Commands ────────────────────────────────────────────────────────────────
+
+/**
+ * List all installed skills from `.claude/skills/`.
+ */
+export function cmdSkillList(cwd: string, raw: boolean): void {
+  const dir = skillsDir(cwd);
+
+  if (!fs.existsSync(dir)) {
+    output({ skills: [], count: 0 }, raw, 'No skills installed.');
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const skills: SkillInfo[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const info = readSkillInfo(path.join(dir, entry.name), entry.name);
+    if (info) skills.push(info);
+  }
+
+  output({ skills, count: skills.length }, raw, skills.map(s => `${s.name}: ${s.description}`).join('\n'));
+}
+
+/**
+ * Install a specific skill from the templates directory.
+ */
+export function cmdSkillInstall(cwd: string, skillName: string | undefined, raw: boolean): void {
+  if (!skillName) {
+    error('skill name required. Usage: skill-install <name>');
+  }
+
+  const srcFile = path.join(skillsTemplateDir(), skillName, 'SKILL.md');
+
+  if (!fs.existsSync(srcFile)) {
+    // List available skills for a helpful error
+    const available = listAvailableTemplates();
+    error(`Skill "${skillName}" not found in templates. Available: ${available.join(', ')}`);
+  }
+
+  const destDir = path.join(skillsDir(cwd), skillName);
+  const destFile = path.join(destDir, 'SKILL.md');
+
+  fs.mkdirSync(destDir, { recursive: true });
+  fs.copyFileSync(srcFile, destFile);
+
+  output({ installed: true, skill: skillName, path: path.relative(cwd, destFile) }, raw, `Installed skill: ${skillName}`);
+}
+
+/**
+ * Update one or all installed skills from the templates source.
+ */
+export function cmdSkillUpdate(cwd: string, skillName: string | undefined, raw: boolean): void {
+  const dir = skillsDir(cwd);
+  const templateDir = skillsTemplateDir();
+
+  if (skillName) {
+    // Update a single skill
+    const srcFile = path.join(templateDir, skillName, 'SKILL.md');
+    if (!fs.existsSync(srcFile)) {
+      error(`Skill template "${skillName}" not found.`);
+    }
+
+    const destDir = path.join(dir, skillName);
+    if (!fs.existsSync(destDir)) {
+      error(`Skill "${skillName}" is not installed. Use skill-install first.`);
+    }
+
+    const destFile = path.join(destDir, 'SKILL.md');
+    fs.copyFileSync(srcFile, destFile);
+
+    output({ updated: [skillName], skipped: [], not_found: [] }, raw, `Updated skill: ${skillName}`);
+    return;
+  }
+
+  // Update all installed skills
+  if (!fs.existsSync(dir)) {
+    output({ updated: [], skipped: [], not_found: [] }, raw, 'No skills installed.');
+    return;
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const updated: string[] = [];
+  const skipped: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const name = entry.name;
+    const srcFile = path.join(templateDir, name, 'SKILL.md');
+
+    if (!fs.existsSync(srcFile)) {
+      // Custom/user skill — no template to update from
+      skipped.push(name);
+      continue;
+    }
+
+    const destFile = path.join(dir, name, 'SKILL.md');
+    fs.copyFileSync(srcFile, destFile);
+    updated.push(name);
+  }
+
+  const summary = updated.length > 0
+    ? `Updated ${updated.length} skill(s): ${updated.join(', ')}`
+    : 'No skills updated.';
+
+  output({ updated, skipped }, raw, summary);
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function listAvailableTemplates(): string[] {
+  const dir = skillsTemplateDir();
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => e.name);
+}

--- a/packages/cli/src/install/index.ts
+++ b/packages/cli/src/install/index.ts
@@ -529,6 +529,33 @@ const subcommand = argv._[0];
     return;
   }
 
+  // Skill management subcommands
+  if (subcommand === 'skill-list' || subcommand === 'skill-install' || subcommand === 'skill-update') {
+    const { cmdSkillList, cmdSkillInstall, cmdSkillUpdate } = await import('../core/skills.js');
+    const { CliOutput, writeOutput, CliError } = await import('../core/core.js');
+    const cwd = process.cwd();
+    try {
+      if (subcommand === 'skill-list') {
+        cmdSkillList(cwd, false);
+      } else if (subcommand === 'skill-install') {
+        cmdSkillInstall(cwd, argv._[1] as string | undefined, false);
+      } else if (subcommand === 'skill-update') {
+        cmdSkillUpdate(cwd, argv._[1] as string | undefined, false);
+      }
+    } catch (thrown: unknown) {
+      if (thrown instanceof CliOutput) {
+        writeOutput(thrown);
+        process.exit(0);
+      }
+      if (thrown instanceof CliError) {
+        console.error('Error: ' + thrown.message);
+        process.exit(1);
+      }
+      throw thrown;
+    }
+    return;
+  }
+
   if (hasGlobal && hasLocal) {
     console.error(chalk.yellow('Cannot specify both --global and --local'));
     process.exit(1);


### PR DESCRIPTION
## Summary
- Add new `packages/cli/src/core/skills.ts` module with `cmdSkillList`, `cmdSkillInstall`, and `cmdSkillUpdate` commands
- Wire skill commands into the tools router (`cli.ts`) as `skill-list`, `skill-install`, `skill-update`
- Wire skill subcommands into the install CLI (`install/index.ts`) so `maxsimcli skill-list`, `maxsimcli skill-install <name>`, and `maxsimcli skill-update [name]` work

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (190/190 tests)
- [x] `npx vitest run` passes in packages/cli
- [ ] Manual: `node dist/cli.cjs skill-list` lists installed skills
- [ ] Manual: `node dist/cli.cjs skill-install brainstorming` installs a skill
- [ ] Manual: `node dist/cli.cjs skill-update` updates all installed skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)