### PR TITLE
fix(dashboard): increase health check timeout and add project name display

### DIFF
--- a/packages/cli/src/core/dashboard-launcher.ts
+++ b/packages/cli/src/core/dashboard-launcher.ts
@@ -15,7 +15,7 @@ import { debugLog, errorMsg } from './core.js';
 
 export const DEFAULT_PORT = 3333;
 export const PORT_RANGE_END = 3343;
-export const HEALTH_TIMEOUT_MS = 1500;
+export const HEALTH_TIMEOUT_MS = 10_000;
 
 // ─── Health check ───────────────────────────────────────────────────────────
 

--- a/packages/dashboard/src/components/layout/sidebar.tsx
+++ b/packages/dashboard/src/components/layout/sidebar.tsx
@@ -5,6 +5,19 @@ import { NetworkQRButton } from "@/components/network/NetworkQRButton";
 import { cn } from "@/lib/utils";
 import type { DashboardPhase } from "@/lib/types";
 
+function useProjectName(): string | null {
+  const [name, setName] = useState<string | null>(null);
+  useEffect(() => {
+    fetch("/api/server-info")
+      .then((r) => r.json())
+      .then((data: { projectName?: string }) => {
+        if (data.projectName) setName(data.projectName);
+      })
+      .catch(() => {});
+  }, []);
+  return name;
+}
+
 type ActiveView = "overview" | "phase" | "todos" | "blockers" | "discussion";
 
 interface SidebarProps {
@@ -33,6 +46,7 @@ function statusDotClass(status: DashboardPhase["diskStatus"]): string {
 export function Sidebar({ activeView, activePhaseId, onNavigate, terminalOpen, onTerminalToggle }: SidebarProps) {
   const { roadmap, state, todos } = useDashboardData();
   const { connected } = useWebSocket();
+  const projectName = useProjectName();
   const [confirmShutdown, setConfirmShutdown] = useState(false);
 
   useEffect(() => {
@@ -72,18 +86,18 @@ export function Sidebar({ activeView, activePhaseId, onNavigate, terminalOpen, o
 
   return (
     <aside className="flex h-full w-56 shrink-0 flex-col border-r border-border bg-card">
-      {/* Logo */}
+      {/* Logo + project name */}
       <div className="border-b border-border px-5 py-4 flex items-center justify-between">
         <button
           type="button"
           onClick={() => onNavigate("overview")}
-          className="flex flex-col gap-0.5 text-left"
+          className="flex flex-col gap-0.5 text-left min-w-0"
         >
           <span className="text-sm font-bold tracking-tight text-foreground">
             MAXSIM
           </span>
-          <span className="text-xs text-muted-foreground">
-            Dashboard
+          <span className="text-xs text-muted-foreground truncate max-w-[160px]" title={projectName ?? "Dashboard"}>
+            {projectName ?? "Dashboard"}
           </span>
         </button>
       </div>

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -961,6 +961,8 @@ app.get('/api/server-info', (_req: Request, res: Response) => {
     localUrl: `http://localhost:${resolvedPort}`,
     networkUrl: localNetworkIp ? `http://${localNetworkIp}:${resolvedPort}` : null,
     tailscaleUrl: tailscaleIp ? `http://${tailscaleIp}:${resolvedPort}` : null,
+    projectName: path.basename(projectCwd),
+    projectCwd,
   });
 });
 


### PR DESCRIPTION
## Summary
- Increase `HEALTH_TIMEOUT_MS` from 1500ms to 10000ms in `dashboard-launcher.ts` to allow slower machines to complete dashboard startup
- Add `projectName` and `projectCwd` to the `/api/server-info` endpoint response
- Add project name display in the dashboard sidebar (replaces static "Dashboard" text with the actual project directory name)
- Verified multi-project isolation: each project gets a deterministic port via `projectPort()` hash, state is isolated via `MAXSIM_PROJECT_CWD` env var
- Verified file watcher debouncing: chokidar uses `awaitWriteFinish` + `lodash.debounce` for bulk edit handling

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (190 tests)
- [ ] E2E tests have pre-existing failure (`isCodex is not defined` in install.cjs) unrelated to this change
- [ ] Manual: launch dashboard for two different projects, verify they get different ports and show correct project names


🤖 Generated with [Claude Code](https://claude.com/claude-code)