### PR TITLE
refactor(skills): rewrite code-review skill to Anthropic standards

### DIFF
--- a/templates/skills/code-review/SKILL.md
+++ b/templates/skills/code-review/SKILL.md
@@ -1,40 +1,28 @@
 ---
 name: code-review
-description: Use after completing a phase or significant implementation — requires reviewing all changed code for critical issues before sign-off
+description: >-
+  Reviews all changed code for security vulnerabilities, interface correctness,
+  error handling, test coverage, and quality before sign-off. Use when completing
+  a phase, reviewing implementation, or before approving changes for merge.
 ---
 
 # Code Review
 
 Shipping unreviewed code is shipping unknown risk. Review before sign-off.
 
-**If you have not reviewed every changed file, you cannot approve the phase.**
+**HARD GATE: NO PHASE SIGN-OFF WITHOUT REVIEWING ALL CHANGED CODE.** If every diff introduced in this phase has not been read, the phase cannot be marked complete. Passing tests do not prove code quality.
 
-## The Iron Law
+## Process
 
-<HARD-GATE>
-NO PHASE SIGN-OFF WITHOUT REVIEWING ALL CHANGED CODE.
-If you have not read every diff introduced in this phase, you CANNOT mark it complete.
-"It works" is not "it's correct." Passing tests do not prove code quality.
-Violating this rule is a violation — not a shortcut.
-</HARD-GATE>
+Follow these steps in order before approving any phase or significant implementation.
 
-## The Gate Function
+### 1. SCOPE -- Identify All Changes
 
-Follow these steps IN ORDER before approving any phase or significant implementation.
+- Diff against the phase starting point to see every changed file
+- List all new, modified, and deleted files
+- Do not skip generated files, config changes, or minor edits
 
-### 1. SCOPE — Identify All Changes
-
-- Run `git diff` against the phase's starting point to see every changed file
-- List all new files, modified files, and deleted files
-- Do NOT skip generated files, config changes, or "minor" edits
-
-```bash
-# Example: see all changes since phase branch point
-git diff --stat main...HEAD
-git diff main...HEAD
-```
-
-### 2. SECURITY — Check for Vulnerabilities
+### 2. SECURITY -- Check for Vulnerabilities
 
 Review every changed file for:
 
@@ -48,75 +36,47 @@ Review every changed file for:
 
 **Any security issue is a blocking finding. No exceptions.**
 
-### 3. INTERFACES — Verify API Contracts
+### 3. INTERFACES -- Verify API Contracts
 
 - Do public function signatures match their documentation?
 - Are return types accurate and complete?
 - Do error types cover all failure modes?
 - Are breaking changes documented and intentional?
-- Do exported interfaces maintain backward compatibility (or is the break intentional)?
+- Do exported interfaces maintain backward compatibility?
 
-### 4. ERROR HANDLING — Check Failure Paths
+### 4. ERROR HANDLING -- Check Failure Paths
 
-- Are all external calls (I/O, network, user input) wrapped in error handling?
+- Are all external calls wrapped in error handling?
 - Do error messages provide enough context to diagnose the issue?
 - Are errors propagated correctly (not swallowed silently)?
 - Are edge cases handled (empty input, null values, boundary conditions)?
 
-### 5. TESTS — Evaluate Coverage
+### 5. TESTS -- Evaluate Coverage
 
 - Does every new public function have corresponding tests?
 - Do tests cover both success and failure paths?
-- Are edge cases tested (empty, null, boundary, error conditions)?
+- Are edge cases tested?
 - Do tests verify behavior, not implementation details?
 
-### 6. QUALITY — Assess Maintainability
+### 6. QUALITY -- Assess Maintainability
 
-- Is naming consistent with the existing codebase conventions?
-- Are there code duplication opportunities that should be extracted?
+- Is naming consistent with existing codebase conventions?
+- Are there duplication opportunities that should be extracted?
 - Is the complexity justified by the requirements?
-- Are comments present where logic is non-obvious (and absent where code is self-evident)?
+- Are comments present where logic is non-obvious?
 
-## Critical Issues — Block Phase Sign-Off
+## Common Pitfalls
 
-These categories MUST be resolved before the phase can be marked complete:
-
-| Severity | Category | Example |
-|----------|----------|---------|
-| **Blocker** | Security vulnerability | SQL injection, XSS, hardcoded secrets |
-| **Blocker** | Broken interface | Public API returns wrong type, missing required field |
-| **Blocker** | Missing error handling | Unhandled promise rejection, swallowed exceptions on I/O |
-| **Blocker** | Data loss risk | Destructive operation without confirmation, missing transaction |
-| **High** | Performance regression | O(n^2) where O(n) is trivial, unbounded memory allocation |
-| **High** | Missing critical tests | No tests for error paths, no tests for new public API |
-| **Medium** | Naming inconsistency | Convention mismatch with existing codebase |
-| **Medium** | Dead code | Unreachable branches, unused imports, commented-out code |
-
-**Blocker and High severity issues block sign-off. Medium issues should be filed for follow-up.**
-
-## Common Rationalizations — REJECT THESE
-
-| Excuse | Why It Violates the Rule |
-|--------|--------------------------|
+| Issue | Reality |
+|-------|---------|
 | "Tests pass, so the code is fine" | Tests verify behavior, not code quality. Review is separate. |
 | "I wrote it, so I know it's correct" | Author bias is real. Review as if someone else wrote it. |
-| "It's just a small change" | Small changes cause large outages. Review proportional effort, not zero effort. |
-| "We'll clean it up later" | "Later" accumulates. Fix blockers now, file medium issues. |
-| "The deadline is tight" | Shipping broken code costs more time than reviewing. |
+| "It's just a small change" | Small changes cause large outages. |
 | "Generated code doesn't need review" | Generated code has the same bugs. Review it. |
 
-## Red Flags — STOP If You Catch Yourself:
+Stop if you catch yourself skipping files because they "look fine," approving without reading actual code, or rushing through review to meet a deadline.
 
-- Skipping files because they "look fine" from the diff stat
-- Approving without reading the actual code changes
-- Ignoring a gut feeling that something is wrong
-- Rushing through review to meet a deadline
-- Assuming tests cover everything without checking
-- Skipping error handling review because "the happy path works"
-
-**If any red flag triggers: STOP. Go back to step 1 (SCOPE) and review properly.**
-
-## Verification Checklist
+## Verification
 
 Before signing off on a phase, confirm:
 
@@ -128,9 +88,21 @@ Before signing off on a phase, confirm:
 - [ ] Naming and style are consistent with codebase conventions
 - [ ] No blocker or high severity issues remain open
 
-## Review Output Format
+### Severity Reference
 
-Produce a review summary for phase documentation:
+| Severity | Category | Example |
+|----------|----------|---------|
+| Blocker | Security vulnerability | SQL injection, XSS, hardcoded secrets |
+| Blocker | Broken interface | Public API returns wrong type |
+| Blocker | Data loss risk | Destructive operation without confirmation |
+| High | Performance regression | O(n^2) where O(n) is trivial |
+| High | Missing critical tests | No tests for error paths or new public API |
+| Medium | Naming inconsistency | Convention mismatch with existing codebase |
+| Medium | Dead code | Unreachable branches, unused imports |
+
+Blocker and High severity issues block sign-off. Medium issues should be filed for follow-up.
+
+### Review Output Format
 
 ```
 REVIEW SCOPE: [number] files changed, [number] additions, [number] deletions
@@ -142,7 +114,7 @@ QUALITY: PASS | ISSUES FOUND (list)
 VERDICT: APPROVED | BLOCKED (list blocking issues)
 ```
 
-## In MAXSIM Plan Execution
+## MAXSIM Integration
 
 Code review applies at phase boundaries:
 - After all tasks in a phase are complete, run this review before marking the phase done


### PR DESCRIPTION
## Summary
- Rewrites `code-review` SKILL.md to Anthropic quality standards (~123 lines, down from 152)
- Replaces XML `<HARD-GATE>` tags with `**HARD GATE:**` bold markdown
- Removes tutorial-level git commands and trims rationalizations
- Restructures sections to standard layout: frontmatter, title, motto, HARD GATE, Process, Common Pitfalls, Verification, MAXSIM Integration

## Test plan
- [x] No `<` or `>` characters in file body
- [x] YAML frontmatter parses correctly
- [x] `npm run build` succeeds
- [x] `npm test` passes (190/190)

🤖 Generated with [Claude Code](https://claude.com/claude-code)