### PR TITLE
fix(skills): rewrite verification-before-completion to Anthropic standard

### DIFF
--- a/templates/skills/verification-before-completion/SKILL.md
+++ b/templates/skills/verification-before-completion/SKILL.md
@@ -1,36 +1,28 @@
 ---
 name: verification-before-completion
-description: Use before claiming any work is complete, fixed, or passing — requires running verification commands and reading output before making success claims
+description: >-
+  Requires running verification commands and reading actual output before making
+  any completion claims. Use when claiming work is done, tests pass, builds
+  succeed, or bugs are fixed. Prevents false completion claims.
 ---
 
 # Verification Before Completion
 
-Claiming work is complete without verification is dishonesty, not efficiency.
+Evidence before claims, always.
 
-**Evidence before claims, always.**
+**HARD GATE -- No completion claims without fresh verification evidence. If you have not run the verification command in this turn, you cannot claim it passes. "Should work" is not evidence. "I'm confident" is not evidence.**
 
-## The Iron Law
+## Process
 
-<HARD-GATE>
-NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE.
-If you have not run the verification command in this turn, you CANNOT claim it passes.
-"Should work" is not evidence. "I'm confident" is not evidence.
-Violating this rule is a violation — not a special case.
-</HARD-GATE>
+Before claiming any status or marking a task done:
 
-## The Gate Function
-
-BEFORE claiming any status, expressing satisfaction, or marking a task done:
-
-1. **IDENTIFY:** What command proves this claim?
-2. **RUN:** Execute the FULL command (fresh, in this turn — not a previous run)
-3. **READ:** Read the FULL output. Check the exit code. Count failures.
-4. **VERIFY:** Does the output actually confirm the claim?
-   - If NO: State the actual status with evidence
-   - If YES: State the claim WITH the evidence
-5. **CLAIM:** Only now may you assert completion
-
-**Skip any step = lying, not verifying.**
+1. **IDENTIFY** -- What command proves this claim?
+2. **RUN** -- Execute the full command fresh in this turn (not a previous run)
+3. **READ** -- Read the full output, check the exit code, count failures
+4. **VERIFY** -- Does the output actually confirm the claim?
+   - If NO: state the actual status with evidence
+   - If YES: state the claim with the evidence
+5. **CLAIM** -- Only now may you assert completion
 
 ### Evidence Block Format
 
@@ -43,35 +35,11 @@ OUTPUT: [relevant excerpt of actual output]
 VERDICT: PASS | FAIL
 ```
 
-This format is required for task completion claims in MAXSIM plan execution. It is NOT required for intermediate status updates like "I have read the file" or "here is the plan."
+This format is required for task completion claims in MAXSIM plan execution. It is not required for intermediate status updates.
 
-## Common Rationalizations — REJECT THESE
+### What Counts as Verification
 
-| Excuse | Why It Violates the Rule |
-|--------|--------------------------|
-| "Should work now" | "Should" is not evidence. RUN the command. |
-| "I'm confident in the logic" | Confidence is not evidence. Run it. |
-| "The linter passed" | Linter passing does not mean tests pass or build succeeds. |
-| "Just this once" | NO EXCEPTIONS. This is the rule, not a guideline. |
-| "I only changed one line" | One line can break everything. Verify. |
-| "The subagent reported success" | Trust test output and VCS diffs, not agent reports. |
-| "Partial check is enough" | Partial proves nothing about the unchecked parts. |
-
-## Red Flags — STOP If You Catch Yourself:
-
-- Using "should", "probably", "seems to", or "looks good" about unverified work
-- Expressing satisfaction ("Great!", "Perfect!", "Done!") before running verification
-- About to commit or push without running the test/build command in THIS turn
-- Trusting a subagent's completion report without independent verification
-- Thinking "the last run was clean, I only changed one line"
-- About to mark a MAXSIM task as done without running the `<verify>` block
-- Relying on a previous turn's test output as current evidence
-
-**If any red flag triggers: STOP. Run the command. Read the output. THEN make the claim.**
-
-## What Counts as Verification
-
-| Claim | Requires | NOT Sufficient |
+| Claim | Requires | Not Sufficient |
 |-------|----------|----------------|
 | "Tests pass" | Test command output showing 0 failures | Previous run, "should pass", partial run |
 | "Build succeeds" | Build command with exit code 0 | Linter passing, "logs look clean" |
@@ -79,7 +47,19 @@ This format is required for task completion claims in MAXSIM plan execution. It 
 | "Task is complete" | All done criteria checked with evidence | "I implemented everything in the plan" |
 | "No regressions" | Full test suite passing | "I only changed one file" |
 
-## Verification Checklist
+## Common Pitfalls
+
+| Excuse | Why It Fails |
+|--------|-------------|
+| "Should work now" | "Should" is not evidence. Run the command. |
+| "I'm confident in the logic" | Confidence is not evidence. Run it. |
+| "The linter passed" | Linter passing does not mean tests pass or build succeeds. |
+| "I only changed one line" | One line can break everything. Verify. |
+| "The subagent reported success" | Trust test output and VCS diffs, not agent reports. |
+
+Stop if you catch yourself using "should", "probably", or "looks good" about unverified work, or expressing satisfaction before running verification.
+
+## Verification
 
 Before marking any work as complete:
 
@@ -91,12 +71,13 @@ Before marking any work as complete:
 - [ ] No "should", "probably", or "seems to" in your completion statement
 - [ ] Evidence block produced for the task completion claim
 
-## In MAXSIM Plan Execution
+## MAXSIM Integration
 
-The executor's task commit protocol requires verification BEFORE committing:
-1. Run the task's `<verify>` block (automated checks)
-2. Confirm the `<done>` criteria are met with evidence
+The executor's task commit protocol requires verification before committing:
+
+1. Run the task's verify block (automated checks)
+2. Confirm the done criteria are met with evidence
 3. Produce an evidence block for the task completion
 4. Only then: stage files and commit
 
-The verifier agent independently re-checks all claims — do not assume the verifier will catch what you missed.
+The verifier agent independently re-checks all claims -- do not assume the verifier will catch what you missed.


### PR DESCRIPTION
## Summary
- Frontmatter updated with third-person description and "Use when" triggers
- XML `<HARD-GATE>` tags replaced with `**HARD GATE**` markdown bold
- Evidence block format and verification table preserved
- Line count: 103 → ~80

## Test plan
- [x] No `<` or `>` characters in file body
- [x] YAML frontmatter parses correctly
- [x] Build succeeds
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)