### PR TITLE
feat(mcp): add context, roadmap, and config query tools

### DIFF
--- a/packages/cli/src/mcp/config-tools.ts
+++ b/packages/cli/src/mcp/config-tools.ts
@@ -1,0 +1,90 @@
+/**
+ * Config Query MCP Tools — Project configuration exposed as MCP tools
+ *
+ * CRITICAL: Never import output() or error() from core — they call process.exit().
+ * CRITICAL: Never write to stdout — it is reserved for MCP JSON-RPC protocol.
+ * CRITICAL: Never call process.exit() — the server must stay alive after every tool call.
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { loadConfig } from '../core/core.js';
+import { cmdConfigGet, cmdConfigSet } from '../core/config.js';
+import { detectProjectRoot, mcpSuccess, mcpError } from './utils.js';
+
+/**
+ * Register all config query tools on the MCP server.
+ */
+export function registerConfigTools(server: McpServer): void {
+  // ── mcp_get_config ──────────────────────────────────────────────────────────
+
+  server.tool(
+    'mcp_get_config',
+    'Get project configuration. Optionally provide a key path to get a specific value.',
+    {
+      key: z
+        .string()
+        .optional()
+        .describe('Optional dot-separated key path (e.g. "model_profile", "branching.strategy")'),
+    },
+    async ({ key }) => {
+      try {
+        const cwd = detectProjectRoot();
+        if (!cwd) {
+          return mcpError('No .planning/ directory found', 'Project not detected');
+        }
+
+        if (key) {
+          const result = cmdConfigGet(cwd, key, true);
+          if (!result.ok) {
+            return mcpError(result.error, 'Config get failed');
+          }
+          return mcpSuccess(
+            { key, value: result.rawValue ?? result.result },
+            `Config value for "${key}"`,
+          );
+        }
+
+        const config = loadConfig(cwd);
+        return mcpSuccess(
+          { config },
+          'Full configuration loaded',
+        );
+      } catch (e: unknown) {
+        return mcpError('Failed: ' + (e as Error).message, 'Error occurred');
+      }
+    },
+  );
+
+  // ── mcp_update_config ───────────────────────────────────────────────────────
+
+  server.tool(
+    'mcp_update_config',
+    'Update a project configuration value by key path.',
+    {
+      key: z.string().describe('Dot-separated key path (e.g. "model_profile", "branching.strategy")'),
+      value: z.string().describe('New value to set'),
+    },
+    async ({ key, value }) => {
+      try {
+        const cwd = detectProjectRoot();
+        if (!cwd) {
+          return mcpError('No .planning/ directory found', 'Project not detected');
+        }
+
+        const result = cmdConfigSet(cwd, key, value, true);
+        if (!result.ok) {
+          return mcpError(result.error, 'Config update failed');
+        }
+
+        return mcpSuccess(
+          { updated: true, key, value },
+          `Config "${key}" updated to "${value}"`,
+        );
+      } catch (e: unknown) {
+        return mcpError('Failed: ' + (e as Error).message, 'Error occurred');
+      }
+    },
+  );
+}

--- a/packages/cli/src/mcp/context-tools.ts
+++ b/packages/cli/src/mcp/context-tools.ts
@@ -1,0 +1,233 @@
+/**
+ * Context Query MCP Tools — Project context exposed as MCP tools
+ *
+ * CRITICAL: Never import output() or error() from core — they call process.exit().
+ * CRITICAL: Never write to stdout — it is reserved for MCP JSON-RPC protocol.
+ * CRITICAL: Never call process.exit() — the server must stay alive after every tool call.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import {
+  findPhaseInternal,
+  planningPath,
+  safeReadFile,
+  loadConfig,
+} from '../core/core.js';
+
+import { cmdRoadmapAnalyze } from '../core/roadmap.js';
+import { stateExtractField } from '../core/state.js';
+import { cmdContextLoad } from '../core/context-loader.js';
+import { detectProjectRoot, mcpSuccess, mcpError } from './utils.js';
+
+/**
+ * Register all context query tools on the MCP server.
+ */
+export function registerContextTools(server: McpServer): void {
+  // ── mcp_get_active_phase ────────────────────────────────────────────────────
+
+  server.tool(
+    'mcp_get_active_phase',
+    'Get the currently active phase and next phase from roadmap analysis and STATE.md.',
+    {},
+    async () => {
+      try {
+        const cwd = detectProjectRoot();
+        if (!cwd) {
+          return mcpError('No .planning/ directory found', 'Project not detected');
+        }
+
+        const roadmapResult = await cmdRoadmapAnalyze(cwd);
+        let current_phase: unknown = null;
+        let next_phase: unknown = null;
+        let phase_name: string | null = null;
+        let status: string | null = null;
+
+        if (roadmapResult.ok) {
+          const data = roadmapResult.result as Record<string, unknown>;
+          current_phase = data.current_phase ?? null;
+          next_phase = data.next_phase ?? null;
+        }
+
+        // Also read STATE.md for current phase field
+        const stateContent = safeReadFile(planningPath(cwd, 'STATE.md'));
+        if (stateContent) {
+          const statePhase = stateExtractField(stateContent, 'Current Phase');
+          if (statePhase) phase_name = statePhase;
+          const stateStatus = stateExtractField(stateContent, 'Status');
+          if (stateStatus) status = stateStatus;
+        }
+
+        return mcpSuccess(
+          { current_phase, next_phase, phase_name, status },
+          `Active phase: ${phase_name ?? current_phase ?? 'unknown'}`,
+        );
+      } catch (e: unknown) {
+        return mcpError('Failed: ' + (e as Error).message, 'Error occurred');
+      }
+    },
+  );
+
+  // ── mcp_get_guidelines ──────────────────────────────────────────────────────
+
+  server.tool(
+    'mcp_get_guidelines',
+    'Get project guidelines: PROJECT.md vision, config, and optionally phase-specific context.',
+    {
+      phase: z
+        .string()
+        .optional()
+        .describe('Optional phase number to include phase-specific context'),
+    },
+    async ({ phase }) => {
+      try {
+        const cwd = detectProjectRoot();
+        if (!cwd) {
+          return mcpError('No .planning/ directory found', 'Project not detected');
+        }
+
+        const project_vision = safeReadFile(planningPath(cwd, 'PROJECT.md'));
+        const config = loadConfig(cwd);
+
+        let phase_context: string | null = null;
+        if (phase) {
+          const phaseInfo = findPhaseInternal(cwd, phase);
+          if (phaseInfo) {
+            const contextPath = path.join(
+              phaseInfo.directory,
+              `${phaseInfo.phase_number}-CONTEXT.md`,
+            );
+            phase_context = safeReadFile(contextPath);
+          }
+        }
+
+        return mcpSuccess(
+          { project_vision, config, phase_context },
+          `Guidelines loaded${phase ? ` with phase ${phase} context` : ''}`,
+        );
+      } catch (e: unknown) {
+        return mcpError('Failed: ' + (e as Error).message, 'Error occurred');
+      }
+    },
+  );
+
+  // ── mcp_get_context_for_task ────────────────────────────────────────────────
+
+  server.tool(
+    'mcp_get_context_for_task',
+    'Load context files for a task, including project context, roadmap, and optionally phase-specific and topic-specific files.',
+    {
+      phase: z
+        .string()
+        .optional()
+        .describe('Optional phase number to scope context to'),
+      topic: z
+        .string()
+        .optional()
+        .describe('Optional topic to filter context by'),
+    },
+    async ({ phase, topic }) => {
+      try {
+        const cwd = detectProjectRoot();
+        if (!cwd) {
+          return mcpError('No .planning/ directory found', 'Project not detected');
+        }
+
+        const result = cmdContextLoad(cwd, phase, topic, true);
+        if (!result.ok) {
+          return mcpError(result.error, 'Context load failed');
+        }
+
+        return mcpSuccess(
+          { context: result.result },
+          `Context loaded${phase ? ` for phase ${phase}` : ''}${topic ? ` topic "${topic}"` : ''}`,
+        );
+      } catch (e: unknown) {
+        return mcpError('Failed: ' + (e as Error).message, 'Error occurred');
+      }
+    },
+  );
+
+  // ── mcp_get_project_overview ────────────────────────────────────────────────
+
+  server.tool(
+    'mcp_get_project_overview',
+    'Get a high-level project overview: PROJECT.md, REQUIREMENTS.md, and STATE.md contents.',
+    {},
+    async () => {
+      try {
+        const cwd = detectProjectRoot();
+        if (!cwd) {
+          return mcpError('No .planning/ directory found', 'Project not detected');
+        }
+
+        const project = safeReadFile(planningPath(cwd, 'PROJECT.md'));
+        const requirements = safeReadFile(planningPath(cwd, 'REQUIREMENTS.md'));
+        const state = safeReadFile(planningPath(cwd, 'STATE.md'));
+
+        return mcpSuccess(
+          { project, requirements, state },
+          'Project overview loaded',
+        );
+      } catch (e: unknown) {
+        return mcpError('Failed: ' + (e as Error).message, 'Error occurred');
+      }
+    },
+  );
+
+  // ── mcp_get_phase_detail ────────────────────────────────────────────────────
+
+  server.tool(
+    'mcp_get_phase_detail',
+    'Get detailed information about a specific phase including all its files (plans, summaries, context, research, verification).',
+    {
+      phase: z.string().describe('Phase number or name (e.g. "01", "1", "01A")'),
+    },
+    async ({ phase }) => {
+      try {
+        const cwd = detectProjectRoot();
+        if (!cwd) {
+          return mcpError('No .planning/ directory found', 'Project not detected');
+        }
+
+        const phaseInfo = findPhaseInternal(cwd, phase);
+        if (!phaseInfo) {
+          return mcpError(`Phase ${phase} not found`, 'Phase not found');
+        }
+
+        // Read all files in the phase directory
+        const files: Array<{ name: string; content: string | null }> = [];
+        try {
+          const entries = fs.readdirSync(phaseInfo.directory);
+          for (const entry of entries) {
+            const fullPath = path.join(phaseInfo.directory, entry);
+            const stat = fs.statSync(fullPath);
+            if (stat.isFile()) {
+              files.push({
+                name: entry,
+                content: safeReadFile(fullPath),
+              });
+            }
+          }
+        } catch {
+          // Directory may not exist or be empty
+        }
+
+        return mcpSuccess(
+          {
+            phase_number: phaseInfo.phase_number,
+            phase_name: phaseInfo.phase_name,
+            directory: phaseInfo.directory,
+            files,
+          },
+          `Phase ${phaseInfo.phase_number} detail: ${files.length} file(s)`,
+        );
+      } catch (e: unknown) {
+        return mcpError('Failed: ' + (e as Error).message, 'Error occurred');
+      }
+    },
+  );
+}

--- a/packages/cli/src/mcp/index.ts
+++ b/packages/cli/src/mcp/index.ts
@@ -2,13 +2,15 @@
  * MCP Tool Registration — Orchestrates all tool registrations
  *
  * This is the single entry point for registering MCP tools on the server.
- * Later plans will add registerTodoTools, registerStateTools, etc.
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerPhaseTools } from './phase-tools.js';
 import { registerTodoTools } from './todo-tools.js';
 import { registerStateTools } from './state-tools.js';
+import { registerContextTools } from './context-tools.js';
+import { registerRoadmapTools } from './roadmap-tools.js';
+import { registerConfigTools } from './config-tools.js';
 
 /**
  * Register all MCP tools on the given server instance.
@@ -17,4 +19,7 @@ export function registerAllTools(server: McpServer): void {
   registerPhaseTools(server);
   registerTodoTools(server);
   registerStateTools(server);
+  registerContextTools(server);
+  registerRoadmapTools(server);
+  registerConfigTools(server);
 }

--- a/packages/cli/src/mcp/roadmap-tools.ts
+++ b/packages/cli/src/mcp/roadmap-tools.ts
@@ -1,0 +1,103 @@
+/**
+ * Roadmap Query MCP Tools — Roadmap analysis exposed as MCP tools
+ *
+ * CRITICAL: Never import output() or error() from core — they call process.exit().
+ * CRITICAL: Never write to stdout — it is reserved for MCP JSON-RPC protocol.
+ * CRITICAL: Never call process.exit() — the server must stay alive after every tool call.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { cmdRoadmapAnalyze } from '../core/roadmap.js';
+import { detectProjectRoot, mcpSuccess, mcpError } from './utils.js';
+
+/**
+ * Register all roadmap query tools on the MCP server.
+ */
+export function registerRoadmapTools(server: McpServer): void {
+  // ── mcp_get_roadmap ─────────────────────────────────────────────────────────
+
+  server.tool(
+    'mcp_get_roadmap',
+    'Get the full roadmap analysis including all phases, their status, and progress.',
+    {},
+    async () => {
+      try {
+        const cwd = detectProjectRoot();
+        if (!cwd) {
+          return mcpError('No .planning/ directory found', 'Project not detected');
+        }
+
+        const result = await cmdRoadmapAnalyze(cwd);
+        if (!result.ok) {
+          return mcpError(result.error, 'Roadmap analysis failed');
+        }
+
+        return mcpSuccess(
+          { roadmap: result.result },
+          'Roadmap analysis complete',
+        );
+      } catch (e: unknown) {
+        return mcpError('Failed: ' + (e as Error).message, 'Error occurred');
+      }
+    },
+  );
+
+  // ── mcp_get_roadmap_progress ────────────────────────────────────────────────
+
+  server.tool(
+    'mcp_get_roadmap_progress',
+    'Get a focused progress summary: total phases, completed, in-progress, not started, and progress percentage.',
+    {},
+    async () => {
+      try {
+        const cwd = detectProjectRoot();
+        if (!cwd) {
+          return mcpError('No .planning/ directory found', 'Project not detected');
+        }
+
+        const result = await cmdRoadmapAnalyze(cwd);
+        if (!result.ok) {
+          return mcpError(result.error, 'Roadmap analysis failed');
+        }
+
+        const data = result.result as Record<string, unknown>;
+        const phases = (data.phases ?? []) as Array<Record<string, unknown>>;
+
+        const total_phases = phases.length;
+        let completed = 0;
+        let in_progress = 0;
+        let not_started = 0;
+
+        for (const p of phases) {
+          const status = String(p.status ?? '').toLowerCase();
+          if (status === 'completed' || status === 'done') {
+            completed++;
+          } else if (status === 'in-progress' || status === 'in_progress' || status === 'active') {
+            in_progress++;
+          } else {
+            not_started++;
+          }
+        }
+
+        const progress_percent =
+          total_phases > 0 ? Math.round((completed / total_phases) * 100) : 0;
+
+        return mcpSuccess(
+          {
+            total_phases,
+            completed,
+            in_progress,
+            not_started,
+            progress_percent,
+            current_phase: data.current_phase ?? null,
+            next_phase: data.next_phase ?? null,
+          },
+          `Progress: ${completed}/${total_phases} phases complete (${progress_percent}%)`,
+        );
+      } catch (e: unknown) {
+        return mcpError('Failed: ' + (e as Error).message, 'Error occurred');
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add 9 new MCP tools across 3 new tool files for context queries, roadmap analysis, and config management
- **context-tools.ts**: `mcp_get_active_phase`, `mcp_get_guidelines`, `mcp_get_context_for_task`, `mcp_get_project_overview`, `mcp_get_phase_detail`
- **roadmap-tools.ts**: `mcp_get_roadmap`, `mcp_get_roadmap_progress`
- **config-tools.ts**: `mcp_get_config`, `mcp_update_config`
- Updated `index.ts` to register all new tool groups

## Test plan
- [x] All 196 unit tests pass
- [x] Full build succeeds (cli + dashboard)
- [x] Lint passes with no issues
- [x] New tools follow exact same pattern as existing phase-tools.ts, todo-tools.ts, state-tools.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)