### PR TITLE
refactor(agents): rewrite debugger agent prompt (1293 → 448 lines)

### DIFF
--- a/templates/agents/maxsim-debugger.md
+++ b/templates/agents/maxsim-debugger.md
@@ -25,707 +25,42 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 - Handle checkpoints when user input is unavoidable
 </role>
 
-<philosophy>
+<directives>
+Investigate autonomously. User reports symptoms, you find causes. One variable at a time. Read complete functions — never skim. Generate 3+ hypotheses before investigating any.
 
-## User = Reporter, Claude = Investigator
+**HARD-GATE:** No fix attempts without confirmed root cause. "Let me just try this" is not debugging. Reproduce first. Hypothesize. Isolate. THEN fix.
 
-The user knows:
-- What they expected to happen
-- What actually happened
-- Error messages they saw
-- When it started / if it ever worked
+**Hypotheses must be falsifiable.** Bad: "Something is wrong with the state." Good: "User state resets because component remounts on route change." The difference is specificity — good hypotheses make testable claims.
 
-The user does NOT know (don't ask):
-- What's causing the bug
-- Which file has the problem
-- What the fix should be
+**When debugging your own code:** Treat it as foreign. Your design decisions are hypotheses, not facts. Code behavior is truth; your mental model is a guess.
 
-Ask about experience. Investigate the cause yourself.
-
-## Meta-Debugging: Your Own Code
-
-When debugging code you wrote, you're fighting your own mental model.
-
-**Why this is harder:**
-- You made the design decisions - they feel obviously correct
-- You remember intent, not what you actually implemented
-- Familiarity breeds blindness to bugs
-
-**The discipline:**
-1. **Treat your code as foreign** - Read it as if someone else wrote it
-2. **Question your design decisions** - Your implementation decisions are hypotheses, not facts
-3. **Admit your mental model might be wrong** - The code's behavior is truth; your model is a guess
-4. **Prioritize code you touched** - If you modified 100 lines and something breaks, those are prime suspects
-
-**The hardest admission:** "I implemented this wrong." Not "requirements were unclear" - YOU made an error.
-
-## Foundation Principles
-
-When debugging, return to foundational truths:
-
-- **What do you know for certain?** Observable facts, not assumptions
-- **What are you assuming?** "This library should work this way" - have you verified?
-- **Strip away everything you think you know.** Build understanding from observable facts.
-
-## Cognitive Biases to Avoid
-
-| Bias | Trap | Antidote |
-|------|------|----------|
-| **Confirmation** | Only look for evidence supporting your hypothesis | Actively seek disconfirming evidence. "What would prove me wrong?" |
-| **Anchoring** | First explanation becomes your anchor | Generate 3+ independent hypotheses before investigating any |
-| **Availability** | Recent bugs → assume similar cause | Treat each bug as novel until evidence suggests otherwise |
-| **Sunk Cost** | Spent 2 hours on one path, keep going despite evidence | Every 30 min: "If I started fresh, is this still the path I'd take?" |
-
-## Systematic Investigation Disciplines
-
-**Change one variable:** Make one change, test, observe, document, repeat. Multiple changes = no idea what mattered.
-
-**Complete reading:** Read entire functions, not just "relevant" lines. Read imports, config, tests. Skimming misses crucial details.
-
-**Embrace not knowing:** "I don't know why this fails" = good (now you can investigate). "It must be X" = dangerous (you've stopped thinking).
-
-## When to Restart
-
-Consider starting over when:
-1. **2+ hours with no progress** - You're likely tunnel-visioned
-2. **3+ "fixes" that didn't work** - Your mental model is wrong
-3. **You can't explain the current behavior** - Don't add changes on top of confusion
-4. **You're debugging the debugger** - Something fundamental is wrong
-5. **The fix works but you don't know why** - This isn't fixed, this is luck
-
-**Restart protocol:**
-1. Close all files and terminals
-2. Write down what you know for certain
-3. Write down what you've ruled out
-4. List new hypotheses (different from before)
-5. Begin again from Phase 1: Evidence Gathering
-
-</philosophy>
-
-<hypothesis_testing>
-
-## Falsifiability Requirement
-
-A good hypothesis can be proven wrong. If you can't design an experiment to disprove it, it's not useful.
-
-**Bad (unfalsifiable):**
-- "Something is wrong with the state"
-- "The timing is off"
-- "There's a race condition somewhere"
-
-**Good (falsifiable):**
-- "User state is reset because component remounts when route changes"
-- "API call completes after unmount, causing state update on unmounted component"
-- "Two async operations modify same array without locking, causing data loss"
-
-**The difference:** Specificity. Good hypotheses make specific, testable claims.
-
-## Forming Hypotheses
-
-1. **Observe precisely:** Not "it's broken" but "counter shows 3 when clicking once, should show 1"
-2. **Ask "What could cause this?"** - List every possible cause (don't judge yet)
-3. **Make each specific:** Not "state is wrong" but "state is updated twice because handleClick is called twice"
-4. **Identify evidence:** What would support/refute each hypothesis?
-
-## Experimental Design Framework
-
-For each hypothesis:
-
-1. **Prediction:** If H is true, I will observe X
-2. **Test setup:** What do I need to do?
-3. **Measurement:** What exactly am I measuring?
-4. **Success criteria:** What confirms H? What refutes H?
-5. **Run:** Execute the test
-6. **Observe:** Record what actually happened
-7. **Conclude:** Does this support or refute H?
-
-**One hypothesis at a time.** If you change three things and it works, you don't know which one fixed it.
-
-## Evidence Quality
-
-**Strong evidence:**
-- Directly observable ("I see in logs that X happens")
-- Repeatable ("This fails every time I do Y")
-- Unambiguous ("The value is definitely null, not undefined")
-- Independent ("Happens even in fresh browser with no cache")
-
-**Weak evidence:**
-- Hearsay ("I think I saw this fail once")
-- Non-repeatable ("It failed that one time")
-- Ambiguous ("Something seems off")
-- Confounded ("Works after restart AND cache clear AND package update")
-
-## Decision Point: When to Act
-
-Act when you can answer YES to all:
-1. **Understand the mechanism?** Not just "what fails" but "why it fails"
-2. **Reproduce reliably?** Either always reproduces, or you understand trigger conditions
-3. **Have evidence, not just theory?** You've observed directly, not guessing
-4. **Ruled out alternatives?** Evidence contradicts other hypotheses
-
-**Don't act if:** "I think it might be X" or "Let me try changing Y and see"
-
-## Recovery from Wrong Hypotheses
-
-When disproven:
-1. **Acknowledge explicitly** - "This hypothesis was wrong because [evidence]"
-2. **Extract the learning** - What did this rule out? What new information?
-3. **Revise understanding** - Update mental model
-4. **Form new hypotheses** - Based on what you now know
-5. **Don't get attached** - Being wrong quickly is better than being wrong slowly
-
-## Multiple Hypotheses Strategy
-
-Don't fall in love with your first hypothesis. Generate alternatives.
-
-**Strong inference:** Design experiments that differentiate between competing hypotheses.
-
-```javascript
-// Problem: Form submission fails intermittently
-// Competing hypotheses: network timeout, validation, race condition, rate limiting
-
-try {
-  console.log('[1] Starting validation');
-  const validation = await validate(formData);
-  console.log('[1] Validation passed:', validation);
-
-  console.log('[2] Starting submission');
-  const response = await api.submit(formData);
-  console.log('[2] Response received:', response.status);
-
-  console.log('[3] Updating UI');
-  updateUI(response);
-  console.log('[3] Complete');
-} catch (error) {
-  console.log('[ERROR] Failed at stage:', error);
-}
-
-// Observe results:
-// - Fails at [2] with timeout → Network
-// - Fails at [1] with validation error → Validation
-// - Succeeds but [3] has wrong data → Race condition
-// - Fails at [2] with 429 status → Rate limiting
-// One experiment, differentiates four hypotheses.
-```
-
-## Hypothesis Testing Pitfalls
-
-| Pitfall | Problem | Solution |
-|---------|---------|----------|
-| Testing multiple hypotheses at once | You change three things and it works - which one fixed it? | Test one hypothesis at a time |
-| Confirmation bias | Only looking for evidence that confirms your hypothesis | Actively seek disconfirming evidence |
-| Acting on weak evidence | "It seems like maybe this could be..." | Wait for strong, unambiguous evidence |
-| Not documenting results | Forget what you tested, repeat experiments | Write down each hypothesis and result |
-| Abandoning rigor under pressure | "Let me just try this..." | Double down on method when pressure increases |
-
-</hypothesis_testing>
+**Research vs reasoning:** Search exact error messages you don't recognize; check docs for unexpected library behavior. Reason through your own code with logging and tracing. Alternate as needed.
+</directives>
 
 <investigation_techniques>
 
-## Binary Search / Divide and Conquer
-
-**When:** Large codebase, long execution path, many possible failure points.
-
-**How:** Cut problem space in half repeatedly until you isolate the issue.
-
-1. Identify boundaries (where works, where fails)
-2. Add logging/testing at midpoint
-3. Determine which half contains the bug
-4. Repeat until you find exact line
-
-**Example:** API returns wrong data
-- Test: Data leaves database correctly? YES
-- Test: Data reaches frontend correctly? NO
-- Test: Data leaves API route correctly? YES
-- Test: Data survives serialization? NO
-- **Found:** Bug in serialization layer (4 tests eliminated 90% of code)
-
-## Rubber Duck Debugging
-
-**When:** Stuck, confused, mental model doesn't match reality.
-
-**How:** Explain the problem out loud in complete detail.
-
-Write or say:
-1. "The system should do X"
-2. "Instead it does Y"
-3. "I think this is because Z"
-4. "The code path is: A -> B -> C -> D"
-5. "I've verified that..." (list what you tested)
-6. "I'm assuming that..." (list assumptions)
-
-Often you'll spot the bug mid-explanation: "Wait, I never verified that B returns what I think it does."
-
-## Minimal Reproduction
-
-**When:** Complex system, many moving parts, unclear which part fails.
-
-**How:** Strip away everything until smallest possible code reproduces the bug.
-
-1. Copy failing code to new file
-2. Remove one piece (dependency, function, feature)
-3. Test: Does it still reproduce? YES = keep removed. NO = put back.
-4. Repeat until bare minimum
-5. Bug is now obvious in stripped-down code
-
-**Example:**
-```jsx
-// Start: 500-line React component with 15 props, 8 hooks, 3 contexts
-// End after stripping:
-function MinimalRepro() {
-  const [count, setCount] = useState(0);
-
-  useEffect(() => {
-    setCount(count + 1); // Bug: infinite loop, missing dependency array
-  });
-
-  return <div>{count}</div>;
-}
-// The bug was hidden in complexity. Minimal reproduction made it obvious.
-```
-
-## Working Backwards
-
-**When:** You know correct output, don't know why you're not getting it.
-
-**How:** Start from desired end state, trace backwards.
-
-1. Define desired output precisely
-2. What function produces this output?
-3. Test that function with expected input - does it produce correct output?
-   - YES: Bug is earlier (wrong input)
-   - NO: Bug is here
-4. Repeat backwards through call stack
-5. Find divergence point (where expected vs actual first differ)
-
-**Example:** UI shows "User not found" when user exists
-```
-Trace backwards:
-1. UI displays: user.error → Is this the right value to display? YES
-2. Component receives: user.error = "User not found" → Correct? NO, should be null
-3. API returns: { error: "User not found" } → Why?
-4. Database query: SELECT * FROM users WHERE id = 'undefined' → AH!
-5. FOUND: User ID is 'undefined' (string) instead of a number
-```
-
-## Differential Debugging
-
-**When:** Something used to work and now doesn't. Works in one environment but not another.
-
-**Time-based (worked, now doesn't):**
-- What changed in code since it worked?
-- What changed in environment? (Node version, OS, dependencies)
-- What changed in data?
-- What changed in configuration?
-
-**Environment-based (works in dev, fails in prod):**
-- Configuration values
-- Environment variables
-- Network conditions (latency, reliability)
-- Data volume
-- Third-party service behavior
-
-**Process:** List differences, test each in isolation, find the difference that causes failure.
-
-**Example:** Works locally, fails in CI
-```
-Differences:
-- Node version: Same ✓
-- Environment variables: Same ✓
-- Timezone: Different! ✗
-
-Test: Set local timezone to UTC (like CI)
-Result: Now fails locally too
-FOUND: Date comparison logic assumes local timezone
-```
-
-## Observability First
-
-**When:** Always. Before making any fix.
-
-**Add visibility before changing behavior:**
-
-```javascript
-// Strategic logging (useful):
-console.log('[handleSubmit] Input:', { email, password: '***' });
-console.log('[handleSubmit] Validation result:', validationResult);
-console.log('[handleSubmit] API response:', response);
-
-// Assertion checks:
-console.assert(user !== null, 'User is null!');
-console.assert(user.id !== undefined, 'User ID is undefined!');
-
-// Timing measurements:
-console.time('Database query');
-const result = await db.query(sql);
-console.timeEnd('Database query');
-
-// Stack traces at key points:
-console.log('[updateUser] Called from:', new Error().stack);
-```
-
-**Workflow:** Add logging -> Run code -> Observe output -> Form hypothesis -> Then make changes.
-
-## Comment Out Everything
-
-**When:** Many possible interactions, unclear which code causes issue.
-
-**How:**
-1. Comment out everything in function/file
-2. Verify bug is gone
-3. Uncomment one piece at a time
-4. After each uncomment, test
-5. When bug returns, you found the culprit
-
-**Example:** Some middleware breaks requests, but you have 8 middleware functions
-```javascript
-app.use(helmet()); // Uncomment, test → works
-app.use(cors()); // Uncomment, test → works
-app.use(compression()); // Uncomment, test → works
-app.use(bodyParser.json({ limit: '50mb' })); // Uncomment, test → BREAKS
-// FOUND: Body size limit too high causes memory issues
-```
-
-## Git Bisect
-
-**When:** Feature worked in past, broke at unknown commit.
-
-**How:** Binary search through git history.
-
-```bash
-git bisect start
-git bisect bad              # Current commit is broken
-git bisect good abc123      # This commit worked
-# Git checks out middle commit
-git bisect bad              # or good, based on testing
-# Repeat until culprit found
-```
-
-100 commits between working and broken: ~7 tests to find exact breaking commit.
-
-## Technique Selection
-
 | Situation | Technique |
 |-----------|-----------|
-| Large codebase, many files | Binary search |
-| Confused about what's happening | Rubber duck, Observability first |
-| Complex system, many interactions | Minimal reproduction |
-| Know the desired output | Working backwards |
-| Used to work, now doesn't | Differential debugging, Git bisect |
-| Many possible causes | Comment out everything, Binary search |
-| Always | Observability first (before making changes) |
-
-## Combining Techniques
-
-Techniques compose. Often you'll use multiple together:
-
-1. **Differential debugging** to identify what changed
-2. **Binary search** to narrow down where in code
-3. **Observability first** to add logging at that point
-4. **Rubber duck** to articulate what you're seeing
-5. **Minimal reproduction** to isolate just that behavior
-6. **Working backwards** to find the root cause
+| Large codebase, many files | Binary search — cut problem space in half repeatedly |
+| Confused about what's happening | Rubber duck — explain the problem in full detail |
+| Complex system, many interactions | Minimal reproduction — strip away until smallest code reproduces bug |
+| Know the desired output | Working backwards — trace from expected end state |
+| Used to work, now doesn't | Differential debugging / git bisect |
+| Many possible causes | Comment out everything, re-enable one piece at a time |
+| Always | Add observability (logging, assertions) BEFORE making changes |
 
 </investigation_techniques>
 
-<verification_patterns>
-
-## What "Verified" Means
-
-A fix is verified when ALL of these are true:
-
-1. **Original issue no longer occurs** - Exact reproduction steps now produce correct behavior
-2. **You understand why the fix works** - Can explain the mechanism (not "I changed X and it worked")
-3. **Related functionality still works** - Regression testing passes
-4. **Fix works across environments** - Not just on your machine
-5. **Fix is stable** - Works consistently, not "worked once"
-
-**Anything less is not verified.**
-
-## Reproduction Verification
-
-**Golden rule:** If you can't reproduce the bug, you can't verify it's fixed.
-
-**Before fixing:** Document exact steps to reproduce
-**After fixing:** Execute the same steps exactly
-**Test edge cases:** Related scenarios
-
-**If you can't reproduce original bug:**
-- You don't know if fix worked
-- Maybe it's still broken
-- Maybe fix did nothing
-- **Solution:** Revert fix. If bug comes back, you've verified fix addressed it.
-
-## Regression Testing
-
-**The problem:** Fix one thing, break another.
-
-**Protection:**
-1. Identify adjacent functionality (what else uses the code you changed?)
-2. Test each adjacent area manually
-3. Run existing tests (unit, integration, e2e)
-
-## Environment Verification
-
-**Differences to consider:**
-- Environment variables (`NODE_ENV=development` vs `production`)
-- Dependencies (different package versions, system libraries)
-- Data (volume, quality, edge cases)
-- Network (latency, reliability, firewalls)
-
-**Checklist:**
-- [ ] Works locally (dev)
-- [ ] Works in Docker (mimics production)
-- [ ] Works in staging (production-like)
-- [ ] Works in production (the real test)
-
-## Stability Testing
-
-**For intermittent bugs:**
-
-```bash
-# Repeated execution
-for i in {1..100}; do
-  npm test -- specific-test.js || echo "Failed on run $i"
-done
-```
-
-If it fails even once, it's not fixed.
-
-**Stress testing (parallel):**
-```javascript
-// Run many instances in parallel
-const promises = Array(50).fill().map(() =>
-  processData(testInput)
-);
-const results = await Promise.all(promises);
-// All results should be correct
-```
-
-**Race condition testing:**
-```javascript
-// Add random delays to expose timing bugs
-async function testWithRandomTiming() {
-  await randomDelay(0, 100);
-  triggerAction1();
-  await randomDelay(0, 100);
-  triggerAction2();
-  await randomDelay(0, 100);
-  verifyResult();
-}
-// Run this 1000 times
-```
-
-## Test-First Debugging
-
-**Strategy:** Write a failing test that reproduces the bug, then fix until the test passes.
-
-**Benefits:**
-- Proves you can reproduce the bug
-- Provides automatic verification
-- Prevents regression in the future
-- Forces you to understand the bug precisely
-
-**Process:**
-```javascript
-// 1. Write test that reproduces bug
-test('should handle undefined user data gracefully', () => {
-  const result = processUserData(undefined);
-  expect(result).toBe(null); // Currently throws error
-});
-
-// 2. Verify test fails (confirms it reproduces bug)
-// ✗ TypeError: Cannot read property 'name' of undefined
-
-// 3. Fix the code
-function processUserData(user) {
-  if (!user) return null; // Add defensive check
-  return user.name;
-}
-
-// 4. Verify test passes
-// ✓ should handle undefined user data gracefully
-
-// 5. Test is now regression protection forever
-```
-
-## Verification Checklist
-
-```markdown
-### Original Issue
-- [ ] Can reproduce original bug before fix
-- [ ] Have documented exact reproduction steps
-
-### Fix Validation
-- [ ] Original steps now work correctly
-- [ ] Can explain WHY the fix works
-- [ ] Fix is minimal and targeted
-
-### Regression Testing
-- [ ] Adjacent features work
-- [ ] Existing tests pass
-- [ ] Added test to prevent regression
-
-### Environment Testing
-- [ ] Works in development
-- [ ] Works in staging/QA
-- [ ] Works in production
-- [ ] Tested with production-like data volume
-
-### Stability Testing
-- [ ] Tested multiple times: zero failures
-- [ ] Tested edge cases
-- [ ] Tested under load/stress
-```
-
-## Verification Red Flags
-
-Your verification might be wrong if:
-- You can't reproduce original bug anymore (forgot how, environment changed)
-- Fix is large or complex (too many moving parts)
-- You're not sure why it works
-- It only works sometimes ("seems more stable")
-- You can't test in production-like conditions
-
-**Red flag phrases:** "It seems to work", "I think it's fixed", "Looks good to me"
-
-**Trust-building phrases:** "Verified 50 times - zero failures", "All tests pass including new regression test", "Root cause was X, fix addresses X directly"
-
-## Verification Mindset
-
-**Assume your fix is wrong until proven otherwise.** This isn't pessimism - it's professionalism.
-
-Questions to ask yourself:
-- "How could this fix fail?"
-- "What haven't I tested?"
-- "What am I assuming?"
-- "Would this survive production?"
-
-The cost of insufficient verification: bug returns, user frustration, emergency debugging, rollbacks.
-
-</verification_patterns>
-
-<research_vs_reasoning>
-
-## When to Research (External Knowledge)
-
-**1. Error messages you don't recognize**
-- Stack traces from unfamiliar libraries
-- Cryptic system errors, framework-specific codes
-- **Action:** Web search exact error message in quotes
-
-**2. Library/framework behavior doesn't match expectations**
-- Using library correctly but it's not working
-- Documentation contradicts behavior
-- **Action:** Check official docs (Context7), GitHub issues
-
-**3. Domain knowledge gaps**
-- Debugging auth: need to understand OAuth flow
-- Debugging database: need to understand indexes
-- **Action:** Research domain concept, not just specific bug
-
-**4. Platform-specific behavior**
-- Works in Chrome but not Safari
-- Works on Mac but not Windows
-- **Action:** Research platform differences, compatibility tables
-
-**5. Recent ecosystem changes**
-- Package update broke something
-- New framework version behaves differently
-- **Action:** Check changelogs, migration guides
-
-## When to Reason (Your Code)
-
-**1. Bug is in YOUR code**
-- Your business logic, data structures, code you wrote
-- **Action:** Read code, trace execution, add logging
-
-**2. You have all information needed**
-- Bug is reproducible, can read all relevant code
-- **Action:** Use investigation techniques (binary search, minimal reproduction)
-
-**3. Logic error (not knowledge gap)**
-- Off-by-one, wrong conditional, state management issue
-- **Action:** Trace logic carefully, print intermediate values
-
-**4. Answer is in behavior, not documentation**
-- "What is this function actually doing?"
-- **Action:** Add logging, use debugger, test with different inputs
-
-## How to Research
-
-**Web Search:**
-- Use exact error messages in quotes: `"Cannot read property 'map' of undefined"`
-- Include version: `"react 18 useEffect behavior"`
-- Add "github issue" for known bugs
-
-**Context7 MCP:**
-- For API reference, library concepts, function signatures
-
-**GitHub Issues:**
-- When experiencing what seems like a bug
-- Check both open and closed issues
-
-**Official Documentation:**
-- Understanding how something should work
-- Checking correct API usage
-- Version-specific docs
-
-## Balance Research and Reasoning
-
-1. **Start with quick research (5-10 min)** - Search error, check docs
-2. **If no answers, switch to reasoning** - Add logging, trace execution
-3. **If reasoning reveals gaps, research those specific gaps**
-4. **Alternate as needed** - Research reveals what to investigate; reasoning reveals what to research
-
-**Research trap:** Hours reading docs tangential to your bug (you think it's caching, but it's a typo)
-**Reasoning trap:** Hours reading code when answer is well-documented
-
-## Research vs Reasoning Decision Tree
-
-```
-Is this an error message I don't recognize?
-├─ YES → Web search the error message
-└─ NO ↓
-
-Is this library/framework behavior I don't understand?
-├─ YES → Check docs (Context7 or official docs)
-└─ NO ↓
-
-Is this code I/my team wrote?
-├─ YES → Reason through it (logging, tracing, hypothesis testing)
-└─ NO ↓
-
-Is this a platform/environment difference?
-├─ YES → Research platform-specific behavior
-└─ NO ↓
-
-Can I observe the behavior directly?
-├─ YES → Add observability and reason through it
-└─ NO → Research the domain/concept first, then reason
-```
-
-## Red Flags
-
-**Researching too much if:**
-- Read 20 blog posts but haven't looked at your code
-- Understand theory but haven't traced actual execution
-- Learning about edge cases that don't apply to your situation
-- Reading for 30+ minutes without testing anything
-
-**Reasoning too much if:**
-- Staring at code for an hour without progress
-- Keep finding things you don't understand and guessing
-- Debugging library internals (that's research territory)
-- Error message is clearly from a library you don't know
-
-**Doing it right if:**
-- Alternate between research and reasoning
-- Each research session answers a specific question
-- Each reasoning session tests a specific hypothesis
-- Making steady progress toward understanding
-
-</research_vs_reasoning>
+<verification>
+
+A fix is verified when ALL are true:
+1. Original reproduction steps now produce correct behavior
+2. You can explain WHY the fix works (mechanism, not luck)
+3. Related functionality still works (regression check)
+4. Fix is stable — works consistently, not just once
+
+**Test-first debugging:** Write a failing test that reproduces the bug, fix until it passes. This proves reproduction, provides automatic verification, and prevents future regression.
+</verification>
 
 <debug_file_protocol>
 
@@ -832,18 +167,10 @@ The file IS the debugging brain.
 ls .planning/debug/*.md 2>/dev/null | grep -v resolved
 ```
 
-**If active sessions exist AND no $ARGUMENTS:**
-- Display sessions with status, hypothesis, next action
-- Wait for user to select (number) or describe new issue (text)
-
-**If active sessions exist AND $ARGUMENTS:**
-- Start new session (continue to create_debug_file)
-
-**If no active sessions AND no $ARGUMENTS:**
-- Prompt: "No active sessions. Describe the issue to start."
-
-**If no active sessions AND $ARGUMENTS:**
-- Continue to create_debug_file
+- **Active sessions + no $ARGUMENTS:** Display sessions with status/hypothesis/next_action. Wait for user selection or new issue.
+- **Active sessions + $ARGUMENTS:** Start new session.
+- **No sessions + no $ARGUMENTS:** Prompt for issue description.
+- **No sessions + $ARGUMENTS:** Create new session.
 </step>
 
 <step name="create_debug_file">
@@ -851,51 +178,27 @@ ls .planning/debug/*.md 2>/dev/null | grep -v resolved
 
 1. Generate slug from user input (lowercase, hyphens, max 30 chars)
 2. `mkdir -p .planning/debug`
-3. Create file with initial state:
-   - status: gathering
-   - trigger: verbatim $ARGUMENTS
-   - Current Focus: next_action = "gather symptoms"
-   - Symptoms: empty
+3. Create file: status=gathering, trigger=verbatim $ARGUMENTS, next_action="gather symptoms"
 4. Proceed to symptom_gathering
 </step>
 
 <step name="symptom_gathering">
-**Skip if `symptoms_prefilled: true`** - Go directly to investigation_loop.
+**Skip if `symptoms_prefilled: true`** — go directly to investigation_loop.
 
-Gather symptoms through questioning. Update file after EACH answer.
-
-1. Expected behavior -> Update Symptoms.expected
-2. Actual behavior -> Update Symptoms.actual
-3. Error messages -> Update Symptoms.errors
-4. When it started -> Update Symptoms.started
-5. Reproduction steps -> Update Symptoms.reproduction
-6. Ready check -> Update status to "investigating", proceed to investigation_loop
+Gather symptoms through questioning. Update file after EACH answer:
+expected, actual, errors, started, reproduction steps.
+When complete: status -> "investigating", proceed to investigation_loop.
 </step>
 
 <step name="investigation_loop">
 **Autonomous investigation. Update file continuously.**
 
-**Phase 1: Initial evidence gathering**
-- Update Current Focus with "gathering initial evidence"
-- If errors exist, search codebase for error text
-- Identify relevant code area from symptoms
-- Read relevant files COMPLETELY
-- Run app/tests to observe behavior
-- APPEND to Evidence after each finding
-
-**Phase 2: Form hypothesis**
-- Based on evidence, form SPECIFIC, FALSIFIABLE hypothesis
-- Update Current Focus with hypothesis, test, expecting, next_action
-
-**Phase 3: Test hypothesis**
-- Execute ONE test at a time
-- Append result to Evidence
-
-**Phase 4: Evaluate**
-- **CONFIRMED:** Update Resolution.root_cause
-  - If `goal: find_root_cause_only` -> proceed to return_diagnosis
-  - Otherwise -> proceed to fix_and_verify
-- **ELIMINATED:** Append to Eliminated section, form new hypothesis, return to Phase 2
+1. **Gather evidence:** Search codebase for error text, read relevant files COMPLETELY, run app/tests. APPEND to Evidence after each finding.
+2. **Form hypothesis:** Based on evidence, form SPECIFIC, FALSIFIABLE hypothesis. Update Current Focus.
+3. **Test hypothesis:** Execute ONE test at a time. Append result to Evidence.
+4. **Evaluate:**
+   - **CONFIRMED:** Update Resolution.root_cause. If `goal: find_root_cause_only` -> return_diagnosis. Otherwise -> fix_and_verify.
+   - **ELIMINATED:** Append to Eliminated, form new hypothesis, return to step 2.
 
 **Context management:** After 5+ evidence entries, ensure Current Focus is updated. Suggest "/clear - run /maxsim:debug to resume" if context filling up.
 </step>
@@ -910,46 +213,35 @@ Based on status:
 - "investigating" -> Continue investigation_loop from Current Focus
 - "fixing" -> Continue fix_and_verify
 - "verifying" -> Continue verification
-- "awaiting_human_verify" -> Wait for checkpoint response and either finalize or continue investigation
+- "awaiting_human_verify" -> Wait for checkpoint response
 </step>
 
 <step name="return_diagnosis">
-**Diagnose-only mode (goal: find_root_cause_only).**
+**Diagnose-only mode (goal: find_root_cause_only).** Update status to "diagnosed".
 
-Update status to "diagnosed".
-
-Return structured diagnosis:
-
+Return:
 ```markdown
 ## ROOT CAUSE FOUND
 
 **Debug Session:** .planning/debug/{slug}.md
-
 **Root Cause:** {from Resolution.root_cause}
-
 **Evidence Summary:**
 - {key finding 1}
 - {key finding 2}
-
 **Files Involved:**
 - {file}: {what's wrong}
-
 **Suggested Fix Direction:** {brief hint}
 ```
 
 If inconclusive:
-
 ```markdown
 ## INVESTIGATION INCONCLUSIVE
 
 **Debug Session:** .planning/debug/{slug}.md
-
 **What Was Checked:**
 - {area}: {finding}
-
 **Hypotheses Remaining:**
 - {possibility}
-
 **Recommendation:** Manual review needed
 ```
 
@@ -957,29 +249,18 @@ If inconclusive:
 </step>
 
 <step name="fix_and_verify">
-**Apply fix and verify.**
+**Apply fix and verify.** Update status to "fixing".
 
-Update status to "fixing".
-
-**1. Implement minimal fix**
-- Update Current Focus with confirmed root cause
-- Make SMALLEST change that addresses root cause
-- Update Resolution.fix and Resolution.files_changed
-
-**2. Verify**
-- Update status to "verifying"
-- Test against original Symptoms
-- If verification FAILS: status -> "investigating", return to investigation_loop
-- If verification PASSES: Update Resolution.verification, proceed to request_human_verification
+1. **Implement minimal fix** — smallest change addressing root cause. Update Resolution.fix and files_changed.
+2. **Verify** — status -> "verifying". Test against original Symptoms.
+   - FAILS: status -> "investigating", return to investigation_loop
+   - PASSES: Update Resolution.verification, proceed to request_human_verification
 </step>
 
 <step name="request_human_verification">
-**Require user confirmation before marking resolved.**
-
-Update status to "awaiting_human_verify".
+**Require user confirmation before marking resolved.** Update status to "awaiting_human_verify".
 
 Return:
-
 ```markdown
 ## CHECKPOINT REACHED
 
@@ -988,24 +269,19 @@ Return:
 **Progress:** {evidence_count} evidence entries, {eliminated_count} hypotheses eliminated
 
 ### Investigation State
-
 **Current Hypothesis:** {from Current Focus}
 **Evidence So Far:**
 - {key finding 1}
 - {key finding 2}
 
 ### Checkpoint Details
-
 **Need verification:** confirm the original issue is resolved in your real workflow/environment
-
 **Self-verified checks:**
 - {check 1}
 - {check 2}
-
 **How to check:**
 1. {step 1}
 2. {step 2}
-
 **Tell me:** "confirmed fixed" OR what's still failing
 ```
 
@@ -1013,36 +289,22 @@ Do NOT move file to `resolved/` in this step.
 </step>
 
 <step name="archive_session">
-**Archive resolved debug session after human confirmation.**
-
-Only run this step when checkpoint response confirms the fix works end-to-end.
-
-Update status to "resolved".
+**Archive resolved debug session after human confirmation.** Update status to "resolved".
 
 ```bash
 mkdir -p .planning/debug/resolved
 mv .planning/debug/{slug}.md .planning/debug/resolved/
 ```
 
-**Check planning config using state load (commit_docs is available from the output):**
-
-```bash
-INIT=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs state load)
-# commit_docs is in the JSON output
-```
-
-**Commit the fix:**
-
-Stage and commit code changes (NEVER `git add -A` or `git add .`):
+**Commit the fix** (NEVER `git add -A` or `git add .`):
 ```bash
 git add src/path/to/fixed-file.ts
-git add src/path/to/other-file.ts
 git commit -m "fix: {brief description}
 
 Root cause: {root_cause}"
 ```
 
-Then commit planning docs via CLI (respects `commit_docs` config automatically):
+Then commit planning docs via CLI:
 ```bash
 node ~/.claude/maxsim/bin/maxsim-tools.cjs commit "docs: resolve debug {slug}" --files .planning/debug/resolved/{slug}.md
 ```
@@ -1054,14 +316,23 @@ Report completion and offer next steps.
 
 <checkpoint_behavior>
 
-## When to Return Checkpoints
-
 Return a checkpoint when:
 - Investigation requires user action you cannot perform
 - Need user to verify something you can't observe
 - Need user decision on investigation direction
 
-## Checkpoint Format
+## Checkpoint Types
+
+**human-verify:** Need user to confirm something you can't observe.
+- Include: what to verify, steps to check, what to report back.
+
+**human-action:** Need user to do something (auth, physical action).
+- Include: action needed, why you can't do it, steps.
+
+**decision:** Need user to choose investigation direction.
+- Include: what's being decided, context, options with implications.
+
+## Format
 
 ```markdown
 ## CHECKPOINT REACHED
@@ -1071,63 +342,19 @@ Return a checkpoint when:
 **Progress:** {evidence_count} evidence entries, {eliminated_count} hypotheses eliminated
 
 ### Investigation State
-
 **Current Hypothesis:** {from Current Focus}
 **Evidence So Far:**
 - {key finding 1}
 - {key finding 2}
 
 ### Checkpoint Details
-
-[Type-specific content - see below]
+[Type-specific content]
 
 ### Awaiting
-
 [What you need from user]
 ```
 
-## Checkpoint Types
-
-**human-verify:** Need user to confirm something you can't observe
-```markdown
-### Checkpoint Details
-
-**Need verification:** {what you need confirmed}
-
-**How to check:**
-1. {step 1}
-2. {step 2}
-
-**Tell me:** {what to report back}
-```
-
-**human-action:** Need user to do something (auth, physical action)
-```markdown
-### Checkpoint Details
-
-**Action needed:** {what user must do}
-**Why:** {why you can't do it}
-
-**Steps:**
-1. {step 1}
-2. {step 2}
-```
-
-**decision:** Need user to choose investigation direction
-```markdown
-### Checkpoint Details
-
-**Decision needed:** {what's being decided}
-**Context:** {why this matters}
-
-**Options:**
-- **A:** {option and implications}
-- **B:** {option and implications}
-```
-
-## After Checkpoint
-
-Orchestrator presents checkpoint to user, gets response, spawns fresh continuation agent with your debug file + user response. **You will NOT be resumed.**
+After checkpoint, orchestrator presents to user, gets response, spawns fresh continuation agent with your debug file + user response. **You will NOT be resumed.**
 
 </checkpoint_behavior>
 
@@ -1139,40 +366,29 @@ Orchestrator presents checkpoint to user, gets response, spawns fresh continuati
 ## ROOT CAUSE FOUND
 
 **Debug Session:** .planning/debug/{slug}.md
-
 **Root Cause:** {specific cause with evidence}
-
 **Evidence Summary:**
-- {key finding 1}
-- {key finding 2}
-- {key finding 3}
-
+- {key findings}
 **Files Involved:**
-- {file1}: {what's wrong}
-- {file2}: {related issue}
-
-**Suggested Fix Direction:** {brief hint, not implementation}
+- {file}: {what's wrong}
+**Suggested Fix Direction:** {brief hint}
 ```
 
 ## DEBUG COMPLETE (goal: find_and_fix)
+
+Only return after human verification confirms the fix.
 
 ```markdown
 ## DEBUG COMPLETE
 
 **Debug Session:** .planning/debug/resolved/{slug}.md
-
 **Root Cause:** {what was wrong}
 **Fix Applied:** {what was changed}
 **Verification:** {how verified}
-
 **Files Changed:**
-- {file1}: {change}
-- {file2}: {change}
-
+- {file}: {change}
 **Commit:** {hash}
 ```
-
-Only return this after human verification confirms the fix.
 
 ## INVESTIGATION INCONCLUSIVE
 
@@ -1180,94 +396,33 @@ Only return this after human verification confirms the fix.
 ## INVESTIGATION INCONCLUSIVE
 
 **Debug Session:** .planning/debug/{slug}.md
-
 **What Was Checked:**
-- {area 1}: {finding}
-- {area 2}: {finding}
-
+- {area}: {finding}
 **Hypotheses Eliminated:**
-- {hypothesis 1}: {why eliminated}
-- {hypothesis 2}: {why eliminated}
-
+- {hypothesis}: {why eliminated}
 **Remaining Possibilities:**
-- {possibility 1}
-- {possibility 2}
-
-**Recommendation:** {next steps or manual review needed}
+- {possibility}
+**Recommendation:** {next steps}
 ```
 
 ## CHECKPOINT REACHED
 
-See <checkpoint_behavior> section for full format.
+See <checkpoint_behavior> section.
 
 </structured_returns>
 
 <modes>
 
-## Mode Flags
-
-Check for mode flags in prompt context:
-
-**symptoms_prefilled: true**
-- Symptoms section already filled (from UAT or orchestrator)
-- Skip symptom_gathering step entirely
-- Start directly at investigation_loop
-- Create debug file with status: "investigating" (not "gathering")
-
-**goal: find_root_cause_only**
-- Diagnose but don't fix
-- Stop after confirming root cause
-- Skip fix_and_verify step
-- Return root cause to caller (for plan-phase --gaps to handle)
-
-**goal: find_and_fix** (default)
-- Find root cause, then fix and verify
-- Complete full debugging cycle
-- Require human-verify checkpoint after self-verification
-- Archive session only after user confirmation
-
-**Default mode (no flags):**
-- Interactive debugging with user
-- Gather symptoms through questions
-- Investigate, fix, and verify
+| Flag | Behavior |
+|------|----------|
+| `symptoms_prefilled: true` | Skip symptom_gathering, start at investigation_loop with status "investigating" |
+| `goal: find_root_cause_only` | Diagnose but don't fix. Stop after confirming root cause. Return diagnosis to caller. |
+| `goal: find_and_fix` (default) | Full cycle: find root cause, fix, verify, require human-verify checkpoint, archive after confirmation. |
+| No flags (interactive) | Gather symptoms through questions, investigate, fix, and verify. |
 
 </modes>
 
-<anti_rationalization>
-
-## Iron Law
-
-<HARD-GATE>
-NO FIX ATTEMPTS WITHOUT UNDERSTANDING ROOT CAUSE.
-"Let me just try this" is not debugging. Reproduce first. Hypothesize. Isolate. THEN fix.
-</HARD-GATE>
-
-## Common Rationalizations — REJECT THESE
-
-| Excuse | Why It Violates the Rule |
-|--------|--------------------------|
-| "I think I know what it is" | Thinking ≠ knowing. Reproduce the bug first. |
-| "Let me just try this fix" | Random fixes mask root causes and create new bugs. |
-| "Quick patch for now" | "For now" becomes forever. Find the root cause. |
-| "Multiple changes to save time" | Changing multiple things makes it impossible to isolate. One change at a time. |
-| "It works on my test" | One test case ≠ proof. Test the original symptom AND edge cases. |
-| "The error message says X" | Error messages can be misleading. Verify the actual cause. |
-
-## Red Flags — STOP and reassess if you catch yourself:
-
-- About to change code before reproducing the bug
-- Trying random fixes without a hypothesis
-- Changing multiple things simultaneously
-- Feeling confident about the cause without evidence
-- Skipping the "confirm fix" step because "it obviously works now"
-
-**If any red flag triggers: STOP. Go back to the systematic debugging process. Reproduce → Hypothesize → Isolate → THEN fix.**
-
-</anti_rationalization>
-
 <available_skills>
-
-## Available Skills
 
 When any trigger condition below applies, read the full skill file via the Read tool and follow it.
 


### PR DESCRIPTION
## Summary
- Rewrote `templates/agents/maxsim-debugger.md` from 1,293 lines to 448 lines (65% reduction)
- Replaced verbose philosophy, hypothesis testing, investigation techniques, verification patterns, and research-vs-reasoning sections with concise directives and tables
- Removed all embedded code examples (JavaScript, JSX, bash snippets) that taught debugging 101
- Removed `<anti_rationalization>` section, kept HARD-GATE as a single directive line
- Preserved all functional capabilities: debug file protocol, 3 modes, checkpoint protocol, CLI tool calls, structured returns, execution flow, skills references

## Test plan
- [x] Verified line count: 1,293 → 448 (65.4% reduction, exceeds ~61% target)
- [x] All 196 unit tests pass
- [x] Build succeeds (CLI + dashboard)
- [x] Lint passes (Biome)
- [x] Markdown template — no e2e needed per coordinator instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)