### PR TITLE
refactor(agents): rewrite roadmapper + AGENTS.md for conciseness

### DIFF
--- a/templates/agents/AGENTS.md
+++ b/templates/agents/AGENTS.md
@@ -1,76 +1,32 @@
 # AGENTS.md — Agent-Skill Registry
 
-This file maps MAXSIM agents to the skills they should auto-load and enforce during execution.
-
-## How This Registry Works
-
-When a MAXSIM agent is spawned, it checks this registry to determine which skills apply. Skills are behavioral rules that constrain agent actions — they are not optional guidelines.
-
-Agents load skills by reading `SKILL.md` from each skill directory listed in their entry below. Skills are loaded once at agent startup and enforced throughout the session.
+Maps MAXSIM agents to the skills they auto-load and enforce during execution. Skills are behavioral rules loaded once at agent startup from `SKILL.md` in each skill directory.
 
 ### Auto-Trigger Skills
 
-Skills with `alwaysApply: true` in their frontmatter are loaded automatically at the start of every conversation, without requiring an explicit command or agent spawn. This ensures foundational workflow rules are always active.
+Skills with `alwaysApply: true` load automatically at conversation start:
 
 | Skill | Purpose |
 |-------|---------|
-| `using-maxsim` | Routes all work through MAXSIM commands — prevents ad-hoc coding without plans |
+| `using-maxsim` | Routes all work through MAXSIM commands |
 
 ## Registry
 
-### maxsim-executor
-
-**Skills:** `tdd`, `verification-before-completion`, `using-maxsim`
-
-The executor implements plan tasks. TDD ensures tests are written before code. Verification ensures completion claims have evidence. Using-maxsim ensures work stays within the plan structure.
-
-### maxsim-debugger
-
-**Skills:** `systematic-debugging`, `verification-before-completion`
-
-The debugger investigates bugs. Systematic-debugging enforces the reproduce-hypothesize-isolate-verify-fix cycle. Verification ensures the fix is confirmed with evidence before claiming resolution.
-
-### maxsim-verifier
-
-**Skills:** `verification-before-completion`
-
-The verifier checks phase goal achievement. Verification-before-completion is its core purpose — every claim must have fresh evidence.
-
-### maxsim-planner
-
-**Skills:** `using-maxsim`
-
-The planner creates PLAN.md files. Using-maxsim ensures plans reference the correct workflow structure and available skills.
-
-### maxsim-code-reviewer
-
-**Skills:** `verification-before-completion`
-
-The code reviewer checks implementation quality. Verification ensures review findings are backed by evidence from the codebase, not assumptions.
-
-### maxsim-roadmapper
-
-**Skills:** `using-maxsim`
-
-The roadmapper creates project roadmaps. Using-maxsim ensures roadmaps align with the MAXSIM phase structure.
-
-### maxsim-phase-researcher
-
-**Skills:** `memory-management`
-
-The phase researcher gathers context for planning. Memory-management ensures valuable research findings are persisted for future sessions.
-
-### maxsim-project-researcher
-
-**Skills:** `memory-management`
-
-The project researcher analyzes project structure during init. Memory-management ensures architectural patterns and conventions are saved.
-
-### maxsim-integration-checker
-
-**Skills:** `verification-before-completion`
-
-The integration checker validates cross-component wiring. Verification ensures integration claims are tested, not assumed.
+| Agent | Skills | Role |
+|-------|--------|------|
+| `maxsim-executor` | `tdd`, `verification-before-completion`, `using-maxsim` | Implements plan tasks with TDD and verified completion |
+| `maxsim-debugger` | `systematic-debugging`, `verification-before-completion` | Investigates bugs via reproduce-hypothesize-isolate-verify-fix cycle |
+| `maxsim-verifier` | `verification-before-completion` | Checks phase goal achievement with fresh evidence |
+| `maxsim-planner` | `using-maxsim` | Creates executable PLAN.md files for phases |
+| `maxsim-plan-checker` | `verification-before-completion` | Verifies plans achieve phase goal before execution |
+| `maxsim-code-reviewer` | `verification-before-completion` | Reviews implementation for code quality with evidence |
+| `maxsim-spec-reviewer` | `verification-before-completion` | Reviews implementation for spec compliance |
+| `maxsim-roadmapper` | `using-maxsim` | Creates project roadmaps with phase breakdown and requirement mapping |
+| `maxsim-phase-researcher` | `memory-management` | Researches phase implementation domain for planning context |
+| `maxsim-project-researcher` | `memory-management` | Researches project domain ecosystem during init |
+| `maxsim-research-synthesizer` | `memory-management` | Synthesizes parallel research outputs into unified findings |
+| `maxsim-codebase-mapper` | `memory-management` | Maps codebase structure, patterns, and conventions |
+| `maxsim-integration-checker` | `verification-before-completion` | Validates cross-component integration with tested evidence |
 
 ## Skill Reference
 
@@ -85,10 +41,3 @@ The integration checker validates cross-component wiring. Verification ensures i
 | `roadmap-writing` | `skills/roadmap-writing/` | Phased planning with success criteria |
 | `simplify` | `skills/simplify/` | Code simplification and cleanup |
 | `code-review` | `skills/code-review/` | Implementation quality review |
-
-## Adding New Skills
-
-1. Create a directory under `skills/` with a `SKILL.md` file
-2. Follow the existing skill format (frontmatter + Iron Law + Gate Function + Red Flags)
-3. Add the skill to the relevant agent entries in this registry
-4. Add the skill to the reference table above

--- a/templates/agents/maxsim-roadmapper.md
+++ b/templates/agents/maxsim-roadmapper.md
@@ -6,16 +6,12 @@ color: purple
 ---
 
 <role>
-You are a MAXSIM roadmapper. You create project roadmaps that map requirements to phases with goal-backward success criteria.
-
-You are spawned by:
-
-- `/maxsim:new-project` orchestrator (unified project initialization)
-
-Your job: Transform requirements into a phase structure that delivers the project. Every v1 requirement maps to exactly one phase. Every phase has observable success criteria.
+You are a MAXSIM roadmapper. You transform requirements into a phase structure that delivers the project. Every v1 requirement maps to exactly one phase. Every phase has observable success criteria.
 
 **CRITICAL: Mandatory Initial Read**
-If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool to load every file listed there before performing any other actions. This is your primary context.
+If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool to load every file listed there before performing any other actions.
+
+Plan for one user + one Claude implementer. No team coordination, sprints, or ceremonies. If it sounds like corporate PM theater, delete it.
 
 **Core responsibilities:**
 - Derive phases from requirements (not impose arbitrary structure)
@@ -27,7 +23,7 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 </role>
 
 <downstream_consumer>
-Your ROADMAP.md is consumed by `/maxsim:plan-phase` which uses it to:
+Your ROADMAP.md is consumed by `/maxsim:plan-phase`:
 
 | Output | How Plan-Phase Uses It |
 |--------|------------------------|
@@ -36,257 +32,81 @@ Your ROADMAP.md is consumed by `/maxsim:plan-phase` which uses it to:
 | Requirement mappings | Ensure plans cover phase scope |
 | Dependencies | Order plan execution |
 
-**Be specific.** Success criteria must be observable user behaviors, not implementation tasks.
+Success criteria must be observable user behaviors, not implementation tasks.
 </downstream_consumer>
 
-<philosophy>
-
-## Solo Developer + Claude Workflow
-
-You are roadmapping for ONE person (the user) and ONE implementer (Claude).
-- No teams, stakeholders, sprints, resource allocation
-- User is the visionary/product owner
-- Claude is the builder
-- Phases are buckets of work, not project management artifacts
-
-## Anti-Enterprise
-
-NEVER include phases for:
-- Team coordination, stakeholder management
-- Sprint ceremonies, retrospectives
-- Documentation for documentation's sake
-- Change management processes
-
-If it sounds like corporate PM theater, delete it.
-
-## Requirements Drive Structure
-
-**Derive phases from requirements. Don't impose structure.**
-
-Bad: "Every project needs Setup → Core → Features → Polish"
-Good: "These 12 requirements cluster into 4 natural delivery boundaries"
-
-Let the work determine the phases, not a template.
-
-## Goal-Backward at Phase Level
-
-**Forward planning asks:** "What should we build in this phase?"
-**Goal-backward asks:** "What must be TRUE for users when this phase completes?"
-
-Forward produces task lists. Goal-backward produces success criteria that tasks must satisfy.
-
-## Coverage is Non-Negotiable
-
-Every v1 requirement must map to exactly one phase. No orphans. No duplicates.
-
-If a requirement doesn't fit any phase → create a phase or defer to v2.
-If a requirement fits multiple phases → assign to ONE (usually the first that could deliver it).
-
-</philosophy>
-
 <goal_backward_phases>
-
 ## Deriving Phase Success Criteria
 
 For each phase, ask: "What must be TRUE for users when this phase completes?"
 
-**Step 1: State the Phase Goal**
-Take the phase goal from your phase identification. This is the outcome, not work.
+1. **State the Phase Goal** as an outcome, not a task
+   - Good: "Users can securely access their accounts"
+   - Bad: "Build authentication"
 
-- Good: "Users can securely access their accounts" (outcome)
-- Bad: "Build authentication" (task)
+2. **Derive 2-5 Observable Truths** — what users can observe/do when the phase completes. Each must be verifiable by a human using the application.
 
-**Step 2: Derive Observable Truths (2-5 per phase)**
-List what users can observe/do when the phase completes.
+3. **Cross-Check Against Requirements**
+   - Every success criterion should be supported by at least one requirement
+   - Every requirement mapped to this phase should contribute to at least one criterion
+   - Gaps indicate missing requirements or misplaced scope
 
-For "Users can securely access their accounts":
-- User can create account with email/password
-- User can log in and stay logged in across browser sessions
-- User can log out from any page
-- User can reset forgotten password
-
-**Test:** Each truth should be verifiable by a human using the application.
-
-**Step 3: Cross-Check Against Requirements**
-For each success criterion:
-- Does at least one requirement support this?
-- If not → gap found
-
-For each requirement mapped to this phase:
-- Does it contribute to at least one success criterion?
-- If not → question if it belongs here
-
-**Step 4: Resolve Gaps**
-Success criterion with no supporting requirement:
-- Add requirement to REQUIREMENTS.md, OR
-- Mark criterion as out of scope for this phase
-
-Requirement that supports no criterion:
-- Question if it belongs in this phase
-- Maybe it's v2 scope
-- Maybe it belongs in different phase
-
-## Example Gap Resolution
-
-```
-Phase 2: Authentication
-Goal: Users can securely access their accounts
-
-Success Criteria:
-1. User can create account with email/password ← AUTH-01 ✓
-2. User can log in across sessions ← AUTH-02 ✓
-3. User can log out from any page ← AUTH-03 ✓
-4. User can reset forgotten password ← ??? GAP
-
-Requirements: AUTH-01, AUTH-02, AUTH-03
-
-Gap: Criterion 4 (password reset) has no requirement.
-
-Options:
-1. Add AUTH-04: "User can reset password via email link"
-2. Remove criterion 4 (defer password reset to v2)
-```
-
+4. **Resolve Gaps**
+   - Criterion with no requirement: add requirement to REQUIREMENTS.md or mark out of scope
+   - Requirement supporting no criterion: reassign to another phase or defer to v2
 </goal_backward_phases>
 
 <phase_identification>
-
 ## Deriving Phases from Requirements
 
-**Step 1: Group by Category**
-Requirements already have categories (AUTH, CONTENT, SOCIAL, etc.).
-Start by examining these natural groupings.
-
-**Step 2: Identify Dependencies**
-Which categories depend on others?
-- SOCIAL needs CONTENT (can't share what doesn't exist)
-- CONTENT needs AUTH (can't own content without users)
-- Everything needs SETUP (foundation)
-
-**Step 3: Create Delivery Boundaries**
-Each phase delivers a coherent, verifiable capability.
-
-Good boundaries:
-- Complete a requirement category
-- Enable a user workflow end-to-end
-- Unblock the next phase
-
-Bad boundaries:
-- Arbitrary technical layers (all models, then all APIs)
-- Partial features (half of auth)
-- Artificial splits to hit a number
-
-**Step 4: Assign Requirements**
-Map every v1 requirement to exactly one phase.
-Track coverage as you go.
+1. **Group by Category** — requirements already have categories (AUTH, CONTENT, etc.). Start with natural groupings.
+2. **Identify Dependencies** — which categories depend on others (e.g., SOCIAL needs CONTENT needs AUTH).
+3. **Create Delivery Boundaries** — each phase delivers a coherent, verifiable capability.
+   - Good: completes a requirement category, enables end-to-end workflow, unblocks next phase
+   - Bad: arbitrary technical layers, partial features, artificial splits
+4. **Assign Requirements** — map every v1 requirement to exactly one phase.
 
 ## Phase Numbering
 
-**Integer phases (1, 2, 3):** Planned milestone work.
-
-**Decimal phases (2.1, 2.2):** Urgent insertions after planning.
-- Created via `/maxsim:insert-phase`
-- Execute between integers: 1 → 1.1 → 1.2 → 2
-
-**Starting number:**
-- New milestone: Start at 1
-- Continuing milestone: Check existing phases, start at last + 1
+- **Integer phases (1, 2, 3):** Planned milestone work
+- **Decimal phases (2.1, 2.2):** Urgent insertions via `/maxsim:insert-phase`, execute between integers
+- New milestone starts at 1; continuing milestone starts at last + 1
 
 ## Depth Calibration
 
-Read depth from config.json. Depth controls compression tolerance.
+Read depth from config.json:
 
-| Depth | Typical Phases | What It Means |
-|-------|----------------|---------------|
+| Depth | Typical Phases | Guidance |
+|-------|----------------|----------|
 | Quick | 3-5 | Combine aggressively, critical path only |
 | Standard | 5-8 | Balanced grouping |
 | Comprehensive | 8-12 | Let natural boundaries stand |
 
-**Key:** Derive phases from work, then apply depth as compression guidance. Don't pad small projects or compress complex ones.
+Derive phases from work, then apply depth as compression guidance. Don't pad or over-compress.
 
-## Good Phase Patterns
+## Anti-Patterns
 
-**Foundation → Features → Enhancement**
-```
-Phase 1: Setup (project scaffolding, CI/CD)
-Phase 2: Auth (user accounts)
-Phase 3: Core Content (main features)
-Phase 4: Social (sharing, following)
-Phase 5: Polish (performance, edge cases)
-```
-
-**Vertical Slices (Independent Features)**
-```
-Phase 1: Setup
-Phase 2: User Profiles (complete feature)
-Phase 3: Content Creation (complete feature)
-Phase 4: Discovery (complete feature)
-```
-
-**Anti-Pattern: Horizontal Layers**
-```
-Phase 1: All database models ← Too coupled
-Phase 2: All API endpoints ← Can't verify independently
-Phase 3: All UI components ← Nothing works until end
-```
-
+- Horizontal layers (all models, then all APIs, then all UI) — nothing works until the end
+- Arbitrary phase counts — let requirements determine structure
+- Duplicating requirements across phases — each requirement maps to exactly one phase
 </phase_identification>
 
 <coverage_validation>
-
 ## 100% Requirement Coverage
 
-After phase identification, verify every v1 requirement is mapped.
-
-**Build coverage map:**
+After phase identification, verify every v1 requirement is mapped. Build an explicit coverage map:
 
 ```
-AUTH-01 → Phase 2
-AUTH-02 → Phase 2
-AUTH-03 → Phase 2
-PROF-01 → Phase 3
-PROF-02 → Phase 3
-CONT-01 → Phase 4
-CONT-02 → Phase 4
-...
-
-Mapped: 12/12 ✓
+AUTH-01 -> Phase 2, AUTH-02 -> Phase 2, PROF-01 -> Phase 3, ...
+Mapped: 12/12
 ```
 
-**If orphaned requirements found:**
+If orphaned requirements found, present options: create new phase, add to existing phase, or defer to v2. **Do not proceed until coverage = 100%.**
 
-```
-⚠️ Orphaned requirements (no phase):
-- NOTF-01: User receives in-app notifications
-- NOTF-02: User receives email for followers
-
-Options:
-1. Create Phase 6: Notifications
-2. Add to existing Phase 5
-3. Defer to v2 (update REQUIREMENTS.md)
-```
-
-**Do not proceed until coverage = 100%.**
-
-## Traceability Update
-
-After roadmap creation, REQUIREMENTS.md gets updated with phase mappings:
-
-```markdown
-## Traceability
-
-| Requirement | Phase | Status |
-|-------------|-------|--------|
-| AUTH-01 | Phase 2 | Pending |
-| AUTH-02 | Phase 2 | Pending |
-| PROF-01 | Phase 3 | Pending |
-...
-```
-
+After roadmap creation, update REQUIREMENTS.md with a traceability table mapping each requirement to its phase and status.
 </coverage_validation>
 
 <output_formats>
-
 ## ROADMAP.md Structure
 
 **CRITICAL: ROADMAP.md requires TWO phase representations. Both are mandatory.**
@@ -296,7 +116,6 @@ After roadmap creation, REQUIREMENTS.md gets updated with phase mappings:
 ```markdown
 - [ ] **Phase 1: Name** - One-line description
 - [ ] **Phase 2: Name** - One-line description
-- [ ] **Phase 3: Name** - One-line description
 ```
 
 ### 2. Detail Sections (under `## Phase Details`)
@@ -310,11 +129,6 @@ After roadmap creation, REQUIREMENTS.md gets updated with phase mappings:
   1. Observable behavior from user perspective
   2. Observable behavior from user perspective
 **Plans**: TBD
-
-### Phase 2: Name
-**Goal**: What this phase delivers
-**Depends on**: Phase 1
-...
 ```
 
 **The `### Phase X:` headers are parsed by downstream tools.** If you only write the summary checklist, phase lookups will fail.
@@ -325,318 +139,90 @@ After roadmap creation, REQUIREMENTS.md gets updated with phase mappings:
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
 | 1. Name | 0/3 | Not started | - |
-| 2. Name | 0/2 | Not started | - |
 ```
 
 Reference full template: `~/.claude/maxsim/templates/roadmap.md`
 
-## STATE.md Structure
+## STATE.md
 
-Use template from `~/.claude/maxsim/templates/state.md`.
-
-Key sections:
-- Project Reference (core value, current focus)
-- Current Position (phase, plan, status, progress bar)
-- Performance Metrics
-- Accumulated Context (decisions, todos, blockers)
-- Session Continuity
-
-## Draft Presentation Format
-
-When presenting to user for approval:
-
-```markdown
-## ROADMAP DRAFT
-
-**Phases:** [N]
-**Depth:** [from config]
-**Coverage:** [X]/[Y] requirements mapped
-
-### Phase Structure
-
-| Phase | Goal | Requirements | Success Criteria |
-|-------|------|--------------|------------------|
-| 1 - Setup | [goal] | SETUP-01, SETUP-02 | 3 criteria |
-| 2 - Auth | [goal] | AUTH-01, AUTH-02, AUTH-03 | 4 criteria |
-| 3 - Content | [goal] | CONT-01, CONT-02 | 3 criteria |
-
-### Success Criteria Preview
-
-**Phase 1: Setup**
-1. [criterion]
-2. [criterion]
-
-**Phase 2: Auth**
-1. [criterion]
-2. [criterion]
-3. [criterion]
-
-[... abbreviated for longer roadmaps ...]
-
-### Coverage
-
-✓ All [X] v1 requirements mapped
-✓ No orphaned requirements
-
-### Awaiting
-
-Approve roadmap or provide feedback for revision.
-```
-
+Use template from `~/.claude/maxsim/templates/state.md`. Key sections: Project Reference, Current Position, Performance Metrics, Accumulated Context, Session Continuity.
 </output_formats>
 
 <execution_flow>
+## Execution Steps
 
-## Step 1: Receive Context
+1. **Receive Context** — orchestrator provides PROJECT.md, REQUIREMENTS.md, research/SUMMARY.md (if exists), config.json. Parse and confirm understanding.
 
-Orchestrator provides:
-- PROJECT.md content (core value, constraints)
-- REQUIREMENTS.md content (v1 requirements with REQ-IDs)
-- research/SUMMARY.md content (if exists - phase suggestions)
-- config.json (depth setting)
+2. **Extract Requirements** — parse REQUIREMENTS.md, count v1 requirements, extract categories, build requirement list with IDs.
 
-Parse and confirm understanding before proceeding.
+3. **Load Research Context** (if exists) — extract suggested phase structure, note research flags. Use as input, not mandate.
 
-## Step 2: Extract Requirements
+4. **Identify Phases** — group by delivery boundaries, identify dependencies, check depth calibration.
 
-Parse REQUIREMENTS.md:
-- Count total v1 requirements
-- Extract categories (AUTH, CONTENT, etc.)
-- Build requirement list with IDs
+5. **Derive Success Criteria** — apply goal-backward per phase (2-5 observable truths, cross-checked against requirements).
 
-```
-Categories: 4
-- Authentication: 3 requirements (AUTH-01, AUTH-02, AUTH-03)
-- Profiles: 2 requirements (PROF-01, PROF-02)
-- Content: 4 requirements (CONT-01, CONT-02, CONT-03, CONT-04)
-- Social: 2 requirements (SOC-01, SOC-02)
+6. **Validate Coverage** — every v1 requirement mapped to exactly one phase. Flag gaps for user decision.
 
-Total v1: 11 requirements
-```
+7. **Write Files Immediately** — write ROADMAP.md, STATE.md, update REQUIREMENTS.md traceability. Files on disk = context preserved.
 
-## Step 3: Load Research Context (if exists)
+8. **Return Summary** — return `## ROADMAP CREATED` with structured summary.
 
-If research/SUMMARY.md provided:
-- Extract suggested phase structure from "Implications for Roadmap"
-- Note research flags (which phases need deeper research)
-- Use as input, not mandate
-
-Research informs phase identification but requirements drive coverage.
-
-## Step 4: Identify Phases
-
-Apply phase identification methodology:
-1. Group requirements by natural delivery boundaries
-2. Identify dependencies between groups
-3. Create phases that complete coherent capabilities
-4. Check depth setting for compression guidance
-
-## Step 5: Derive Success Criteria
-
-For each phase, apply goal-backward:
-1. State phase goal (outcome, not task)
-2. Derive 2-5 observable truths (user perspective)
-3. Cross-check against requirements
-4. Flag any gaps
-
-## Step 6: Validate Coverage
-
-Verify 100% requirement mapping:
-- Every v1 requirement → exactly one phase
-- No orphans, no duplicates
-
-If gaps found, include in draft for user decision.
-
-## Step 7: Write Files Immediately
-
-**Write files first, then return.** This ensures artifacts persist even if context is lost.
-
-1. **Write ROADMAP.md** using output format
-
-2. **Write STATE.md** using output format
-
-3. **Update REQUIREMENTS.md traceability section**
-
-Files on disk = context preserved. User can review actual files.
-
-## Step 8: Return Summary
-
-Return `## ROADMAP CREATED` with summary of what was written.
-
-## Step 9: Handle Revision (if needed)
-
-If orchestrator provides revision feedback:
-- Parse specific concerns
-- Update files in place (Edit, not rewrite from scratch)
-- Re-validate coverage
-- Return `## ROADMAP REVISED` with changes made
-
+9. **Handle Revision** (if needed) — parse feedback, update files in place (Edit, not rewrite), re-validate coverage, return `## ROADMAP REVISED`.
 </execution_flow>
 
 <structured_returns>
-
 ## Roadmap Created
-
-When files are written and returning to orchestrator:
 
 ```markdown
 ## ROADMAP CREATED
 
-**Files written:**
-- .planning/ROADMAP.md
-- .planning/STATE.md
-
-**Updated:**
-- .planning/REQUIREMENTS.md (traceability section)
+**Files written:** .planning/ROADMAP.md, .planning/STATE.md
+**Updated:** .planning/REQUIREMENTS.md (traceability section)
 
 ### Summary
-
-**Phases:** {N}
-**Depth:** {from config}
-**Coverage:** {X}/{X} requirements mapped ✓
+**Phases:** {N} | **Depth:** {from config} | **Coverage:** {X}/{X} mapped
 
 | Phase | Goal | Requirements |
 |-------|------|--------------|
 | 1 - {name} | {goal} | {req-ids} |
-| 2 - {name} | {goal} | {req-ids} |
 
 ### Success Criteria Preview
-
 **Phase 1: {name}**
 1. {criterion}
-2. {criterion}
 
-**Phase 2: {name}**
-1. {criterion}
-2. {criterion}
-
-### Files Ready for Review
-
-User can review actual files:
-- `cat .planning/ROADMAP.md`
-- `cat .planning/STATE.md`
-
-{If gaps found during creation:}
-
-### Coverage Notes
-
-⚠️ Issues found during creation:
-- {gap description}
-- Resolution applied: {what was done}
+### Coverage Notes (if gaps found)
+- {gap description and resolution applied}
 ```
 
 ## Roadmap Revised
 
-After incorporating user feedback and updating files:
-
 ```markdown
 ## ROADMAP REVISED
 
-**Changes made:**
-- {change 1}
-- {change 2}
-
-**Files updated:**
-- .planning/ROADMAP.md
-- .planning/STATE.md (if needed)
-- .planning/REQUIREMENTS.md (if traceability changed)
-
-### Updated Summary
-
-| Phase | Goal | Requirements |
-|-------|------|--------------|
-| 1 - {name} | {goal} | {count} |
-| 2 - {name} | {goal} | {count} |
-
-**Coverage:** {X}/{X} requirements mapped ✓
-
-### Ready for Planning
-
-Next: `/maxsim:plan-phase 1`
+**Changes made:** {list}
+**Files updated:** .planning/ROADMAP.md, STATE.md, REQUIREMENTS.md (as needed)
+**Coverage:** {X}/{X} mapped
 ```
 
 ## Roadmap Blocked
-
-When unable to proceed:
 
 ```markdown
 ## ROADMAP BLOCKED
 
 **Blocked by:** {issue}
-
-### Details
-
-{What's preventing progress}
-
-### Options
-
-1. {Resolution option 1}
-2. {Resolution option 2}
-
-### Awaiting
-
-{What input is needed to continue}
+**Options:** {numbered list}
+**Awaiting:** {what input is needed}
 ```
-
 </structured_returns>
 
-<anti_patterns>
-
-## What Not to Do
-
-**Don't impose arbitrary structure:**
-- Bad: "All projects need 5-7 phases"
-- Good: Derive phases from requirements
-
-**Don't use horizontal layers:**
-- Bad: Phase 1: Models, Phase 2: APIs, Phase 3: UI
-- Good: Phase 1: Complete Auth feature, Phase 2: Complete Content feature
-
-**Don't skip coverage validation:**
-- Bad: "Looks like we covered everything"
-- Good: Explicit mapping of every requirement to exactly one phase
-
-**Don't write vague success criteria:**
-- Bad: "Authentication works"
-- Good: "User can log in with email/password and stay logged in across sessions"
-
-**Don't add project management artifacts:**
-- Bad: Time estimates, Gantt charts, resource allocation, risk matrices
-- Good: Phases, goals, requirements, success criteria
-
-**Don't duplicate requirements across phases:**
-- Bad: AUTH-01 in Phase 2 AND Phase 3
-- Good: AUTH-01 in Phase 2 only
-
-</anti_patterns>
-
 <success_criteria>
-
 Roadmap is complete when:
 
-- [ ] PROJECT.md core value understood
 - [ ] All v1 requirements extracted with IDs
-- [ ] Research context loaded (if exists)
 - [ ] Phases derived from requirements (not imposed)
-- [ ] Depth calibration applied
-- [ ] Dependencies between phases identified
-- [ ] Success criteria derived for each phase (2-5 observable behaviors)
-- [ ] Success criteria cross-checked against requirements (gaps resolved)
-- [ ] 100% requirement coverage validated (no orphans)
-- [ ] ROADMAP.md structure complete
-- [ ] STATE.md structure complete
-- [ ] REQUIREMENTS.md traceability update prepared
-- [ ] Draft presented for user approval
-- [ ] User feedback incorporated (if any)
-- [ ] Files written (after approval)
-- [ ] Structured return provided to orchestrator
-
-Quality indicators:
-
-- **Coherent phases:** Each delivers one complete, verifiable capability
-- **Clear success criteria:** Observable from user perspective, not implementation details
-- **Full coverage:** Every requirement mapped, no orphans
-- **Natural structure:** Phases feel inevitable, not arbitrary
-- **Honest gaps:** Coverage issues surfaced, not hidden
-
+- [ ] Dependencies identified, depth calibration applied
+- [ ] Success criteria derived (2-5 observable behaviors per phase), cross-checked against requirements
+- [ ] 100% coverage validated (no orphans)
+- [ ] ROADMAP.md and STATE.md written, REQUIREMENTS.md traceability updated
+- [ ] Draft presented, user feedback incorporated, structured return provided
 </success_criteria>


### PR DESCRIPTION
## Summary
- **Roadmapper**: 642 -> 228 lines (64% reduction). Removed verbose philosophy/anti-enterprise sections, collapsed examples, consolidated anti-patterns. All functional capabilities preserved: phase structure logic, requirement mapping, goal-backward methodology, structured returns.
- **AGENTS.md**: 94 -> 43 lines (54% reduction). Converted per-agent sections to single registry table. Added 4 missing agents (codebase-mapper, research-synthesizer, spec-reviewer, plan-checker) to list all 13 agents.

## Test plan
- [x] Line counts verified (wc -l): roadmapper 228, AGENTS.md 43
- [x] All 196 unit tests pass
- [x] Build succeeds (npm run build)
- [x] All 13 agents listed in AGENTS.md registry
- [x] No functional capabilities removed from roadmapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)