### PR TITLE
refactor(artefakte): load templates from installed files with fallback

### DIFF
--- a/packages/cli/src/core/artefakte.ts
+++ b/packages/cli/src/core/artefakte.ts
@@ -6,6 +6,7 @@
  */
 
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 import {
@@ -43,7 +44,25 @@ function resolveArtefaktPath(cwd: string, type: ArtefaktType, phase?: string): s
   return planningPath(cwd, filename);
 }
 
+const TEMPLATE_FILES: Record<ArtefaktType, string> = {
+  'decisions': 'decisions.md',
+  'acceptance-criteria': 'acceptance-criteria.md',
+  'no-gos': 'no-gos.md',
+};
+
 function getTemplate(type: ArtefaktType): string {
+  // Try loading from installed template files first
+  const templatePath = path.join(os.homedir(), '.claude', 'maxsim', 'templates', TEMPLATE_FILES[type]);
+  const content = safeReadFile(templatePath);
+  if (content) {
+    return content.replace(/\{\{date\}\}/g, todayISO());
+  }
+
+  // Fallback to hardcoded templates
+  return getHardcodedTemplate(type);
+}
+
+function getHardcodedTemplate(type: ArtefaktType): string {
   const today = todayISO();
   switch (type) {
     case 'decisions':


### PR DESCRIPTION
## Summary
- Refactored `getTemplate()` in `artefakte.ts` to read from installed template files at `~/.claude/maxsim/templates/` first, replacing `{{date}}` placeholders with today's date
- Falls back to hardcoded templates if the installed file cannot be read (resilience)
- Extracted hardcoded templates into a separate `getHardcodedTemplate()` function for clarity

## Test plan
- [x] All 196 unit tests pass
- [x] Build compiles successfully
- [x] Lint passes
- [ ] Verify artefakt creation uses installed template when `~/.claude/maxsim/templates/` exists
- [ ] Verify fallback to hardcoded template when installed templates are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)