### PR TITLE
feat(dashboard): add project switcher (DASH-07)

### DIFF
--- a/packages/dashboard/src/components/layout/ProjectSwitcher.tsx
+++ b/packages/dashboard/src/components/layout/ProjectSwitcher.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect, useRef } from "react";
+import { useRunningDashboards, type RunningDashboard } from "@/hooks/use-running-dashboards";
+import { cn } from "@/lib/utils";
+
+function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+function truncatePath(cwd: string, maxLen = 36): string {
+  if (cwd.length <= maxLen) return cwd;
+  return `...${cwd.slice(-(maxLen - 3))}`;
+}
+
+export function ProjectSwitcher() {
+  const { dashboards, loading } = useRunningDashboards();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const current = dashboards.find((d) => d.isCurrent);
+  const projectName = current?.projectName ?? "Dashboard";
+
+  // Close on outside click or Escape
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  function handleSelect(d: RunningDashboard) {
+    if (d.isCurrent) {
+      setOpen(false);
+      return;
+    }
+    window.open(`http://localhost:${d.port}`, "_blank");
+    setOpen(false);
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1 text-left min-w-0 group"
+      >
+        <span
+          className="text-xs text-muted-foreground truncate max-w-[140px] group-hover:text-foreground transition-colors duration-150"
+          title={projectName}
+        >
+          {projectName}
+        </span>
+        {loading ? (
+          <span className="inline-block h-3 w-3 shrink-0 animate-spin rounded-full border border-muted-foreground/30 border-t-muted-foreground" />
+        ) : (
+          <svg
+            className={cn(
+              "h-3 w-3 shrink-0 text-muted-foreground transition-transform duration-150",
+              open && "rotate-180"
+            )}
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M4 6l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full z-50 mt-1 w-64 rounded border border-border bg-card shadow-lg">
+          <div className="px-3 py-2 border-b border-border">
+            <span className="text-xs uppercase tracking-widest text-muted-foreground">
+              Running dashboards
+            </span>
+          </div>
+          <div className="max-h-64 overflow-y-auto py-1">
+            {dashboards.length === 0 && (
+              <div className="px-3 py-2 text-xs text-muted-foreground">
+                No dashboards found
+              </div>
+            )}
+            {dashboards.map((d) => (
+              <button
+                key={d.port}
+                type="button"
+                onClick={() => handleSelect(d)}
+                className={cn(
+                  "flex w-full flex-col gap-0.5 px-3 py-2 text-left transition-colors duration-150",
+                  d.isCurrent
+                    ? "bg-accent/10 border-l-2 border-l-accent"
+                    : "border-l-2 border-l-transparent hover:bg-card-hover"
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "text-xs font-medium truncate",
+                      d.isCurrent ? "text-accent" : "text-foreground"
+                    )}
+                  >
+                    {d.projectName}
+                  </span>
+                  {d.isCurrent && (
+                    <span className="text-[10px] text-accent/70">current</span>
+                  )}
+                  <span className="ml-auto text-[10px] text-muted-foreground tabular-nums shrink-0">
+                    {formatUptime(d.uptime)}
+                  </span>
+                </div>
+                <span className="text-[10px] text-muted-foreground truncate" title={d.cwd}>
+                  {truncatePath(d.cwd)}
+                </span>
+              </button>
+            ))}
+            {dashboards.length === 1 && (
+              <div className="px-3 py-1.5 text-[10px] text-muted-foreground/60 text-center">
+                (only instance)
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/layout/sidebar.tsx
+++ b/packages/dashboard/src/components/layout/sidebar.tsx
@@ -2,21 +2,9 @@ import { useState, useEffect } from "react";
 import { useDashboardData } from "@/hooks/use-dashboard-data";
 import { useWebSocket } from "@/components/providers/websocket-provider";
 import { NetworkQRButton } from "@/components/network/NetworkQRButton";
+import { ProjectSwitcher } from "@/components/layout/ProjectSwitcher";
 import { cn } from "@/lib/utils";
 import type { DashboardPhase } from "@/lib/types";
-
-function useProjectName(): string | null {
-  const [name, setName] = useState<string | null>(null);
-  useEffect(() => {
-    fetch("/api/server-info")
-      .then((r) => r.json())
-      .then((data: { projectName?: string }) => {
-        if (data.projectName) setName(data.projectName);
-      })
-      .catch(() => {});
-  }, []);
-  return name;
-}
 
 type ActiveView = "overview" | "phase" | "todos" | "blockers" | "discussion";
 
@@ -46,7 +34,6 @@ function statusDotClass(status: DashboardPhase["diskStatus"]): string {
 export function Sidebar({ activeView, activePhaseId, onNavigate, terminalOpen, onTerminalToggle }: SidebarProps) {
   const { roadmap, state, todos } = useDashboardData();
   const { connected, pendingQuestionCount } = useWebSocket();
-  const projectName = useProjectName();
   const [confirmShutdown, setConfirmShutdown] = useState(false);
 
   useEffect(() => {
@@ -96,9 +83,7 @@ export function Sidebar({ activeView, activePhaseId, onNavigate, terminalOpen, o
           <span className="text-sm font-bold tracking-tight text-foreground">
             MAXSIM
           </span>
-          <span className="text-xs text-muted-foreground truncate max-w-[160px]" title={projectName ?? "Dashboard"}>
-            {projectName ?? "Dashboard"}
-          </span>
+          <ProjectSwitcher />
         </button>
       </div>
 

--- a/packages/dashboard/src/hooks/use-running-dashboards.ts
+++ b/packages/dashboard/src/hooks/use-running-dashboards.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+export interface RunningDashboard {
+  port: number;
+  cwd: string;
+  projectName: string;
+  uptime: number;
+  isCurrent: boolean;
+}
+
+interface UseRunningDashboardsResult {
+  dashboards: RunningDashboard[];
+  loading: boolean;
+  refresh: () => void;
+}
+
+const POLL_INTERVAL = 30_000;
+
+export function useRunningDashboards(): UseRunningDashboardsResult {
+  const [dashboards, setDashboards] = useState<RunningDashboard[]>([]);
+  const [loading, setLoading] = useState(true);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/dashboards");
+      if (!res.ok) return;
+      const data = (await res.json()) as { dashboards: RunningDashboard[] };
+      setDashboards(data.dashboards);
+    } catch {
+      // Network error — keep cached value
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    intervalRef.current = setInterval(refresh, POLL_INTERVAL);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [refresh]);
+
+  return { dashboards, loading, refresh };
+}

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -966,6 +966,24 @@ app.get('/api/server-info', (_req: Request, res: Response) => {
   });
 });
 
+// ── Running dashboards (project switcher) ──
+app.get('/api/dashboards', async (_req: Request, res: Response) => {
+  try {
+    const running = await listRunningDashboards();
+    const dashboards = running.map(d => ({
+      port: d.port,
+      cwd: d.cwd,
+      projectName: path.basename(d.cwd),
+      uptime: d.uptime,
+      isCurrent: d.port === resolvedPort,
+    }));
+    return res.json({ dashboards });
+  } catch (err) {
+    log('ERROR', 'api', 'Failed to list dashboards:', err);
+    return res.status(500).json({ error: 'Failed to list running dashboards' });
+  }
+});
+
 // ── Shutdown ──
 // Resolved in main() and exposed here so the endpoint can call it
 let shutdownFn: (() => void) | null = null;


### PR DESCRIPTION
## Summary
- Add `GET /api/dashboards` endpoint that scans running MAXSIM dashboard instances via the existing `listRunningDashboards()` port scanner
- Add `useRunningDashboards` hook with 30-second polling and cached results
- Add `ProjectSwitcher` dropdown component in the sidebar header showing all running dashboards with project name, working directory, and uptime
- Replace the static `useProjectName()` hook in `sidebar.tsx` with the new `ProjectSwitcher` component

## Test plan
- [x] Unit tests pass (196/196)
- [x] Build succeeds (dashboard + CLI)
- [x] Lint passes (Biome)
- [ ] Manual: Start dashboard on a project, verify project name shows in sidebar with chevron
- [ ] Manual: Click chevron, verify dropdown lists current dashboard with "current" badge
- [ ] Manual: Start a second dashboard on another project, verify both appear in dropdown
- [ ] Manual: Click a non-current dashboard entry, verify it opens in a new tab
- [ ] Manual: Press Escape or click outside dropdown to close it

🤖 Generated with [Claude Code](https://claude.com/claude-code)