### PR TITLE
feat(website): Hero + Navbar design refresh

### DIFF
--- a/packages/website/src/components/sections/Hero.tsx
+++ b/packages/website/src/components/sections/Hero.tsx
@@ -4,9 +4,19 @@ import { cn } from "@/lib/utils";
 
 const FLIP_WORDS = ["Engineering", "Prompting", "Development", "Orchestration"];
 
-function AnimatedGridBackground() {
+const TERMINAL_LINES = [
+  { prompt: true, text: "/maxsim:plan-phase", delay: 0 },
+  { prompt: false, text: "Planning phase 02-Auth-System...", delay: 0.6 },
+  { prompt: false, text: "Spawning researcher agent (claude-sonnet-4-20250514)", delay: 1.0 },
+  { prompt: false, text: "Research complete. 4 decisions captured.", delay: 1.6 },
+  { prompt: false, text: "Generating 02-01-PLAN.md (12 tasks)", delay: 2.1 },
+  { prompt: false, text: "Phase plan verified. Ready to execute.", delay: 2.7, accent: true },
+];
+
+function AuroraMeshBackground() {
   return (
     <div className="absolute inset-0 overflow-hidden pointer-events-none" aria-hidden>
+      {/* Grid */}
       <motion.div
         className="absolute inset-0"
         initial={{ opacity: 0 }}
@@ -20,6 +30,18 @@ function AnimatedGridBackground() {
           backgroundSize: "100px 100px",
         }}
       />
+      {/* Aurora gradient mesh — very subtle at ~5% opacity */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background: `
+            radial-gradient(ellipse 60% 50% at 20% 20%, rgba(59,130,246,0.05) 0%, transparent 70%),
+            radial-gradient(ellipse 50% 40% at 80% 30%, rgba(139,92,246,0.04) 0%, transparent 70%),
+            radial-gradient(ellipse 70% 60% at 50% 80%, rgba(59,130,246,0.03) 0%, transparent 70%)
+          `,
+        }}
+      />
+      {/* Top radial glow */}
       <div
         className="absolute inset-0"
         style={{
@@ -59,9 +81,79 @@ function WordFlipper() {
   );
 }
 
-function TerminalBlock() {
-  const [copied, setCopied] = useState(false);
+function TerminalMockup() {
+  const [visibleLines, setVisibleLines] = useState(0);
+  const [showCursor, setShowCursor] = useState(true);
 
+  useEffect(() => {
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    TERMINAL_LINES.forEach((line, i) => {
+      timers.push(
+        setTimeout(() => {
+          setVisibleLines(i + 1);
+        }, line.delay * 1000 + 1200)
+      );
+    });
+    return () => timers.forEach(clearTimeout);
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => setShowCursor((p) => !p), 530);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <motion.div
+      className="w-full max-w-2xl mx-auto rounded-lg overflow-hidden border border-border bg-surface"
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.7, delay: 0.8 }}
+    >
+      {/* Title bar with colored dots */}
+      <div className="flex items-center gap-2 px-4 py-2.5 bg-surface-light border-b border-border">
+        <span className="w-3 h-3 rounded-full bg-[#ff5f57]" />
+        <span className="w-3 h-3 rounded-full bg-[#febc2e]" />
+        <span className="w-3 h-3 rounded-full bg-[#28c840]" />
+        <span className="ml-2 text-xs text-muted font-mono tracking-wide">
+          maxsim workflow
+        </span>
+      </div>
+      {/* Terminal content */}
+      <div className="px-5 py-4 font-mono text-sm leading-relaxed min-h-[180px]">
+        {TERMINAL_LINES.slice(0, visibleLines).map((line, i) => (
+          <motion.div
+            key={i}
+            initial={{ opacity: 0, x: -8 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.25 }}
+            className={cn(
+              "whitespace-nowrap overflow-hidden",
+              line.accent ? "text-accent" : "text-foreground/80"
+            )}
+          >
+            {line.prompt && (
+              <span className="text-accent mr-2 select-none">$</span>
+            )}
+            {!line.prompt && (
+              <span className="text-muted mr-2 select-none">{">"}</span>
+            )}
+            {line.text}
+          </motion.div>
+        ))}
+        {/* Blinking cursor */}
+        <span
+          className={cn(
+            "inline-block w-2 h-4 bg-accent mt-1 transition-opacity duration-100",
+            showCursor ? "opacity-100" : "opacity-0"
+          )}
+        />
+      </div>
+    </motion.div>
+  );
+}
+
+function InstallBlock() {
+  const [copied, setCopied] = useState(false);
   const command = "npx maxsimcli@latest";
 
   const handleCopy = () => {
@@ -76,15 +168,9 @@ function TerminalBlock() {
       className="w-full max-w-xl mx-auto lg:mx-0 rounded-lg overflow-hidden border border-border bg-surface"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.6, delay: 0.9 }}
+      transition={{ duration: 0.6, delay: 1.0 }}
     >
-      <div className="flex items-center gap-2 px-4 py-2.5 bg-surface-light border-b border-border">
-        <span className="w-3 h-3 rounded-full bg-zinc-600" />
-        <span className="w-3 h-3 rounded-full bg-zinc-600" />
-        <span className="w-3 h-3 rounded-full bg-zinc-600" />
-        <span className="ml-2 text-xs text-muted font-mono tracking-wide">terminal</span>
-      </div>
-      <div className="flex items-center justify-between px-5 py-4 gap-4">
+      <div className="flex items-center justify-between px-5 py-3.5 gap-4">
         <pre className="font-mono text-sm md:text-base text-foreground/90 select-all whitespace-nowrap overflow-x-auto">
           <span className="text-accent mr-2 select-none">$</span>
           <span>{command}</span>
@@ -106,10 +192,39 @@ function TerminalBlock() {
   );
 }
 
+function ScrollIndicator() {
+  return (
+    <motion.div
+      className="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.6, delay: 2.0 }}
+    >
+      <motion.svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        className="text-muted"
+        animate={{ y: [0, 6, 0] }}
+        transition={{ duration: 1.8, repeat: Infinity, ease: "easeInOut" }}
+      >
+        <path
+          d="M6 9l6 6 6-6"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </motion.svg>
+    </motion.div>
+  );
+}
+
 export default function Hero() {
   return (
     <section id="home" className="relative min-h-screen flex items-center bg-background overflow-hidden">
-      <AnimatedGridBackground />
+      <AuroraMeshBackground />
 
       <motion.div
         className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-accent/50 to-transparent"
@@ -119,148 +234,114 @@ export default function Hero() {
       />
 
       <div className="relative w-full max-w-7xl mx-auto px-6 sm:px-10 lg:px-16 py-24 lg:py-32">
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-12 lg:gap-8 items-center">
+        <div className="flex flex-col items-center text-center gap-8">
 
-          <div className="lg:col-span-7 flex flex-col gap-8">
+          {/* Badge */}
+          <motion.div
+            className="flex items-center gap-3"
+            initial={{ opacity: 0, y: -12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.1 }}
+          >
+            <span className="block w-6 h-px bg-accent" />
+            <span className="text-xs font-mono uppercase tracking-widest text-accent">
+              CLI Tool
+            </span>
+            <span className="block w-6 h-px bg-accent" />
+          </motion.div>
 
-            <motion.div
-              className="flex items-center gap-3"
-              initial={{ opacity: 0, x: -16 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.5, delay: 0.1 }}
+          {/* Headline with gradient text */}
+          <motion.div
+            className="flex flex-col gap-2"
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+          >
+            <h1
+              className="text-5xl sm:text-6xl md:text-7xl font-extrabold tracking-tight leading-none bg-clip-text text-transparent"
+              style={{
+                backgroundImage: "linear-gradient(to bottom, #ffffff 30%, #3b82f6 100%)",
+              }}
             >
-              <span className="block w-6 h-px bg-accent" />
-              <span className="text-xs font-mono uppercase tracking-widest text-accent">
-                CLI Tool
-              </span>
-            </motion.div>
+              MAXSIM
+            </h1>
+            <p className="text-xl sm:text-2xl md:text-3xl font-semibold text-muted leading-tight mt-2">
+              AI-Powered Context{" "}
+              <WordFlipper />
+            </p>
+          </motion.div>
 
-            <motion.div
-              className="flex flex-col gap-2"
-              initial={{ opacity: 0, y: 24 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.2 }}
-            >
-              <h1 className="text-5xl sm:text-6xl md:text-7xl font-extrabold tracking-tight text-foreground leading-none">
-                MAXSIM
-              </h1>
-              <p className="text-xl sm:text-2xl md:text-3xl font-semibold text-muted leading-tight mt-2">
-                AI-Powered Context{" "}
-                <WordFlipper />
-              </p>
-            </motion.div>
+          {/* Description */}
+          <motion.p
+            className="max-w-2xl text-base md:text-lg text-muted leading-relaxed"
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.45 }}
+          >
+            A meta-prompting, context engineering, and spec-driven development
+            system for Claude Code, OpenCode, Gemini CLI, and Codex &mdash;
+            solving context rot with fresh-context subagents.
+          </motion.p>
 
-            <motion.p
-              className="max-w-lg text-base md:text-lg text-muted leading-relaxed"
-              initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.45 }}
+          {/* CTAs */}
+          <motion.div
+            className="flex flex-wrap items-center justify-center gap-4"
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.6 }}
+          >
+            <a
+              href="#docs"
+              className="inline-flex items-center justify-center px-8 py-3.5 rounded-md bg-accent text-white font-semibold text-sm tracking-wide hover:bg-accent-light transition-colors duration-200 shadow-[0_0_20px_rgba(59,130,246,0.3)]"
             >
-              A meta-prompting, context engineering, and spec-driven development
-              system for Claude Code, OpenCode, Gemini CLI, and Codex &mdash;
-              solving context rot with fresh-context subagents.
-            </motion.p>
-
-            <motion.div
-              className="flex flex-wrap items-center gap-4"
-              initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.6 }}
+              Get Started
+            </a>
+            <a
+              href="https://github.com/maystudios/maxsimcli"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-8 py-3.5 rounded-md border border-border text-foreground font-semibold text-sm tracking-wide hover:border-accent/60 hover:text-accent transition-colors duration-200"
             >
-              <a
-                href="#docs"
-                className="inline-flex items-center justify-center px-6 py-3 rounded-md bg-accent text-white font-semibold text-sm tracking-wide hover:bg-accent-light transition-colors duration-200"
+              GitHub
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 14 14"
+                fill="none"
+                aria-hidden="true"
+                className="translate-y-px"
               >
-                Get Started
-              </a>
-              <a
-                href="https://github.com/maystudios/maxsimcli"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-6 py-3 rounded-md border border-border text-foreground font-semibold text-sm tracking-wide hover:border-accent/60 hover:text-accent transition-colors duration-200"
-              >
-                GitHub
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 14 14"
-                  fill="none"
-                  aria-hidden="true"
-                  className="translate-y-px"
-                >
-                  <path
-                    d="M2 7h10M7 2l5 5-5 5"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </a>
-            </motion.div>
-
-            <TerminalBlock />
-          </div>
-
-          <div className="hidden lg:flex lg:col-span-5 items-center justify-center">
-            <motion.div
-              className="relative w-72 h-72"
-              initial={{ opacity: 0, scale: 0.9 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ duration: 0.8, delay: 0.4 }}
-            >
-              <motion.div
-                className="absolute inset-0 border border-border/60 rounded-sm"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ duration: 0.6, delay: 0.6 }}
-              />
-              <motion.div
-                className="absolute inset-8 border border-accent/30 rounded-sm"
-                initial={{ rotate: 0, opacity: 0 }}
-                animate={{ rotate: 45, opacity: 1 }}
-                transition={{ duration: 1, delay: 0.8, ease: "easeOut" }}
-              />
-              <motion.div
-                className="absolute inset-0 flex items-center justify-center"
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
-                transition={{ duration: 0.5, delay: 1.1, type: "spring", stiffness: 200 }}
-              >
-                <div className="w-4 h-4 rounded-full bg-accent shadow-[0_0_24px_4px_rgba(59,130,246,0.4)]" />
-              </motion.div>
-              {[
-                "top-0 left-0",
-                "top-0 right-0",
-                "bottom-0 left-0",
-                "bottom-0 right-0",
-              ].map((pos, i) => (
-                <motion.div
-                  key={pos}
-                  className={cn("absolute w-2.5 h-2.5 border-accent/80", pos, {
-                    "border-t border-l": i === 0,
-                    "border-t border-r": i === 1,
-                    "border-b border-l": i === 2,
-                    "border-b border-r": i === 3,
-                  })}
-                  initial={{ opacity: 0, scale: 0 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.3, delay: 1.0 + i * 0.08 }}
+                <path
+                  d="M2 7h10M7 2l5 5-5 5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
                 />
-              ))}
-              <motion.span
-                className="absolute -bottom-8 left-0 right-0 text-center text-xs font-mono text-muted tracking-widest uppercase"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ duration: 0.5, delay: 1.4 }}
-              >
-                v{__MAXSIM_VERSION__}
-              </motion.span>
-            </motion.div>
-          </div>
+              </svg>
+            </a>
+          </motion.div>
 
+          {/* Install command */}
+          <InstallBlock />
+
+          {/* Terminal mockup */}
+          <TerminalMockup />
+
+          {/* Version tag */}
+          <motion.span
+            className="text-xs font-mono text-muted tracking-widest uppercase"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5, delay: 1.4 }}
+          >
+            v{__MAXSIM_VERSION__}
+          </motion.span>
         </div>
       </div>
+
+      {/* Scroll indicator */}
+      <ScrollIndicator />
 
       <motion.div
         className="absolute bottom-0 left-0 right-0 h-px bg-border/50"

--- a/packages/website/src/components/sections/Navbar.tsx
+++ b/packages/website/src/components/sections/Navbar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { Menu, X } from "lucide-react";
+import { Menu, X, Github } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 const navLinks = [
   { label: "Home", href: "#home", section: "home" },
@@ -59,6 +60,18 @@ export default function Navbar() {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
+  // Lock body scroll when mobile menu is open
+  useEffect(() => {
+    if (mobileOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [mobileOpen]);
+
   useEffect(() => {
     const sectionIds = navLinks.map((l) => l.section);
     const sections = sectionIds
@@ -103,19 +116,39 @@ export default function Navbar() {
       initial={{ y: -100 }}
       animate={{ y: 0 }}
       transition={{ duration: 0.5, ease: "easeOut" }}
-      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 border-b ${
+      className={cn(
+        "fixed top-0 left-0 right-0 z-50 transition-all duration-300",
         scrolled
-          ? "bg-background/80 backdrop-blur-lg border-border"
-          : "bg-transparent border-transparent"
-      }`}
+          ? "bg-background/80 backdrop-blur-lg"
+          : "bg-transparent"
+      )}
     >
-      <nav className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
+      {/* Gradient bottom border */}
+      <div
+        className={cn(
+          "absolute bottom-0 left-0 right-0 h-px transition-opacity duration-300",
+          scrolled ? "opacity-100" : "opacity-0"
+        )}
+        style={{
+          background:
+            "linear-gradient(to right, transparent, rgba(59,130,246,0.4), transparent)",
+        }}
+      />
+
+      <nav
+        className={cn(
+          "max-w-6xl mx-auto px-6 flex items-center justify-between transition-all duration-300",
+          scrolled ? "h-14" : "h-16"
+        )}
+      >
+        {/* Stylized logo with accent bracket prefix */}
         <a
           href="#home"
           onClick={(e) => handleNavClick(e, "home")}
-          className="text-lg font-bold tracking-tight text-foreground"
+          className="text-lg font-bold tracking-tight text-foreground flex items-center"
         >
-          MAXSIM
+          <span className="text-accent font-mono">/</span>
+          <span>MAXSIM</span>
         </a>
 
         {/* Desktop Nav */}
@@ -127,15 +160,16 @@ export default function Navbar() {
                 key={link.href}
                 href={link.href}
                 onClick={(e) => handleNavClick(e, link.section)}
-                className={`relative text-sm pb-1 transition-colors duration-200 cursor-pointer ${
+                className={cn(
+                  "relative text-sm py-1 transition-colors duration-200 cursor-pointer",
                   active ? "text-foreground" : "text-muted hover:text-foreground"
-                }`}
+                )}
               >
                 {link.label}
                 {active && (
                   <motion.span
-                    layoutId="nav-active-dot"
-                    className="absolute -bottom-0.5 left-1/2 -translate-x-1/2 block w-1 h-1 rounded-full bg-accent"
+                    layoutId="nav-active-pill"
+                    className="absolute -bottom-1 left-0 right-0 block h-0.5 rounded-full bg-accent"
                     transition={{ type: "spring", stiffness: 380, damping: 30 }}
                   />
                 )}
@@ -145,34 +179,38 @@ export default function Navbar() {
           <a
             href="/docs"
             onClick={navigateToDocsPage}
-            className={`relative text-sm pb-1 transition-colors duration-200 cursor-pointer ${
+            className={cn(
+              "relative text-sm py-1 transition-colors duration-200 cursor-pointer",
               window.location.pathname.startsWith("/docs")
                 ? "text-foreground"
                 : "text-muted hover:text-foreground"
-            }`}
+            )}
           >
             Full Docs
             {window.location.pathname.startsWith("/docs") && (
               <motion.span
-                layoutId="nav-active-dot"
-                className="absolute -bottom-0.5 left-1/2 -translate-x-1/2 block w-1 h-1 rounded-full bg-accent"
+                layoutId="nav-active-pill"
+                className="absolute -bottom-1 left-0 right-0 block h-0.5 rounded-full bg-accent"
                 transition={{ type: "spring", stiffness: 380, damping: 30 }}
               />
             )}
           </a>
+
+          {/* GitHub icon button */}
           <a
             href="https://github.com/maystudios/maxsimcli"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-sm px-4 py-2 rounded-md border border-border text-foreground hover:bg-surface transition-colors"
+            className="flex items-center justify-center w-9 h-9 rounded-md border border-border text-muted hover:text-foreground hover:border-accent/50 transition-colors duration-200"
+            aria-label="GitHub repository"
           >
-            GitHub
+            <Github size={16} />
           </a>
         </div>
 
         {/* Mobile Toggle */}
         <button
-          className="md:hidden text-foreground"
+          className="md:hidden text-foreground relative z-50"
           onClick={() => setMobileOpen(!mobileOpen)}
           aria-label="Toggle menu"
         >
@@ -180,45 +218,63 @@ export default function Navbar() {
         </button>
       </nav>
 
-      {/* Mobile Menu */}
+      {/* Full-screen Mobile Overlay Menu */}
       <AnimatePresence>
         {mobileOpen && (
           <motion.div
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: "auto" }}
-            exit={{ opacity: 0, height: 0 }}
-            className="md:hidden bg-background/95 backdrop-blur-lg border-b border-border"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.25 }}
+            className="fixed inset-0 z-40 md:hidden bg-background/98 backdrop-blur-xl flex flex-col items-center justify-center"
           >
-            <div className="px-6 py-4 flex flex-col gap-4">
-              {navLinks.map((link) => (
-                <a
+            <div className="flex flex-col items-center gap-8">
+              {navLinks.map((link, i) => (
+                <motion.a
                   key={link.href}
                   href={link.href}
                   onClick={(e) => handleNavClick(e, link.section, true)}
-                  className={`text-sm transition-colors cursor-pointer ${
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: 10 }}
+                  transition={{ duration: 0.3, delay: i * 0.06 }}
+                  className={cn(
+                    "text-2xl font-semibold transition-colors cursor-pointer",
                     activeSection === link.section
-                      ? "text-foreground"
+                      ? "text-accent"
                       : "text-muted hover:text-foreground"
-                  }`}
+                  )}
                 >
                   {link.label}
-                </a>
+                </motion.a>
               ))}
-              <a
+              <motion.a
                 href="/docs"
-                onClick={(e) => { navigateToDocsPage(e); setMobileOpen(false); }}
-                className="text-sm text-muted hover:text-foreground transition-colors cursor-pointer"
+                onClick={(e) => {
+                  navigateToDocsPage(e);
+                  setMobileOpen(false);
+                }}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 10 }}
+                transition={{ duration: 0.3, delay: navLinks.length * 0.06 }}
+                className="text-2xl font-semibold text-muted hover:text-foreground transition-colors cursor-pointer"
               >
                 Full Docs
-              </a>
-              <a
+              </motion.a>
+              <motion.a
                 href="https://github.com/maystudios/maxsimcli"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-sm text-muted hover:text-foreground transition-colors"
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 10 }}
+                transition={{ duration: 0.3, delay: (navLinks.length + 1) * 0.06 }}
+                className="flex items-center gap-3 text-xl font-semibold text-muted hover:text-foreground transition-colors"
               >
+                <Github size={20} />
                 GitHub
-              </a>
+              </motion.a>
             </div>
           </motion.div>
         )}


### PR DESCRIPTION
## Summary

- **Hero**: Replace abstract geometric art with an animated terminal mockup showing a real MAXSIM workflow (`/maxsim:plan-phase`), gradient text effect on headline (white → blue-400), larger primary CTA with blue glow effect, colored terminal dots (red/yellow/green) with blinking cursor, aurora-style gradient mesh background (~5% opacity), and scroll indicator chevron at bottom
- **Navbar**: Stylized logo with accent `/` prefix (`/MAXSIM`), pill-style active nav indicator replacing the dot, GitHub icon button using existing `lucide-react` Github component, full-screen mobile overlay menu with staggered animations, shrinking height on scroll (h-16 → h-14), and gradient bottom border

## Test plan

- [ ] Verify Hero terminal mockup animates lines sequentially with blinking cursor
- [ ] Verify gradient text on "MAXSIM" heading renders white → blue
- [ ] Verify Get Started CTA has blue glow shadow
- [ ] Verify scroll indicator chevron bounces at bottom of hero
- [ ] Verify Navbar logo shows `/MAXSIM` with blue `/`
- [ ] Verify active nav pill indicator slides between sections on scroll
- [ ] Verify Navbar shrinks from h-16 to h-14 on scroll with gradient bottom border
- [ ] Verify GitHub icon button in desktop nav
- [ ] Verify mobile menu opens as full-screen overlay with staggered link animations
- [ ] Verify `npx tsc --noEmit` and `npx vite build` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)