### PR TITLE
docs(website): enrich TechStack + Docs sections with icons, pill tabs, syntax highlighting

### DIFF
--- a/packages/website/src/components/sections/Docs.tsx
+++ b/packages/website/src/components/sections/Docs.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef } from "react";
+import { useState, useRef, type ReactNode } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { Copy, Check, Terminal, Layers, Settings, Users, FolderTree, LayoutDashboard } from "lucide-react";
+import { Copy, Check, Terminal, Settings, Users, FolderTree, LayoutDashboard, ArrowRight } from "lucide-react";
 
 type TabId = "getting-started" | "commands" | "architecture" | "configuration" | "agents" | "dashboard";
 
@@ -47,6 +47,98 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
+/** Minimal syntax highlighter for code blocks */
+function highlightCode(code: string, language: string): ReactNode[] {
+  if (language === "text") {
+    return [code];
+  }
+
+  const lines = code.split("\n");
+  const result: ReactNode[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    if (i > 0) result.push("\n");
+    const line = lines[i];
+
+    // Full-line comment
+    if (/^\s*#/.test(line) || /^\s*\/\//.test(line)) {
+      result.push(<span key={`comment-${i}`} className="syntax-comment">{line}</span>);
+      continue;
+    }
+
+    // Tokenize the line
+    const tokens = tokenizeLine(line, language);
+    tokens.forEach((tok, j) => {
+      const key = `${i}-${j}`;
+      if (tok.type === "comment") {
+        result.push(<span key={key} className="syntax-comment">{tok.text}</span>);
+      } else if (tok.type === "string") {
+        result.push(<span key={key} className="syntax-string">{tok.text}</span>);
+      } else if (tok.type === "keyword") {
+        result.push(<span key={key} className="syntax-keyword">{tok.text}</span>);
+      } else {
+        result.push(tok.text);
+      }
+    });
+  }
+  return result;
+}
+
+type Token = { type: "plain" | "comment" | "string" | "keyword"; text: string };
+
+const JSON_KEYWORDS = /^(true|false|null)$/;
+const BASH_KEYWORDS = /^(npx|npm|cd|node|git)$/;
+
+function tokenizeLine(line: string, language: string): Token[] {
+  const tokens: Token[] = [];
+  let remaining = line;
+
+  while (remaining.length > 0) {
+    // Inline comment (# ...)
+    const commentMatch = remaining.match(/^(#.*)$/);
+    if (commentMatch) {
+      tokens.push({ type: "comment", text: commentMatch[1] });
+      remaining = "";
+      continue;
+    }
+
+    // Double-quoted string
+    const dqMatch = remaining.match(/^"([^"\\]|\\.)*"/);
+    if (dqMatch) {
+      tokens.push({ type: "string", text: dqMatch[0] });
+      remaining = remaining.slice(dqMatch[0].length);
+      continue;
+    }
+
+    // Single-quoted string
+    const sqMatch = remaining.match(/^'([^'\\]|\\.)*'/);
+    if (sqMatch) {
+      tokens.push({ type: "string", text: sqMatch[0] });
+      remaining = remaining.slice(sqMatch[0].length);
+      continue;
+    }
+
+    // Word boundary — check for keywords
+    const wordMatch = remaining.match(/^[a-zA-Z_]\w*/);
+    if (wordMatch) {
+      const word = wordMatch[0];
+      const isKeyword =
+        (language === "json" && JSON_KEYWORDS.test(word)) ||
+        (language === "bash" && BASH_KEYWORDS.test(word));
+      tokens.push({ type: isKeyword ? "keyword" : "plain", text: word });
+      remaining = remaining.slice(word.length);
+      continue;
+    }
+
+    // Default: consume run of non-special characters
+    const plainMatch = remaining.match(/^[^#"'a-zA-Z_]+/);
+    const len = plainMatch ? plainMatch[0].length : 1;
+    tokens.push({ type: "plain", text: remaining.slice(0, len) });
+    remaining = remaining.slice(len);
+  }
+  return tokens;
+}
+
 function CodeBlock({ code, language = "bash" }: { code: string; language?: string }) {
   return (
     <div className="relative group">
@@ -55,25 +147,25 @@ function CodeBlock({ code, language = "bash" }: { code: string; language?: strin
         <CopyButton text={code.trim()} />
       </div>
       <pre className="bg-surface rounded-b border border-border overflow-x-auto p-4 text-sm font-mono leading-relaxed">
-        <code className="text-zinc-300 whitespace-pre">{code.trim()}</code>
+        <code className="text-zinc-300 whitespace-pre">{highlightCode(code.trim(), language)}</code>
       </pre>
     </div>
   );
 }
 
-function DocHeading({ children }: { children: React.ReactNode }) {
+function DocHeading({ children }: { children: ReactNode }) {
   return (
     <h3 className="text-foreground font-bold text-xl tracking-tight mb-4">{children}</h3>
   );
 }
 
-function DocSubheading({ children }: { children: React.ReactNode }) {
+function DocSubheading({ children }: { children: ReactNode }) {
   return (
     <h4 className="text-foreground font-semibold text-base tracking-tight mb-3 mt-6">{children}</h4>
   );
 }
 
-function DocText({ children }: { children: React.ReactNode }) {
+function DocText({ children }: { children: ReactNode }) {
   return <p className="text-muted text-sm leading-relaxed mb-4">{children}</p>;
 }
 
@@ -617,30 +709,27 @@ export function Docs() {
           </p>
         </motion.div>
 
-        <div className="relative mb-0 overflow-x-auto">
-          <div className="flex min-w-max border-b border-border">
+        {/* Pill-style tab bar: vertical on mobile, horizontal on md+ */}
+        <div className="relative mb-0">
+          <div className="flex flex-col md:flex-row md:flex-wrap gap-2 p-1.5 bg-surface rounded-t border border-border border-b-0">
             {tabs.map((tab) => {
               const isActive = activeTab === tab.id;
+              const Icon = tab.Icon;
               return (
                 <button
                   key={tab.id}
                   ref={(el) => { if (el) tabRefs.current.set(tab.id, el); }}
                   onClick={() => setActiveTab(tab.id)}
                   className={[
-                    "relative px-5 py-3 text-sm font-medium transition-colors whitespace-nowrap",
-                    isActive ? "text-foreground" : "text-muted hover:text-foreground",
+                    "relative px-4 py-2 text-sm font-medium transition-all duration-200 whitespace-nowrap rounded-sm",
+                    "flex items-center gap-2",
+                    isActive
+                      ? "bg-accent/15 text-accent border border-accent/30"
+                      : "text-muted hover:text-foreground hover:bg-surface-light border border-transparent",
                   ].join(" ")}
                 >
-                  <span className="flex items-center gap-2">
-                    {tab.label}
-                  </span>
-                  {isActive && (
-                    <motion.div
-                      layoutId="tab-indicator"
-                      className="absolute bottom-0 left-0 right-0 h-px bg-accent"
-                      transition={{ type: "spring", stiffness: 500, damping: 40 }}
-                    />
-                  )}
+                  <Icon size={14} className={isActive ? "text-accent" : "text-muted"} />
+                  {tab.label}
                 </button>
               );
             })}
@@ -684,10 +773,10 @@ export function Docs() {
               window.history.pushState({}, "", "/docs");
               window.dispatchEvent(new PopStateEvent("popstate"));
             }}
-            className="flex-shrink-0 inline-flex items-center gap-2 text-sm font-medium text-accent hover:text-accent-light border border-accent/30 hover:border-accent/60 px-4 py-2 rounded transition-colors duration-200 cursor-pointer"
+            className="docs-cta-link group flex-shrink-0 inline-flex items-center gap-2.5 text-sm font-semibold bg-accent text-white hover:bg-accent-light px-5 py-2.5 rounded transition-colors duration-200 cursor-pointer"
           >
             Full Documentation
-            <span className="text-xs">→</span>
+            <ArrowRight size={16} className="docs-cta-arrow transition-transform duration-200 group-hover:translate-x-1" />
           </a>
         </motion.div>
 

--- a/packages/website/src/components/sections/TechStack.tsx
+++ b/packages/website/src/components/sections/TechStack.tsx
@@ -1,35 +1,71 @@
+import {
+  FileText,
+  Hash,
+  Terminal,
+  Workflow,
+  Bot,
+  Hexagon,
+  Code,
+  Hammer,
+  Box,
+  FolderGit2,
+  Wrench,
+} from "lucide-react";
+import type { ElementType, ReactNode } from "react";
+
 const commandLayer = [
-  { name: "Markdown Prompts" },
-  { name: "YAML Frontmatter" },
-  { name: "Slash Commands" },
-  { name: "Workflow Specs" },
-  { name: "Agent Definitions" },
+  { name: "Markdown Prompts", Icon: FileText },
+  { name: "YAML Frontmatter", Icon: Hash },
+  { name: "Slash Commands", Icon: Terminal },
+  { name: "Workflow Specs", Icon: Workflow },
+  { name: "Agent Definitions", Icon: Bot },
 ];
 
 const toolchainStack = [
-  { name: "Node.js" },
-  { name: "TypeScript" },
-  { name: "esbuild" },
-  { name: "CJS Modules" },
-  { name: "npm workspaces" },
-  { name: "tsdown" },
+  { name: "Node.js", Icon: Hexagon },
+  { name: "TypeScript", Icon: Code },
+  { name: "esbuild", Icon: Hammer },
+  { name: "CJS Modules", Icon: Box },
+  { name: "npm workspaces", Icon: FolderGit2 },
+  { name: "tsdown", Icon: Wrench },
 ];
 
-const allItems = [...commandLayer, ...toolchainStack];
-const marqueeItems = [...allItems, ...allItems];
+const commandMarquee = [...commandLayer, ...commandLayer, ...commandLayer];
+const toolchainMarquee = [...toolchainStack, ...toolchainStack, ...toolchainStack];
 
-function Badge({ name }: { name: string }) {
+function Badge({ name, Icon }: { name: string; Icon: ElementType }) {
   return (
     <div className="shrink-0 inline-flex items-center gap-2 px-4 py-2 border border-border bg-surface rounded-sm mx-3">
-      <span className="w-1.5 h-1.5 rounded-full bg-accent shrink-0" />
+      <Icon size={14} className="text-accent shrink-0" />
       <span className="font-mono text-sm text-foreground/80 whitespace-nowrap">{name}</span>
+    </div>
+  );
+}
+
+function CategoryLabel({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-3 mb-3">
+      <span className="text-xs font-mono uppercase tracking-widest text-muted">
+        {label}
+      </span>
+      <span className="h-px flex-1 max-w-16 bg-border" />
+    </div>
+  );
+}
+
+function MarqueeRow({ children }: { children: ReactNode }) {
+  return (
+    <div className="marquee-wrapper relative">
+      <div className="absolute left-0 top-0 bottom-0 w-24 z-10 bg-gradient-to-r from-background to-transparent pointer-events-none" />
+      <div className="absolute right-0 top-0 bottom-0 w-24 z-10 bg-gradient-to-l from-background to-transparent pointer-events-none" />
+      {children}
     </div>
   );
 }
 
 export function TechStack() {
   return (
-    <section className="bg-background py-24 border-t border-border overflow-hidden">
+    <section className="techstack-stripes bg-background py-24 border-t border-border overflow-hidden">
       <div className="max-w-6xl mx-auto px-6 mb-12">
         <p className="text-xs uppercase tracking-widest text-muted font-medium mb-4">
           Technology
@@ -42,42 +78,29 @@ export function TechStack() {
         </p>
       </div>
 
-      <div className="max-w-6xl mx-auto px-6 mb-6 flex flex-wrap gap-6">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-mono uppercase tracking-widest text-muted">
-            Command Layer
-          </span>
-          <span className="h-px w-8 bg-border" />
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-mono uppercase tracking-widest text-muted">
-            Toolchain
-          </span>
-          <span className="h-px w-8 bg-border" />
-        </div>
+      {/* Row 1 — Command Layer */}
+      <div className="max-w-6xl mx-auto px-6">
+        <CategoryLabel label="Command Layer" />
       </div>
-
-      {/* Row 1 */}
-      <div className="relative">
-        <div className="absolute left-0 top-0 bottom-0 w-24 z-10 bg-gradient-to-r from-background to-transparent pointer-events-none" />
-        <div className="absolute right-0 top-0 bottom-0 w-24 z-10 bg-gradient-to-l from-background to-transparent pointer-events-none" />
+      <MarqueeRow>
         <div className="marquee flex will-change-transform">
-          {marqueeItems.map((item, i) => (
-            <Badge key={`${item.name}-${i}`} name={item.name} />
+          {commandMarquee.map((item, i) => (
+            <Badge key={`cmd-${item.name}-${i}`} name={item.name} Icon={item.Icon} />
           ))}
         </div>
-      </div>
+      </MarqueeRow>
 
-      {/* Row 2 */}
-      <div className="relative mt-4">
-        <div className="absolute left-0 top-0 bottom-0 w-24 z-10 bg-gradient-to-r from-background to-transparent pointer-events-none" />
-        <div className="absolute right-0 top-0 bottom-0 w-24 z-10 bg-gradient-to-l from-background to-transparent pointer-events-none" />
+      {/* Row 2 — Toolchain */}
+      <div className="max-w-6xl mx-auto px-6 mt-6">
+        <CategoryLabel label="Toolchain" />
+      </div>
+      <MarqueeRow>
         <div className="marquee-reverse flex will-change-transform">
-          {[...marqueeItems].reverse().map((item, i) => (
-            <Badge key={`rev-${item.name}-${i}`} name={item.name} />
+          {toolchainMarquee.map((item, i) => (
+            <Badge key={`tc-${item.name}-${i}`} name={item.name} Icon={item.Icon} />
           ))}
         </div>
-      </div>
+      </MarqueeRow>
     </section>
   );
 }

--- a/packages/website/src/index.css
+++ b/packages/website/src/index.css
@@ -49,19 +49,64 @@ body {
   border-radius: 3px;
 }
 
+/* ─── Marquee animations ──────────────────────────────────────────────────── */
+
 @keyframes marquee {
   from { transform: translateX(0); }
-  to   { transform: translateX(-50%); }
+  to   { transform: translateX(-33.333%); }
 }
 @keyframes marquee-reverse {
-  from { transform: translateX(-50%); }
+  from { transform: translateX(-33.333%); }
   to   { transform: translateX(0); }
 }
 
-.marquee        { animation: marquee         20s linear infinite; }
-.marquee-reverse { animation: marquee-reverse 25s linear infinite; }
+.marquee         { animation: marquee         30s linear infinite; }
+.marquee-reverse { animation: marquee-reverse 35s linear infinite; }
 
 @media (max-width: 640px) {
-  .marquee         { animation-duration: 12s; }
-  .marquee-reverse { animation-duration: 15s; }
+  .marquee         { animation-duration: 18s; }
+  .marquee-reverse { animation-duration: 22s; }
+}
+
+/* Pause marquee on hover */
+.marquee-wrapper:hover .marquee,
+.marquee-wrapper:hover .marquee-reverse {
+  animation-play-state: paused;
+}
+
+/* ─── TechStack diagonal stripes ──────────────────────────────────────────── */
+
+.techstack-stripes {
+  position: relative;
+}
+
+.techstack-stripes::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 40px,
+    rgba(255, 255, 255, 0.015) 40px,
+    rgba(255, 255, 255, 0.015) 41px
+  );
+  pointer-events: none;
+}
+
+/* ─── Syntax highlighting (minimal) ──────────────────────────────────────── */
+
+.syntax-comment { color: #4ade80; } /* green-400 */
+.syntax-string  { color: #fbbf24; } /* amber-400 */
+.syntax-keyword { color: #60a5fa; } /* blue-400 */
+
+/* ─── Docs CTA arrow bounce ──────────────────────────────────────────────── */
+
+@keyframes arrow-nudge {
+  0%, 100% { transform: translateX(0); }
+  50%      { transform: translateX(4px); }
+}
+
+.docs-cta-link:hover .docs-cta-arrow {
+  animation: arrow-nudge 0.8s ease-in-out infinite;
 }


### PR DESCRIPTION
## Summary
- **TechStack**: Added lucide icon prefixes on badge chips, per-row category labels (Command Layer / Toolchain), pause-on-hover marquee, subtle diagonal stripe background, extracted `MarqueeRow` wrapper to DRY gradient overlays, refined marquee animation speeds
- **Docs**: Replaced underline tabs with pill-style segment control tabs showing lucide icons, vertical layout on mobile; added minimal syntax highlighting (comments green, strings amber, keywords blue); upgraded CTA button to prominent filled style with animated arrow icon
- **CSS**: Added marquee pause-on-hover, diagonal stripe pattern, syntax color classes, arrow-nudge keyframe, refined marquee speeds (30s/35s desktop, 18s/22s mobile) with -33.333% offset for tripled item arrays

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vite build` passes
- [x] Full monorepo `npm run build` passes (build + lint + 212 tests)
- [ ] Visual check: TechStack badges show lucide icons and marquee pauses on hover
- [ ] Visual check: Docs tabs render as pills with icons, vertical on mobile
- [ ] Visual check: code blocks show colored comments/strings/keywords
- [ ] Visual check: "Full Documentation" CTA has arrow animation on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)