### PR TITLE
fix(agents): correct skill path prefix in available_skills frontmatter

### DIFF
--- a/templates/agents/executor.md
+++ b/templates/agents/executor.md
@@ -11,7 +11,7 @@ skills:
   - evidence-collection
   - commit-conventions
 available_skills:
-  | github-artifact-protocol | .skills/github-artifact-protocol/SKILL.md | When reading from or writing to GitHub Issues |
+  | github-artifact-protocol | ~/.claude/skills/github-artifact-protocol/SKILL.md | When reading from or writing to GitHub Issues |
 ---
 
 You are a plan executor. You implement plans atomically -- one commit per task, deviations handled inline, every completion claim backed by tool output.

--- a/templates/agents/planner.md
+++ b/templates/agents/planner.md
@@ -10,7 +10,7 @@ skills:
   - handoff-contract
   - input-validation
 available_skills:
-  | github-artifact-protocol | .skills/github-artifact-protocol/SKILL.md | When reading from or writing to GitHub Issues |
+  | github-artifact-protocol | ~/.claude/skills/github-artifact-protocol/SKILL.md | When reading from or writing to GitHub Issues |
 ---
 
 You are a plan creator. You produce phase plans with frontmatter, task breakdown, dependency graphs, wave ordering, and must_haves verification criteria.

--- a/templates/agents/verifier.md
+++ b/templates/agents/verifier.md
@@ -12,7 +12,7 @@ skills:
   - evidence-collection
   - handoff-contract
 available_skills:
-  | github-artifact-protocol | .skills/github-artifact-protocol/SKILL.md | When reading from or writing to GitHub Issues |
+  | github-artifact-protocol | ~/.claude/skills/github-artifact-protocol/SKILL.md | When reading from or writing to GitHub Issues |
 ---
 
 You are a verifier. You check work against specifications using fresh tool output as evidence. You NEVER trust prior claims -- you gather your own evidence for every criterion.


### PR DESCRIPTION
## Summary

- Replace `.skills/github-artifact-protocol/SKILL.md` with `~/.claude/skills/github-artifact-protocol/SKILL.md` in the `available_skills` frontmatter table of three agent files: `executor.md`, `planner.md`, and `verifier.md`
- The installer rewrites `~/.claude/` → `./.claude/` at install time, so this is the correct canonical form; the old `.skills/` prefix was never rewritten and produced a broken path

## Test plan

- [x] `grep -rn "\.skills/" templates/agents/` returns zero results
- [x] `grep -rn "~/.claude/skills/" templates/agents/` shows exactly 3 results (one per agent file)
- [x] All 210 unit tests pass (pre-push hook confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)