### PR TITLE
fix(commands): use absolute @path refs so commands resolve after install

### DIFF
--- a/templates/commands/maxsim/execute.md
+++ b/templates/commands/maxsim/execute.md
@@ -29,8 +29,8 @@ Execute the phase state machine: Execute all plans in wave order, auto-verify, r
 </objective>
 
 <execution_context>
-@./workflows/execute.md
-@./references/ui-brand.md
+@~/.claude/maxsim/workflows/execute.md
+@~/.claude/maxsim/references/ui-brand.md
 </execution_context>
 
 <context>
@@ -40,6 +40,6 @@ Context files are resolved inside the workflow via `maxsim-tools init execute-ph
 </context>
 
 <process>
-Execute the execute workflow from @./workflows/execute.md end-to-end.
+Execute the execute workflow from @~/.claude/maxsim/workflows/execute.md end-to-end.
 Preserve all workflow gates (state detection, wave execution, verification, retry loop, re-entry flow).
 </process>

--- a/templates/commands/maxsim/go.md
+++ b/templates/commands/maxsim/go.md
@@ -21,9 +21,9 @@ Show + Act pattern: display detection reasoning, then act. No arguments -- pure 
 </objective>
 
 <execution_context>
-@./workflows/go.md
+@~/.claude/maxsim/workflows/go.md
 </execution_context>
 
 <process>
-Execute the go workflow from @./workflows/go.md end-to-end.
+Execute the go workflow from @~/.claude/maxsim/workflows/go.md end-to-end.
 </process>

--- a/templates/commands/maxsim/help.md
+++ b/templates/commands/maxsim/help.md
@@ -13,10 +13,10 @@ Output ONLY the reference content below. Do NOT add:
 </objective>
 
 <execution_context>
-@./workflows/help.md
+@~/.claude/maxsim/workflows/help.md
 </execution_context>
 
 <process>
-Output the complete MAXSIM command reference from @./workflows/help.md.
+Output the complete MAXSIM command reference from @~/.claude/maxsim/workflows/help.md.
 Display directly -- no additions or modifications.
 </process>

--- a/templates/commands/maxsim/init.md
+++ b/templates/commands/maxsim/init.md
@@ -38,15 +38,15 @@ Unified project initialization. Detects whether this is a new project, existing 
 </objective>
 
 <execution_context>
-@./workflows/init.md
-@./references/questioning.md
-@./references/thinking-partner.md
-@./references/ui-brand.md
-@./templates/project.md
-@./templates/requirements.md
+@~/.claude/maxsim/workflows/init.md
+@~/.claude/maxsim/references/questioning.md
+@~/.claude/maxsim/references/thinking-partner.md
+@~/.claude/maxsim/references/ui-brand.md
+@~/.claude/maxsim/templates/project.md
+@~/.claude/maxsim/templates/requirements.md
 </execution_context>
 
 <process>
-Execute the init workflow from @./workflows/init.md end-to-end.
+Execute the init workflow from @~/.claude/maxsim/workflows/init.md end-to-end.
 Pass $ARGUMENTS through to the workflow for flag handling (--auto).
 </process>

--- a/templates/commands/maxsim/plan.md
+++ b/templates/commands/maxsim/plan.md
@@ -30,8 +30,8 @@ Execute the plan state machine: Discussion -> Research -> Planning. Each stage p
 </objective>
 
 <execution_context>
-@./workflows/plan.md
-@./references/ui-brand.md
+@~/.claude/maxsim/workflows/plan.md
+@~/.claude/maxsim/references/ui-brand.md
 </execution_context>
 
 <context>
@@ -45,6 +45,6 @@ Context files are resolved inside the workflow via `maxsim-tools init plan-phase
 </context>
 
 <process>
-Execute the plan workflow from @./workflows/plan.md end-to-end.
+Execute the plan workflow from @~/.claude/maxsim/workflows/plan.md end-to-end.
 Preserve all workflow gates (stage detection, discussion, research, planning, gate confirmations, re-entry flow).
 </process>

--- a/templates/commands/maxsim/progress.md
+++ b/templates/commands/maxsim/progress.md
@@ -16,10 +16,10 @@ Provides situational awareness before continuing work, detects phase gaps, and i
 </objective>
 
 <execution_context>
-@./workflows/progress.md
+@~/.claude/maxsim/workflows/progress.md
 </execution_context>
 
 <process>
-Execute the progress workflow from @./workflows/progress.md end-to-end.
+Execute the progress workflow from @~/.claude/maxsim/workflows/progress.md end-to-end.
 Preserve all routing logic (Routes A through F) and edge case handling.
 </process>

--- a/templates/commands/maxsim/quick.md
+++ b/templates/commands/maxsim/quick.md
@@ -28,7 +28,7 @@ Quick mode is the same system with a shorter path:
 </objective>
 
 <execution_context>
-@./workflows/quick.md
+@~/.claude/maxsim/workflows/quick.md
 </execution_context>
 
 <context>
@@ -38,6 +38,6 @@ Context files are resolved inside the workflow (`init quick`) and delegated via 
 </context>
 
 <process>
-Execute the quick workflow from @./workflows/quick.md end-to-end.
+Execute the quick workflow from @~/.claude/maxsim/workflows/quick.md end-to-end.
 Preserve all workflow gates (validation, task description, planning, execution, state updates, commits).
 </process>

--- a/templates/commands/maxsim/settings.md
+++ b/templates/commands/maxsim/settings.md
@@ -21,11 +21,11 @@ Routes to the settings workflow which handles:
 </objective>
 
 <execution_context>
-@./workflows/settings.md
+@~/.claude/maxsim/workflows/settings.md
 </execution_context>
 
 <process>
-**Follow the settings workflow** from `@./workflows/settings.md`.
+**Follow the settings workflow** from `@~/.claude/maxsim/workflows/settings.md`.
 
 The workflow handles all logic including:
 1. Config file creation with defaults if missing


### PR DESCRIPTION
## Summary

- All `@./workflows/`, `@./references/`, and `@./templates/` references in 8 command files under `templates/commands/maxsim/` were broken post-install because commands install to `.claude/commands/maxsim/` while workflows/references/templates install to `.claude/maxsim/`
- Changed all references to use `@~/.claude/maxsim/` prefix, which the installer's regex (`~/.claude/` → `./.claude/`) rewrites to the correct absolute-relative path
- Affects: `help.md`, `settings.md`, `plan.md`, `execute.md`, `go.md`, `quick.md`, `init.md`, `progress.md`

## Test plan

- [x] `grep -rn "@\./workflows/\|@\./references/\|@\./templates/" templates/commands/maxsim/` returns zero results
- [x] `grep -rn "@~/.claude/maxsim/" templates/commands/maxsim/` confirms all new paths present
- [x] All 210 unit tests pass (verified by pre-push hook)
- [x] Build succeeds (verified by pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)