### PR TITLE
fix(workflows): correct @path references to use ~/.claude/maxsim/ prefix

### DIFF
--- a/templates/workflows/discuss-phase.md
+++ b/templates/workflows/discuss-phase.md
@@ -11,7 +11,7 @@ You are a thinking partner, not an interviewer. The user is the visionary — yo
 </purpose>
 
 <required_reading>
-@./references/thinking-partner.md
+@~/.claude/maxsim/references/thinking-partner.md
 </required_reading>
 
 <tool_mandate>
@@ -612,9 +612,9 @@ Task(
     </objective>
 
     <execution_context>
-    @./workflows/plan.md
-    @./references/ui-brand.md
-    @./references/model-profile-resolution.md
+    @~/.claude/maxsim/workflows/plan.md
+    @~/.claude/maxsim/references/ui-brand.md
+    @~/.claude/maxsim/references/model-profile-resolution.md
     </execution_context>
 
     <arguments>

--- a/templates/workflows/execute-plan.md
+++ b/templates/workflows/execute-plan.md
@@ -6,7 +6,7 @@ Execute a phase plan (loaded from GitHub issue comment or local PLAN.md) and pos
 Read STATE.md before any operation to load project context.
 Read config.json for planning behavior settings.
 
-@./references/git-integration.md
+@~/.claude/maxsim/references/git-integration.md
 </required_reading>
 
 MAXSIM provides CLI commands (`github create-phase`, `github list-phases`, etc.) for structured operations.

--- a/templates/workflows/execute.md
+++ b/templates/workflows/execute.md
@@ -8,7 +8,7 @@ Before executing any step in this workflow, verify:
 Thin orchestrator for the /maxsim:execute state machine. Detects the current state of a phase (already done, needs verification, needs execution), delegates per-plan execution to execute-plan.md subagents, runs auto-verification, and handles retry with gap closure.
 
 This file is the ORCHESTRATOR ONLY. Per-plan execution logic lives in:
-- @./workflows/execute-plan.md (per-plan subagent execution)
+- @~/.claude/maxsim/workflows/execute-plan.md (per-plan subagent execution)
 
 Verification is handled inline (spawning verifier agent) since it is a stage of this workflow, not a separate command.
 </purpose>
@@ -213,10 +213,10 @@ Execute each wave in sequence. Within a wave: parallel if `parallelization` is t
        </objective>
 
        <execution_context>
-       @./workflows/execute-plan.md
-       @./templates/summary.md
-       @./references/checkpoints.md
-       @./references/tdd.md
+       @~/.claude/maxsim/workflows/execute-plan.md
+       @~/.claude/maxsim/templates/summary.md
+       @~/.claude/maxsim/references/checkpoints.md
+       @~/.claude/maxsim/references/tdd.md
        </execution_context>
 
        <github_context>

--- a/templates/workflows/init-existing.md
+++ b/templates/workflows/init-existing.md
@@ -6,8 +6,8 @@ Output: `.planning/` directory with config.json, PROJECT.md, REQUIREMENTS.md, RO
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.
-@./references/thinking-partner.md
-@./references/questioning.md
+@~/.claude/maxsim/references/thinking-partner.md
+@~/.claude/maxsim/references/questioning.md
 </required_reading>
 
 <auto_mode>

--- a/templates/workflows/init.md
+++ b/templates/workflows/init.md
@@ -1,10 +1,10 @@
 <purpose>
 
 Unified initialization router. Detects the current project state and delegates to the appropriate sub-workflow:
-- **New project** (no .planning/) -> delegates to @./workflows/new-project.md
-- **Existing project** (.planning/ exists, no ROADMAP.md) -> delegates to @./workflows/init-existing.md
+- **New project** (no .planning/) -> delegates to @~/.claude/maxsim/workflows/new-project.md
+- **Existing project** (.planning/ exists, no ROADMAP.md) -> delegates to @~/.claude/maxsim/workflows/init-existing.md
 - **Active milestone** (.planning/ + ROADMAP.md, phases in progress) -> shows status, offers options
-- **Milestone complete** (all phases done) -> offers completion or new milestone via @./workflows/new-milestone.md
+- **Milestone complete** (all phases done) -> offers completion or new milestone via @~/.claude/maxsim/workflows/new-milestone.md
 
 This file is a THIN ROUTER. All heavy logic lives in the sub-workflows.
 
@@ -81,7 +81,7 @@ echo "$INIT_CONTEXT"
 
 Save this JSON output — the sub-workflow will use it as `INIT_CONTEXT` and skip its own init call.
 
-Now delegate to @./workflows/new-project.md — execute the full new-project workflow end-to-end. The `INIT_CONTEXT` JSON is already loaded; the sub-workflow will detect this and skip Step 1's CLI call.
+Now delegate to @~/.claude/maxsim/workflows/new-project.md — execute the full new-project workflow end-to-end. The `INIT_CONTEXT` JSON is already loaded; the sub-workflow will detect this and skip Step 1's CLI call.
 
 Pass through:
 - `--auto` flag if set
@@ -114,7 +114,7 @@ echo "$INIT_CONTEXT"
 
 Save this JSON output — the sub-workflow will use it as `INIT_CONTEXT` and skip its own init call.
 
-Now delegate to @./workflows/init-existing.md — execute the full init-existing workflow end-to-end. The `INIT_CONTEXT` JSON is already loaded; the sub-workflow will detect this and skip Step 1's CLI call.
+Now delegate to @~/.claude/maxsim/workflows/init-existing.md — execute the full init-existing workflow end-to-end. The `INIT_CONTEXT` JSON is already loaded; the sub-workflow will detect this and skip Step 1's CLI call.
 
 Pass through:
 - `--auto` flag if set
@@ -159,7 +159,7 @@ Then present options conversationally (natural language, not AskUserQuestion):
    - If verification is pending: "Verify the current phase"
 
 2. **Start a new milestone** -- If the user wants to pivot or start fresh:
-   - Delegate to @./workflows/new-milestone.md for the milestone creation flow
+   - Delegate to @~/.claude/maxsim/workflows/new-milestone.md for the milestone creation flow
 
 3. **View detailed progress** -- Direct to `/maxsim:progress` for full status
 
@@ -189,12 +189,12 @@ Then present options conversationally:
 **Options:**
 
 1. **Complete and archive this milestone** -- Run the milestone completion flow:
-   - Delegate to @./workflows/new-milestone.md with completion mode
+   - Delegate to @~/.claude/maxsim/workflows/new-milestone.md with completion mode
    - Archives current milestone data
    - Updates MILESTONES.md with summary
 
 2. **Start a new milestone** -- Begin the next cycle:
-   - Delegate to @./workflows/new-milestone.md for creation flow
+   - Delegate to @~/.claude/maxsim/workflows/new-milestone.md for creation flow
    - Gathers new milestone goals
    - Creates fresh REQUIREMENTS.md and ROADMAP.md
 

--- a/templates/workflows/new-project.md
+++ b/templates/workflows/new-project.md
@@ -4,8 +4,8 @@ Initialize a new project through unified flow: questioning, research (optional),
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.
-@./references/thinking-partner.md
-@./references/questioning.md
+@~/.claude/maxsim/references/thinking-partner.md
+@~/.claude/maxsim/references/questioning.md
 </required_reading>
 
 <auto_mode>

--- a/templates/workflows/plan-discuss.md
+++ b/templates/workflows/plan-discuss.md
@@ -7,7 +7,7 @@ You are a thinking partner, not an interviewer. The user is the visionary -- you
 </purpose>
 
 <required_reading>
-@./references/thinking-partner.md
+@~/.claude/maxsim/references/thinking-partner.md
 </required_reading>
 
 <downstream_awareness>

--- a/templates/workflows/plan.md
+++ b/templates/workflows/plan.md
@@ -8,9 +8,9 @@ Before executing any step in this workflow, verify:
 Thin orchestrator for the /maxsim:plan state machine. Detects the current stage of a phase (Discussion, Research, Planning), delegates to stage sub-workflows, shows gate confirmations between stages, and handles re-entry on already-planned phases.
 
 This file is the ORCHESTRATOR ONLY. Stage-specific logic lives in:
-- @./workflows/plan-discuss.md (Discussion stage)
-- @./workflows/plan-research.md (Research stage)
-- @./workflows/plan-create.md (Planning stage)
+- @~/.claude/maxsim/workflows/plan-discuss.md (Discussion stage)
+- @~/.claude/maxsim/workflows/plan-research.md (Research stage)
+- @~/.claude/maxsim/workflows/plan-create.md (Planning stage)
 </purpose>
 
 <process>
@@ -97,7 +97,7 @@ Wait for user choice via natural conversation.
 
 Delegate to the discussion sub-workflow for full discussion logic:
 
-@./workflows/plan-discuss.md
+@~/.claude/maxsim/workflows/plan-discuss.md
 
 Pass context: `phase_number`, `phase_name`, `phase_dir`, `padded_phase`, `phase_slug`, `commit_docs`, `roadmap_path`, `state_path`, `phase_issue_number`.
 
@@ -132,7 +132,7 @@ Wait for user response via natural conversation (not AskUserQuestion).
 
 Delegate to the research sub-workflow:
 
-@./workflows/plan-research.md
+@~/.claude/maxsim/workflows/plan-research.md
 
 Pass context: `phase_number`, `phase_name`, `phase_dir`, `padded_phase`, `phase_slug`, `commit_docs`, `researcher_model`, `research_enabled`, `has_research`, `state_path`, `roadmap_path`, `requirements_path`, `context_path`, `phase_req_ids`, `phase_issue_number`. Also pass the `--force-research` flag if present in $ARGUMENTS.
 
@@ -164,7 +164,7 @@ Wait for user response via natural conversation.
 
 Delegate to the planning sub-workflow:
 
-@./workflows/plan-create.md
+@~/.claude/maxsim/workflows/plan-create.md
 
 Pass context: `phase_number`, `phase_name`, `phase_dir`, `padded_phase`, `phase_slug`, `commit_docs`, `planner_model`, `checker_model`, `plan_checker_enabled`, `state_path`, `roadmap_path`, `requirements_path`, `context_path`, `research_path`, `phase_req_ids`, `phase_issue_number`. Also pass the `--skip-verify` flag if present in $ARGUMENTS.
 

--- a/templates/workflows/research-phase.md
+++ b/templates/workflows/research-phase.md
@@ -8,14 +8,14 @@ Standalone research command. For most workflows, use `/maxsim:plan` which integr
 
 ## Step 0: Resolve Model Profile
 
-@./references/model-profile-resolution.md
+@~/.claude/maxsim/references/model-profile-resolution.md
 
 Resolve model for:
 - `researcher`
 
 ## Step 1: Normalize and Validate Phase
 
-@./references/phase-argument-parsing.md
+@~/.claude/maxsim/references/phase-argument-parsing.md
 
 ```bash
 PHASE_INFO=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs roadmap get-phase "${PHASE}")

--- a/templates/workflows/verify-phase.md
+++ b/templates/workflows/verify-phase.md
@@ -24,8 +24,8 @@ Then verify each level against the actual codebase.
 </core_principle>
 
 <required_reading>
-@./references/verification-patterns.md
-@./templates/verification-report.md
+@~/.claude/maxsim/references/verification-patterns.md
+@~/.claude/maxsim/templates/verification-report.md
 </required_reading>
 
 <process>

--- a/templates/workflows/verify-work.md
+++ b/templates/workflows/verify-work.md
@@ -18,7 +18,7 @@ No Pass/Fail buttons. No severity questions. Just: "Here's what should happen. D
 </required_reading>
 
 <template>
-@./templates/UAT.md
+@~/.claude/maxsim/templates/UAT.md
 </template>
 
 <process>
@@ -337,7 +337,7 @@ Spawning parallel debug agents to investigate each issue.
 ```
 
 - Load diagnose-issues workflow
-- Follow @./workflows/diagnose-issues.md
+- Follow @~/.claude/maxsim/workflows/diagnose-issues.md
 - Spawn parallel debug agents for each issue
 - Collect root causes
 - Update UAT.md with root causes


### PR DESCRIPTION
## Summary

- All `@./workflows/`, `@./references/`, and `@./templates/` references in workflow templates were broken after install because workflow files land in `.claude/maxsim/workflows/`, making relative paths resolve to a double-nested wrong location (e.g., `.claude/maxsim/workflows/workflows/foo.md`)
- Updated all 35 references across 11 files to use the `@~/.claude/maxsim/` prefix so the installer's path rewrite produces correct absolute paths from the project root

## Files changed

`discuss-phase.md`, `execute-plan.md`, `execute.md`, `init-existing.md`, `init.md`, `new-project.md`, `plan-discuss.md`, `plan.md`, `research-phase.md`, `verify-phase.md`, `verify-work.md`

## Test plan

- [x] `grep -rn "@\./workflows/\|@\./references/\|@\./templates/" templates/workflows/` returns zero results
- [x] `grep -rn "@~/.claude/maxsim/" templates/workflows/` shows all 35 updated references
- [x] All 210 unit tests pass (pre-push hook verified)
- [x] Build succeeds (`npm run build` runs as pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)