### PR TITLE
docs: replace stale add-todo/check-todos refs with quick --todo

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -197,8 +197,8 @@ rapid prototyping phases where test infrastructure isn't the focus.
 | `/maxsim:map-codebase` | Analyze existing codebase | Before `/maxsim:new-project` on existing code |
 | `/maxsim:quick` | Ad-hoc task with MAXSIM guarantees | Bug fixes, small features, config changes |
 | `/maxsim:debug [desc]` | Systematic debugging with persistent state | When something breaks |
-| `/maxsim:add-todo [desc]` | Capture an idea for later | Think of something during a session |
-| `/maxsim:check-todos` | List pending todos | Review captured ideas |
+| `/maxsim:quick --todo "desc"` | Capture an idea as a GitHub Issue | Think of something during a session |
+| `/maxsim:quick --todo list` | List pending todos from GitHub | Review captured ideas |
 | `/maxsim:settings` | Configure workflow toggles and model profile | Change model, toggle agents |
 | `/maxsim:set-profile <profile>` | Quick profile switch | Change cost/quality tradeoff |
 | `/maxsim:reapply-patches` | Restore local modifications after update | After `/maxsim:update` if you had local edits |

--- a/packages/website/src/components/sections/Docs.tsx
+++ b/packages/website/src/components/sections/Docs.tsx
@@ -322,16 +322,10 @@ const commands: CommandDef[] = [
     example: `/maxsim:map-codebase`,
   },
   {
-    name: "add-todo",
-    signature: "/maxsim:add-todo",
-    description: "Capture an idea or task as a todo from the current conversation context. Stored in .planning/todos/pending/.",
-    example: `/maxsim:add-todo`,
-  },
-  {
-    name: "check-todos",
-    signature: "/maxsim:check-todos",
-    description: "List all pending todos and interactively select one to work on next.",
-    example: `/maxsim:check-todos`,
+    name: "quick --todo",
+    signature: `/maxsim:quick --todo "desc"`,
+    description: `Capture a task or idea as a GitHub Issue (label: todo). Use --todo list to view open todos, --todo done N to close Issue #N, or --todo triage to prioritize against the roadmap.`,
+    example: `/maxsim:quick --todo "Refactor auth module"`,
   },
   {
     name: "dashboard",

--- a/packages/website/src/content/docs/commands-todos.md
+++ b/packages/website/src/content/docs/commands-todos.md
@@ -1,18 +1,24 @@
 ---
 id: commands-todos
-title: Todo Commands
+title: Todo Management
 group: Commands Reference
 ---
 
-{% doctable headers=["Command", "Description"] rows=[["/maxsim:add-todo", "Capture an idea or task from the current conversation as a todo file"], ["/maxsim:check-todos", "List pending todos and interactively select one to work on next"]] %}
+{% doctable headers=["Command", "Description"] rows=[["/maxsim:quick --todo \"desc\"", "Capture a task or idea as a GitHub Issue with label 'todo'"], ["/maxsim:quick --todo list", "Show open todo Issues from GitHub"], ["/maxsim:quick --todo done N", "Close GitHub Issue #N as completed"], ["/maxsim:quick --todo triage", "Prioritize todos and cross-reference with the roadmap"]] %}
 {% /doctable %}
 
-Todos are stored as markdown files in `.planning/todos/pending/`. Each todo has a title, description, priority, and creation timestamp. Completed todos move to `.planning/todos/completed/`.
+Todo management uses GitHub Issues as the sole source of truth. Todos are created as Issues with the `todo` label and closed when completed — no local files are involved.
 
 {% codeblock language="bash" %}
-# Save an idea as a todo (from conversation context)
-/maxsim:add-todo
+# Capture an idea as a GitHub Issue
+/maxsim:quick --todo "Refactor auth module to use refresh tokens"
 
-# Review and pick a todo to work on
-/maxsim:check-todos
+# List pending todos (open Issues labeled 'todo')
+/maxsim:quick --todo list
+
+# Mark a todo complete by closing Issue #12
+/maxsim:quick --todo done 12
+
+# Triage: prioritize todos against the current roadmap
+/maxsim:quick --todo triage
 {% /codeblock %}


### PR DESCRIPTION
## Summary

- Remove all references to the deleted `/maxsim:add-todo` and `/maxsim:check-todos` commands from `docs/USER-GUIDE.md`, `packages/website/src/content/docs/commands-todos.md`, and `packages/website/src/components/sections/Docs.tsx`
- Replace with the current `/maxsim:quick --todo` workflow that uses GitHub Issues as the sole source of truth
- The `commands-todos.md` page is rewritten to document all four subcommands: capture, list, done, and triage

## Test plan

- [x] `grep -rn "add-todo|check-todos" docs/ packages/website/` returns zero results
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Unit tests pass — 210/210

🤖 Generated with [Claude Code](https://claude.com/claude-code)