### PR TITLE
fix(hooks): prevent console window flashes on Windows

### DIFF
--- a/packages/cli/src/hooks/maxsim-check-update.ts
+++ b/packages/cli/src/hooks/maxsim-check-update.ts
@@ -37,6 +37,7 @@ export function checkForUpdate(options: CheckForUpdateOptions): void {
   }
 
   // Run check in background (spawn background process, windowsHide prevents console flash)
+  const isWindows = process.platform === 'win32';
   const child = spawn(process.execPath, ['-e', `
   const fs = require('fs');
   const { execSync } = require('child_process');
@@ -71,7 +72,7 @@ export function checkForUpdate(options: CheckForUpdateOptions): void {
 `], {
     stdio: 'ignore',
     windowsHide: true,
-    detached: true,
+    detached: !isWindows,
   });
 
   child.unref();

--- a/packages/cli/src/hooks/maxsim-statusline.ts
+++ b/packages/cli/src/hooks/maxsim-statusline.ts
@@ -44,6 +44,7 @@ try {
     encoding: 'utf8',
     timeout: 10000,
     stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
   }).trim();
 
   if (!nameWithOwner || !nameWithOwner.includes('/')) {
@@ -58,7 +59,7 @@ try {
   try {
     const milestonesRaw = execSync(
       'gh api repos/' + owner + '/' + repo + '/milestones --jq "."',
-      { encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }
+      { encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
     ).trim();
     if (milestonesRaw) {
       const milestones = JSON.parse(milestonesRaw);
@@ -81,7 +82,7 @@ try {
   try {
     const phaseRaw = execSync(
       'gh api "repos/' + owner + '/' + repo + '/issues?state=open&labels=phase&per_page=1&sort=updated&direction=desc" --jq ".[0] | {number: .number, title: .title}"',
-      { encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }
+      { encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
     ).trim();
     const phaseData = JSON.parse(phaseRaw || '{}');
     const titleMatch = (phaseData.title || '').match(/^\\[Phase\\s+(\\S+)\\]/);
@@ -100,7 +101,7 @@ try {
       const gqlQuery = '{ repository(owner: "' + owner + '", name: "' + repo + '") { issue(number: ' + issueNumber + ') { projectItems(first: 5, includeArchived: false) { nodes { fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } } } } } } }';
       const boardRaw = execSync(
         'gh api graphql -f query=@-',
-        { input: gqlQuery, encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }
+        { input: gqlQuery, encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
       ).trim();
       const boardData = JSON.parse(boardRaw);
       const nodes = boardData?.data?.repository?.issue?.projectItems?.nodes || [];
@@ -141,10 +142,11 @@ try {
 }
 `;
 
+    const isWindows = process.platform === 'win32';
     const child = spawn(process.execPath, ['-e', script], {
       stdio: 'ignore',
       windowsHide: true,
-      detached: true,
+      detached: !isWindows,
     });
     child.unref();
   } catch {

--- a/packages/cli/src/hooks/shared.ts
+++ b/packages/cli/src/hooks/shared.ts
@@ -48,8 +48,8 @@ export function playSound(type: 'question' | 'stop'): void {
       const { spawn } = require('node:child_process') as typeof import('node:child_process');
       const child = spawn(
         'powershell',
-        ['-NoProfile', '-Command', `(New-Object Media.SoundPlayer '${file}').PlaySync()`],
-        { stdio: 'ignore', windowsHide: true, detached: true },
+        ['-NoProfile', '-WindowStyle', 'Hidden', '-Command', `(New-Object Media.SoundPlayer '${file}').PlaySync()`],
+        { stdio: 'ignore', windowsHide: true },
       );
       child.unref();
     } else if (platform === 'darwin') {


### PR DESCRIPTION
  - Remove detached: true on Windows (unnecessary, child processes survive parent exit natively) to avoid CREATE_NEW_PROCESS_GROUP console windows
  - Add windowsHide: true to all execSync calls inside statusline background refresh script (4 gh CLI invocations were missing it)
  - Add -WindowStyle Hidden to PowerShell sound playback to suppress console flash during notification and stop sounds
  - No behavior change on macOS/Linux (detached: true preserved via platform check)

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Test (`test:`)
- [ ] Chore / maintenance (`chore:`)
- [ ] Breaking change (`fix!:` / `feat!:`)

## What does this PR do?

<!-- A clear and concise description of the change and why it's needed. -->

## Related Issue

Closes #<!-- issue number -->

## How Has This Been Tested?

<!-- Describe how you tested the change. -->

- [ ] Unit tests (`npm test`)
- [ ] E2e tests (`cd packages/cli && npx vitest run --config vitest.e2e.config.ts`)
- [ ] Manual testing — describe steps:

## Notes for Reviewer

<!-- Anything specific you want the reviewer to focus on or be aware of. -->

## Checklist

- [ ] `npm run build` passes with no errors
- [ ] `npm test` passes
- [ ] Commit message(s) follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have not edited `packages/cli/README.md` directly (it is auto-generated)
