### PR TITLE
fix(agents): correct model profiles and promote verification to preloaded skill

### DIFF
--- a/templates/agents/AGENTS.md
+++ b/templates/agents/AGENTS.md
@@ -19,8 +19,8 @@ Config `model_profile` (quality/balanced/budget) sets baseline model per agent t
 |-------|---------|----------|--------|
 | executor | opus | sonnet | sonnet |
 | planner | opus | opus | sonnet |
-| researcher | opus | sonnet | haiku |
-| verifier | sonnet | sonnet | haiku |
+| researcher | sonnet | sonnet | haiku |
+| verifier | opus | sonnet | sonnet |
 
 All agents use `model: inherit` in their frontmatter, meaning they run on the session model unless the orchestrator specifies an explicit model at spawn time.
 

--- a/templates/agents/executor.md
+++ b/templates/agents/executor.md
@@ -6,6 +6,7 @@ model: inherit
 skills:
   - handoff-contract
   - commit-conventions
+  - verification
 available_skills:
   - name: github-operations
     path: ~/.claude/skills/github-operations/SKILL.md
@@ -13,9 +14,6 @@ available_skills:
   - name: tdd
     path: ~/.claude/skills/tdd/SKILL.md
     trigger: When implementing features with test-first approach
-  - name: verification
-    path: ~/.claude/skills/verification/SKILL.md
-    trigger: When verifying completed work
 ---
 
 You are a plan executor. You implement plans atomically -- one commit per task, deviations handled inline, every completion claim backed by tool output.


### PR DESCRIPTION
## Summary

- Fix model profile table in `templates/agents/AGENTS.md` to match PROJECT.md §7.4: researcher quality is `sonnet` (was `opus`), verifier quality is `opus` (was `sonnet`), verifier budget is `sonnet` (was `haiku`)
- Promote `verification` from `available_skills` to preloaded `skills` in `templates/agents/executor.md` per spec requirement
- Remove now-redundant `available_skills` entry for `verification` (cleanup from simplify review)

## Test plan

- [x] `grep -A5 "quality" templates/agents/AGENTS.md` confirms correct model profile values
- [x] `grep -A5 "skills:" templates/agents/executor.md` confirms verification is preloaded
- [x] Build passes (`npm run build`)
- [x] All 81 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)