### PR TITLE
fix(skills): update 8 skill files — remove stale refs and add missing content

### DIFF
--- a/templates/skills/code-review/SKILL.md
+++ b/templates/skills/code-review/SKILL.md
@@ -124,4 +124,4 @@ These are different activities. Both are required.
 
 Spec review alone misses security issues. Code review alone misses missing requirements. Run both.
 
-See also: `/maxsim-simplify` for maintainability optimization (duplication, dead code, complexity reduction).
+See also: `maxsim-simplify` skill for maintainability optimization (duplication, dead code, complexity reduction).

--- a/templates/skills/github-operations/SKILL.md
+++ b/templates/skills/github-operations/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: github-operations
 description: Unified GitHub interaction covering artifact types, comment conventions, CLI commands, and issue lifecycle. Use when reading from or writing to GitHub Issues, managing the project board, or posting structured comments.
-user-invocable: false
 ---
 
 ## GitHub as Source of Truth
@@ -76,6 +75,15 @@ Add `--raw` to any command for machine-readable JSON output: `{"ok": true, "resu
 | `all-progress` | All phases progress overview |
 | `ensure-labels` | Create any missing standard labels |
 | `sync-check` | Verify local mapping matches GitHub state |
+
+### Milestone Commands
+
+Direct `gh` CLI commands for milestone management (not routed through maxsim-tools):
+
+| Command | Purpose |
+|---------|---------|
+| `gh api repos/{owner}/{repo}/milestones --method POST -f title="Name" -f description="Desc"` | Create a milestone |
+| `gh api repos/{owner}/{repo}/milestones` | List all milestones |
 
 ### Large Text Arguments
 

--- a/templates/skills/maxsim-batch/SKILL.md
+++ b/templates/skills/maxsim-batch/SKILL.md
@@ -83,6 +83,10 @@ When all agents complete:
    - Merge conflict found: decomposition was wrong -- fix overlap and re-run the conflicting units
    - 3+ failures on one unit: stop and escalate to user with full failure context
 
+## Agent Teams (Intra-Branch Coordination)
+
+For tasks that benefit from competitive implementation, use Agent Teams: spawn 2-3 agents on the same task within the same branch, then have a verifier agent pick the best result. This is useful when solution quality matters more than speed and multiple valid approaches exist. The verifier reads each agent's output, evaluates against acceptance criteria, and promotes the winner. See §7.2 of PROJECT.md for the full Agent Teams specification.
+
 ## Limits
 
 - Up to 30 parallel agents; typically 3-10 for manageable coordination

--- a/templates/skills/project-memory/SKILL.md
+++ b/templates/skills/project-memory/SKILL.md
@@ -112,6 +112,12 @@ This surfaces what changed recently without opening every file. Combine with `gh
 
 ---
 
+## Agent-Memory Storage Layer
+
+MaxsimCLI maintains an automated local memory store for learnings captured by the agent itself. The storage path is `.claude/agent-memory/maxsim-learner/MEMORY.md`. This file is written automatically at session end by the `maxsim-capture-learnings` Stop hook (per §11.4 of PROJECT.md), which extracts key lessons from the session transcript and appends them to the file. Agents should read this file at session start alongside GitHub Issues to surface recently captured patterns before planning.
+
+---
+
 ## Claude Code Memory Integration
 
 When operating as a sub-agent within a MaxsimCLI workflow, scope memory to the project:

--- a/templates/skills/research/SKILL.md
+++ b/templates/skills/research/SKILL.md
@@ -47,6 +47,8 @@ Use the correct tool for each task. Using the wrong tool produces slower or inco
 | Find files by name/pattern | `Glob` | `find`, `ls` |
 | Multi-step investigation across many files | `Agent` | Sequential Bash loops |
 | Single shell command or script | `Bash` | — |
+| Discover external docs, packages, or resources | `WebSearch` | Guessing URLs |
+| Read a specific external URL or documentation page | `WebFetch` | `curl` in Bash |
 
 **Parallelise where possible.** When multiple files or sources are independent, read or search them in the same tool call batch rather than sequentially.
 

--- a/templates/skills/systematic-debugging/SKILL.md
+++ b/templates/skills/systematic-debugging/SKILL.md
@@ -88,4 +88,4 @@ If 3+ fix attempts have failed, the issue is likely architectural. Stop guessing
 
 Stop immediately if you catch yourself changing code before reproducing, proposing a fix before reading the full error, trying random fixes, or changing multiple things at once.
 
-See also: `verification-before-completion` for evidence-based confirmation after fixes.
+See also: `verification` for evidence-based confirmation after fixes.

--- a/templates/skills/tdd/SKILL.md
+++ b/templates/skills/tdd/SKILL.md
@@ -71,4 +71,4 @@ TDD uses approximately 40% more context than direct implementation due to cycle 
 
 Stop immediately if you catch yourself writing implementation code before a test, writing a test that passes on the first run, skipping VERIFY RED, or adding features beyond what the current test requires.
 
-See also: `verification-before-completion` for evidence-based completion claims after TDD cycles.
+See also: `verification` for evidence-based completion claims after TDD cycles.

--- a/templates/skills/using-maxsim/SKILL.md
+++ b/templates/skills/using-maxsim/SKILL.md
@@ -7,7 +7,7 @@ description: Routes work through MaxsimCLI commands based on project state and u
 
 MaxsimCLI is a spec-driven development system. Work flows through phases, plans, and tasks — not ad-hoc coding.
 
-**No implementation without a plan.** If there is no `.planning/` directory, run `/maxsim:init` first. If there is no current phase, run `/maxsim:plan N` first. If there is a plan, run `/maxsim:execute N` to execute it.
+**No implementation without a plan.** If MaxsimCLI is not initialized (no GitHub Project Board), run `/maxsim:init` first. If there is no current phase, run `/maxsim:plan N` first. If there is a plan, run `/maxsim:execute N` to execute it.
 
 ---
 
@@ -33,10 +33,9 @@ Determine user intent, then route to the correct command.
 
 Before beginning any task in a session:
 
-1. Check for `.planning/` directory — if missing, run `/maxsim:init`
-2. Read `STATE.md` — if a checkpoint exists, resume from it via `/maxsim:go`
-3. Check `ROADMAP.md` — identify the active phase
-4. Route to the correct command using the table above
+1. Check GitHub Project Board status via `node .claude/maxsim/bin/maxsim-tools.cjs github status`
+2. Identify the active phase from GitHub Issues — if any phase is in progress, resume via `/maxsim:go`
+3. Route to the correct command using the table above
 
 GitHub Issues with label `maxsim:lesson` or `maxsim:decision` are the source of truth for project learnings and architectural decisions. Read them before planning.
 
@@ -63,9 +62,9 @@ All persistent project state lives in GitHub, not in local files that disappear 
 
 | Artifact | Location |
 |----------|---------|
-| Phase plans | `.planning/phases/N/PLAN.md` (committed) |
-| Roadmap | `.planning/ROADMAP.md` (committed) |
-| Session state | `.planning/STATE.md` (committed after each checkpoint) |
+| Phase plans | GitHub Sub-Issues on the phase Issue |
+| Roadmap | GitHub Milestones + Phase Issues |
+| Session state | GitHub Project Board column positions + Issue status |
 | Learnings | GitHub Issues — label `maxsim:lesson` |
 | Decisions | GitHub Issues — label `maxsim:decision` |
 
@@ -73,9 +72,9 @@ All persistent project state lives in GitHub, not in local files that disappear 
 
 ## Common Pitfalls
 
-- Writing implementation code without a `PLAN.md`
+- Writing implementation code without a phase plan on GitHub
 - Skipping `/maxsim:init` because the project seems simple
-- Ignoring `STATE.md` checkpoints from previous sessions
+- Ignoring Project Board state and in-progress issues from previous sessions
 - Working outside the current phase without explicit user approval
 - Making architectural decisions without recording them as `maxsim:decision` issues
 


### PR DESCRIPTION
## Summary

- Replace stale `verification-before-completion` skill reference with `verification` in `tdd` and `systematic-debugging`
- Update `using-maxsim` to reference GitHub Project Board / Issues instead of deprecated `.planning/` local files
- Add Agent Teams section (intra-branch coordination, competitive implementation) to `maxsim-batch` per §7.2
- Add agent-memory storage layer section to `project-memory` (`.claude/agent-memory/maxsim-learner/MEMORY.md` + `maxsim-capture-learnings` Stop hook) per §11.4
- Remove unrecognized `user-invocable: false` frontmatter field from `github-operations`; add milestone CLI commands
- Add `WebSearch` and `WebFetch` rows to the tool priority table in `research`
- Fix leading-slash typo in `code-review` See also line (`/maxsim-simplify` → `maxsim-simplify` skill)

## Test plan

- [x] `grep -n "\.planning/" templates/skills/using-maxsim/SKILL.md` returns 0 lines
- [x] `grep -rn "verification-before-completion" templates/skills/` returns 0 lines
- [x] Build passes (`npm run build`)
- [x] All 81 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)