### PR TITLE
fix(commands): standardize all 9 slash command definitions

### DIFF
--- a/templates/commands/maxsim/debug.md
+++ b/templates/commands/maxsim/debug.md
@@ -2,7 +2,7 @@
 name: maxsim:debug
 description: Systematic debugging with reproduce-hypothesize-isolate-verify-fix cycle
 argument-hint: "[issue description]"
-allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion]
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion, EnterPlanMode, ExitPlanMode]
 ---
 
 <objective>
@@ -18,7 +18,7 @@ GitHub is the sole source of truth. Check for open Issues labeled `debug` to det
 </context>
 
 <process>
-Follow @~/.claude/maxsim/workflows/debug.md end-to-end.
+Follow @.claude/maxsim/workflows/debug.md end-to-end. Invoke the `systematic-debugging` skill at step 4 to drive the reproduce-hypothesize-isolate-verify-fix cycle.
 
 1. Check GitHub for open Issues labeled `debug` (active sessions)
    - If active sessions exist and no $ARGUMENTS: list them, let user pick to resume or start new

--- a/templates/commands/maxsim/execute.md
+++ b/templates/commands/maxsim/execute.md
@@ -2,7 +2,7 @@
 name: maxsim:execute
 description: Execute all plans in a phase with parallel agents and auto-verification
 argument-hint: "<phase-number>"
-allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent]
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent, EnterPlanMode, ExitPlanMode]
 ---
 
 <objective>
@@ -20,7 +20,7 @@ Re-entry: If phase is already executed and verified, show status and offer optio
 </context>
 
 <process>
-Follow @~/.claude/maxsim/workflows/execute.md end-to-end.
+Follow @.claude/maxsim/workflows/execute.md end-to-end.
 
 1. Detect phase state from GitHub Project Board (already done / partially executed / ready)
 2. Group task Issues by wave — execute parallel Agents within each wave, sequential across waves

--- a/templates/commands/maxsim/go.md
+++ b/templates/commands/maxsim/go.md
@@ -1,7 +1,7 @@
 ---
 name: maxsim:go
 description: Auto-detect project state and execute the right action
-allowed-tools: [Read, Bash, Grep, Glob, Agent, AskUserQuestion]
+allowed-tools: [Read, Bash, Grep, Glob, Agent, AskUserQuestion, EnterPlanMode, ExitPlanMode]
 ---
 
 <objective>
@@ -20,7 +20,7 @@ Detection priority:
 </context>
 
 <process>
-Follow @~/.claude/maxsim/workflows/go.md end-to-end.
+Follow @.claude/maxsim/workflows/go.md end-to-end.
 
 1. Read GitHub Project Board state via `gh` CLI
 2. Detect what's next using the priority list above

--- a/templates/commands/maxsim/help.md
+++ b/templates/commands/maxsim/help.md
@@ -9,5 +9,5 @@ Display the complete MaxsimCLI command reference. Output ONLY the reference cont
 </objective>
 
 <process>
-Output the command reference from @~/.claude/maxsim/workflows/help.md directly. No additions or modifications.
+Output the command reference from @.claude/maxsim/workflows/help.md directly. No additions or modifications.
 </process>

--- a/templates/commands/maxsim/init.md
+++ b/templates/commands/maxsim/init.md
@@ -2,7 +2,7 @@
 name: maxsim:init
 description: Initialize MaxsimCLI in current project with GitHub integration
 argument-hint: "[--auto]"
-allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion, WebFetch]
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion, WebFetch, WebSearch, EnterPlanMode, ExitPlanMode]
 ---
 
 <objective>
@@ -19,12 +19,12 @@ GitHub is the sole source of truth. Init creates GitHub Milestones and Issues â€
 </context>
 
 <process>
-Follow @~/.claude/maxsim/workflows/init.md end-to-end.
+Follow @.claude/maxsim/workflows/init.md end-to-end.
 
 1. Scan repo structure (language, framework, existing CI)
 2. Interview user: project goal, scope, constraints, success criteria
 3. Create GitHub Milestone for this project/version
 4. Write CLAUDE.md with project context and MaxsimCLI config
 5. Optionally generate Roadmap as GitHub Issues (phases)
-6. Confirm setup and suggest `/maxsim:plan 1` as next step
+6. Confirm setup and suggest `/maxsim:go` as next step
 </process>

--- a/templates/commands/maxsim/plan.md
+++ b/templates/commands/maxsim/plan.md
@@ -2,7 +2,7 @@
 name: maxsim:plan
 description: Plan a specific phase with discussion, research, and task breakdown
 argument-hint: "<phase-number> [--force-research] [--skip-verify]"
-allowed-tools: [Read, Write, Bash, Grep, Glob, Agent, AskUserQuestion, WebFetch]
+allowed-tools: [Read, Write, Bash, Grep, Glob, Agent, AskUserQuestion, WebFetch, EnterPlanMode, ExitPlanMode]
 ---
 
 <objective>
@@ -24,7 +24,7 @@ Re-entry: If phase is already planned, show status and offer options (view, re-p
 </context>
 
 <process>
-Follow @~/.claude/maxsim/workflows/plan.md end-to-end.
+Follow @.claude/maxsim/workflows/plan.md end-to-end.
 
 1. Detect current stage from GitHub Issue labels on the phase Issue
 2. Start at earliest incomplete stage

--- a/templates/commands/maxsim/progress.md
+++ b/templates/commands/maxsim/progress.md
@@ -13,7 +13,7 @@ GitHub is the sole source of truth. Read the GitHub Project Board, Milestone pro
 </context>
 
 <process>
-Follow @~/.claude/maxsim/workflows/progress.md end-to-end.
+Follow @.claude/maxsim/workflows/progress.md end-to-end.
 
 1. Read active GitHub Milestone and its completion percentage
 2. Read GitHub Project Board columns to get phase/task states

--- a/templates/commands/maxsim/quick.md
+++ b/templates/commands/maxsim/quick.md
@@ -2,7 +2,7 @@
 name: maxsim:quick
 description: Quick task - create GitHub Issue and execute in simplified flow
 argument-hint: "[task description]"
-allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion]
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion, EnterPlanMode, ExitPlanMode]
 ---
 
 <objective>
@@ -18,7 +18,7 @@ Quick tasks are tracked as GitHub Issues (label: `quick`) — separate from plan
 </context>
 
 <process>
-Follow @~/.claude/maxsim/workflows/quick.md end-to-end.
+Follow @.claude/maxsim/workflows/quick.md end-to-end.
 
 1. Get task description from $ARGUMENTS or via AskUserQuestion
 2. Clarify scope if ambiguous (one focused question)

--- a/templates/commands/maxsim/settings.md
+++ b/templates/commands/maxsim/settings.md
@@ -9,13 +9,13 @@ Interactively view and modify MaxsimCLI configuration: model profile, pipeline t
 </objective>
 
 <context>
-Configuration is stored in CLAUDE.md (project-level) and `~/.claude/maxsim/config.json` (global). Present current values as pre-selections in each prompt.
+Configuration is stored in CLAUDE.md (project-level) and `.claude/maxsim/config.json` (global). Present current values as pre-selections in each prompt.
 </context>
 
 <process>
-Follow @~/.claude/maxsim/workflows/settings.md end-to-end.
+Follow @.claude/maxsim/workflows/settings.md end-to-end.
 
-1. Read current config from CLAUDE.md and `~/.claude/maxsim/config.json`
+1. Read current config from CLAUDE.md and `.claude/maxsim/config.json`
 2. Display current settings with descriptions
 3. Use AskUserQuestion to interactively configure:
    - Model profile (with per-tier model assignment details)


### PR DESCRIPTION
## Summary

- Replace `@~/.claude/maxsim/` path references with `@.claude/maxsim/` (project-local) in all 9 command files
- Add `EnterPlanMode` and `ExitPlanMode` to `allowed-tools` in all 6 code-modifying commands (go, init, plan, execute, debug, quick)
- Add `WebSearch` to `init.md` allowed-tools
- Remove stray `</output>` closing tag from `go.md`
- Change `init.md` post-init suggestion from `/maxsim:plan 1` to `/maxsim:go`
- Add `systematic-debugging` skill reference to `debug.md` process description
- Fix `~/.claude/maxsim/config.json` → `.claude/maxsim/config.json` in `settings.md` (2 occurrences)

## Test plan

- [x] `grep -rn "~/.claude/maxsim/" templates/commands/` returns 0 lines
- [x] `grep -n "</output>" templates/commands/maxsim/go.md templates/commands/maxsim/debug.md templates/commands/maxsim/quick.md` returns 0 lines
- [x] All 81 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)