### PR TITLE
fix(core): audit fixes for types, config, labels, and board schema

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,6 @@
 /**
  * MAXSIM Tools — CLI dispatcher.
- * Usage: node maxsim-tools.cjs <command> [args] [--raw]
+ * Usage: node maxsim-tools.cjs <command> [args]
  */
 
 const COMMANDS: Record<string, () => void> = {};
@@ -12,7 +12,7 @@ async function main(): Promise<void> {
   if (!command) {
     const available = Object.keys(COMMANDS).join(', ') || '(none yet)';
     process.stderr.write(
-      `Usage: maxsim-tools <command> [args] [--raw]\nCommands: ${available}\n`,
+      `Usage: maxsim-tools <command> [args]\nCommands: ${available}\n`,
     );
     process.exit(1);
   }

--- a/packages/cli/src/core/config.ts
+++ b/packages/cli/src/core/config.ts
@@ -53,10 +53,14 @@ export function loadConfig(projectDir: string): MaxsimConfig {
 
   try {
     const raw = fs.readFileSync(configPath, 'utf8');
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      console.warn(`[maxsim] Invalid config at ${configPath}: expected an object. Using defaults.`);
+      return { ...DEFAULT_CONFIG };
+    }
     return deepMerge(
       DEFAULT_CONFIG as unknown as Record<string, unknown>,
-      parsed,
+      parsed as Record<string, unknown>,
     ) as unknown as MaxsimConfig;
   } catch {
     return { ...DEFAULT_CONFIG };

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -179,6 +179,13 @@ export interface MaxsimConfig {
     autoCommitOnSuccess: boolean;
     conventionalCommits: boolean;
   };
+  github: {
+    projectName: string;
+    autoPush: boolean;
+  };
+  hooks: {
+    enabled: boolean;
+  };
 }
 
 export const DEFAULT_CONFIG: MaxsimConfig = {
@@ -211,5 +218,12 @@ export const DEFAULT_CONFIG: MaxsimConfig = {
   automation: {
     autoCommitOnSuccess: true,
     conventionalCommits: true,
+  },
+  github: {
+    projectName: '',
+    autoPush: true,
+  },
+  hooks: {
+    enabled: true,
   },
 };

--- a/packages/cli/src/github/types.ts
+++ b/packages/cli/src/github/types.ts
@@ -111,7 +111,7 @@ export interface GhProjectItem {
 
 /** Machine-readable metadata embedded in issue body as HTML comments. */
 export interface MaxsimIssueMeta {
-  type: 'phase' | 'task' | 'bug' | 'quick' | 'user';
+  type: 'phase' | 'task' | 'bug' | 'quick' | 'user' | 'milestone';
   phase: number | null;
   task: number | null;
   parentIssue: number | null;
@@ -136,7 +136,7 @@ export interface MaxsimIssueState {
 
 /** Structured comment metadata from HTML comment markers. */
 export interface MaxsimCommentMeta {
-  type: 'plan' | 'research' | 'context' | 'progress' | 'verification' | 'summary' | 'error' | 'escalation' | 'handoff';
+  type: 'plan' | 'research' | 'context' | 'progress' | 'verification' | 'summary' | 'error' | 'escalation' | 'handoff' | 'user-intent';
   phase?: number;
   task?: number;
   [key: string]: unknown;
@@ -157,13 +157,14 @@ export const MAXSIM_LABELS: LabelDef[] = [
   { name: 'type:task', description: 'Task sub-issue', color: '0e8a16' },
   { name: 'type:bug', description: 'Bug report', color: 'd73a4a' },
   { name: 'type:quick', description: 'Quick task', color: 'e4e669' },
-  { name: 'type:user', description: 'User-created issue', color: 'c5def5' },
+  { name: 'type:user-issue', description: 'User-created issue', color: 'c5def5' },
   // Priority labels
-  { name: 'priority:p0', description: 'P0 Critical', color: 'b60205' },
-  { name: 'priority:p1', description: 'P1 High', color: 'd93f0b' },
-  { name: 'priority:p2', description: 'P2 Medium', color: 'fbca04' },
-  { name: 'priority:p3', description: 'P3 Low', color: '0e8a16' },
+  { name: 'priority:p0-critical', description: 'P0 Critical', color: 'b60205' },
+  { name: 'priority:p1-high', description: 'P1 High', color: 'd93f0b' },
+  { name: 'priority:p2-medium', description: 'P2 Medium', color: 'fbca04' },
+  { name: 'priority:p3-low', description: 'P3 Low', color: '0e8a16' },
   // Status labels
+  { name: 'status:planned', description: 'Planned', color: 'e1d5f7' },
   { name: 'status:planning', description: 'In planning', color: 'bfd4f2' },
   { name: 'status:ready', description: 'Ready for execution', color: '0075ca' },
   { name: 'status:blocked', description: 'Blocked', color: 'b60205' },
@@ -177,6 +178,7 @@ export const MAXSIM_LABELS: LabelDef[] = [
 
 /** Status column definitions for the Kanban board. */
 export const BOARD_COLUMNS = [
+  { name: 'Backlog', color: 'GRAY' },
   { name: 'To Do', color: 'BLUE' },
   { name: 'In Progress', color: 'YELLOW' },
   { name: 'In Review', color: 'ORANGE' },
@@ -189,6 +191,9 @@ export const BOARD_FIELDS = [
   { name: 'Phase', dataType: 'NUMBER' },
   { name: 'Wave', dataType: 'NUMBER' },
   { name: 'Estimate', dataType: 'NUMBER' },
+  { name: 'Type', dataType: 'SINGLE_SELECT' },
+  { name: 'Status', dataType: 'SINGLE_SELECT' },
+  { name: 'Iteration', dataType: 'ITERATION' },
 ] as const;
 
 // ── Repo Info ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Board schema**: Added `Backlog` column (GRAY) to `BOARD_COLUMNS` (now 5 columns); added `Type`, `Status`, `Iteration` fields to `BOARD_FIELDS`
- **Issue/comment types**: Added `'milestone'` to `MaxsimIssueMeta.type`; added `'user-intent'` to `MaxsimCommentMeta.type`
- **Label taxonomy**: Renamed priority labels to full spec names (`priority:p0-critical`, `p1-high`, `p2-medium`, `p3-low`), renamed `type:user` → `type:user-issue`, added `status:planned`
- **Config schema**: Added `github: { projectName, autoPush }` and `hooks: { enabled }` sections to `MaxsimConfig` with defaults
- **Config validation**: `loadConfig` now validates the parsed JSON is a plain object before merging; warns and returns defaults if not
- **cli.ts**: Removed unimplemented `[--raw]` from usage string

## Test plan

- [ ] `npm run build` — passes (verified locally)
- [ ] `npm test` — 81/81 tests pass (verified locally)
- [ ] `npx tsc --noEmit` — 3 pre-existing errors in `github/client.ts` and `github/issues.ts` (not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)