### PR TITLE
fix(workflows): repair plan workflow path refs and dead code

### DIFF
--- a/templates/workflows/plan-create.md
+++ b/templates/workflows/plan-create.md
@@ -15,7 +15,7 @@ GitHub Issues is the sole source of truth. No local PLAN.md files are written.
 - Tool name is `Agent` (NOT `Task`)
 - Agent spawning: Agent(prompt, model, isolation, run_in_background)
 - Plans are posted to GitHub with <!-- maxsim:type=plan -->
-- Use `node ~/.claude/maxsim/bin/maxsim-tools.cjs` for all CLI operations
+- Use `node .claude/maxsim/bin/maxsim-tools.cjs` for all CLI operations
 - No local PLAN.md files are written -- GitHub is the sole source of truth
 - Do NOT show gate confirmation or next steps -- the orchestrator handles those
 </critical_rules>
@@ -29,23 +29,15 @@ The orchestrator provides phase context. Verify we have what we need:
 - `phase_number`, `phase_name`, `phase_dir`, `padded_phase`, `phase_slug`
 - `planner_model`, `checker_model`, `plan_checker_enabled`
 - `commit_docs`
-- `state_path`, `roadmap_path`, `requirements_path`
 - `phase_req_ids` (requirement IDs that this phase must address)
 - `phase_issue_number` (GitHub Issue number for the phase)
 - `--skip-verify` flag presence
 
-## Step 2: Resolve Models
-
-```bash
-PLANNER_MODEL=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs resolve-model planner --raw)
-CHECKER_MODEL=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs resolve-model planner --raw)
-```
-
-## Step 3: Check Existing Plans
+## Step 2: Check Existing Plans
 
 Query the phase GitHub Issue for existing plan comments:
 ```bash
-ISSUE_DATA=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs github get-issue \
+ISSUE_DATA=$(node .claude/maxsim/bin/maxsim-tools.cjs github get-issue \
   --issue-number $PHASE_ISSUE_NUMBER --include-comments)
 ```
 
@@ -64,7 +56,7 @@ Phase {phase_number} already has plan(s) on GitHub Issue #{phase_issue_number}.
 - If "View": Display plan comment contents, then re-offer options.
 - If "Re-plan": Delete existing plan comments from the issue:
   ```bash
-  node ~/.claude/maxsim/bin/maxsim-tools.cjs github delete-comments \
+  node .claude/maxsim/bin/maxsim-tools.cjs github delete-comments \
     --issue-number $PHASE_ISSUE_NUMBER --type plan
   ```
   Then continue to Step 4.
@@ -76,7 +68,7 @@ Phase {phase_number} already has plan(s) on GitHub Issue #{phase_issue_number}.
 Fetch the phase issue with all comments to supply the planner with context and research:
 
 ```bash
-ISSUE_DATA=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs github get-issue \
+ISSUE_DATA=$(node .claude/maxsim/bin/maxsim-tools.cjs github get-issue \
   --issue-number $PHASE_ISSUE_NUMBER --include-comments)
 ```
 
@@ -112,12 +104,6 @@ in its response (not write local files):
 **Research Findings (from research comment):**
 {content of the <!-- maxsim:type=research --> comment}
 </github_context>
-
-<local_context>
-**Roadmap:** {roadmap_path}
-**Requirements:** {requirements_path}
-**State:** {state_path}
-</local_context>
 
 **Phase requirement IDs (every ID MUST appear in a plan's `requirements` field):** {phase_req_ids}
 
@@ -273,11 +259,6 @@ Construct the checker prompt. Pass the in-memory `plans_content` directly:
 {content of the <!-- maxsim:type=research --> comment}
 </github_context>
 
-<local_context>
-**Roadmap:** {roadmap_path}
-**Requirements:** {requirements_path}
-</local_context>
-
 **Phase requirement IDs (MUST ALL be covered):** {phase_req_ids}
 
 **Project instructions:** Read ./CLAUDE.md if exists -- verify plans honor project guidelines
@@ -294,7 +275,7 @@ Spawn the checker:
 
 ```
 Agent(
-  prompt="## Task: Verify plans achieve phase goal\n\n## Suggested Skills: verification-gates\n\n" + checker_prompt,
+  prompt="## Task: Verify plans achieve phase goal\n\n## Suggested Skills: verification\n\n" + checker_prompt,
   model="{checker_model}",
   isolation=true,
   run_in_background=false
@@ -392,7 +373,7 @@ cat > "$TMPFILE" << 'BODY_EOF'
 <!-- maxsim:type=plan -->
 {plan_content}
 BODY_EOF
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github post-plan-comment \
+node .claude/maxsim/bin/maxsim-tools.cjs github post-plan-comment \
   --phase-issue-number $PHASE_ISSUE_NUMBER \
   --plan-number "{plan_number}" \
   --plan-content-file "$TMPFILE"
@@ -418,7 +399,7 @@ Parse tasks from the posted plans. For each `<task>` element in the plan XML, ex
 Run `github batch-create-tasks` with the full tasks array and the phase issue number:
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github batch-create-tasks \
+node .claude/maxsim/bin/maxsim-tools.cjs github batch-create-tasks \
   --phase-number "$PHASE_NUMBER" \
   --parent-issue-number $PHASE_ISSUE_NUMBER \
   --tasks '[{"task_id":"1.1","title":"Task title","body":"Task body"}, ...]'
@@ -447,7 +428,7 @@ After all plans are posted and task sub-issues are created, move the phase issue
 on the project board:
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github move-issue \
+node .claude/maxsim/bin/maxsim-tools.cjs github move-issue \
   --issue-number $PHASE_ISSUE_NUMBER --status "In Progress"
 ```
 

--- a/templates/workflows/plan-discuss.md
+++ b/templates/workflows/plan-discuss.md
@@ -18,13 +18,13 @@ figure out implementation yourself.
 <critical_rules>
 - Tool name is `Agent` (NOT `Task`)
 - Context is posted to GitHub as a comment with <!-- maxsim:type=context -->
-- Use `node ~/.claude/maxsim/bin/maxsim-tools.cjs` for all CLI operations
+- Use `node .claude/maxsim/bin/maxsim-tools.cjs` for all CLI operations
 - No local CONTEXT.md file is written -- GitHub is the sole source of truth
 - Do NOT show gate confirmation or next steps -- the orchestrator handles those
 </critical_rules>
 
 <required_reading>
-@~/.claude/maxsim/references/thinking-partner.md
+.claude/maxsim/references/thinking-partner.md
 </required_reading>
 
 <downstream_awareness>
@@ -118,7 +118,7 @@ multiple ways and would change the result.
 Phase number, name, directory, and GitHub issue number come from the orchestrator context.
 
 ```bash
-PHASE_ISSUE=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs github get-issue \
+PHASE_ISSUE=$(node .claude/maxsim/bin/maxsim-tools.cjs github get-issue \
   --issue-number $PHASE_ISSUE_NUMBER)
 ```
 
@@ -133,7 +133,7 @@ Cannot read phase issue #{phase_issue_number}. Check GitHub connection.
 
 Check if a context comment already exists on the phase GitHub Issue:
 ```bash
-ISSUE_DATA=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs github get-issue \
+ISSUE_DATA=$(node .claude/maxsim/bin/maxsim-tools.cjs github get-issue \
   --issue-number $PHASE_ISSUE_NUMBER --include-comments)
 ```
 
@@ -315,7 +315,7 @@ TMPFILE=$(mktemp)
 cat > "$TMPFILE" << 'BODY_EOF'
 {context_content}
 BODY_EOF
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github post-comment \
+node .claude/maxsim/bin/maxsim-tools.cjs github post-comment \
   --issue-number $PHASE_ISSUE_NUMBER --body-file "$TMPFILE" --type context
 ```
 

--- a/templates/workflows/plan-research.md
+++ b/templates/workflows/plan-research.md
@@ -16,7 +16,7 @@ GitHub Issues is the sole source of truth. No local RESEARCH.md file is written.
 - Agent spawning: Agent(prompt, model, isolation, run_in_background)
 - Parallel agents use run_in_background=true, then collect results
 - Research is posted to GitHub with <!-- maxsim:type=research -->
-- Use `node ~/.claude/maxsim/bin/maxsim-tools.cjs` for all CLI operations
+- Use `node .claude/maxsim/bin/maxsim-tools.cjs` for all CLI operations
 - No local RESEARCH.md file is written -- GitHub is the sole source of truth
 - Do NOT show gate confirmation or next steps -- the orchestrator handles those
 </critical_rules>
@@ -30,7 +30,6 @@ The orchestrator provides phase context. Verify we have what we need:
 - `phase_number`, `phase_name`, `phase_dir`, `padded_phase`, `phase_slug`
 - `researcher_model`, `research_enabled`
 - `has_research` (whether a research comment already exists on the phase issue)
-- `state_path`, `roadmap_path`, `requirements_path`
 - `phase_req_ids` (requirement IDs that this phase must address)
 - `phase_issue_number` (GitHub Issue number for the phase)
 - `--force-research` flag presence
@@ -38,7 +37,7 @@ The orchestrator provides phase context. Verify we have what we need:
 ## Step 2: Resolve Researcher Model
 
 ```bash
-RESEARCHER_MODEL=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs resolve-model researcher --raw)
+RESEARCHER_MODEL=$(node .claude/maxsim/bin/maxsim-tools.cjs resolve-model researcher --raw)
 ```
 
 ## Step 3: Check Existing Research
@@ -79,7 +78,7 @@ Return control to orchestrator.
 Fetch the phase issue with all comments to extract context for research scoping:
 
 ```bash
-ISSUE_DATA=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs github get-issue \
+ISSUE_DATA=$(node .claude/maxsim/bin/maxsim-tools.cjs github get-issue \
   --issue-number $PHASE_ISSUE_NUMBER --include-comments)
 ```
 
@@ -228,7 +227,7 @@ TMPFILE=$(mktemp)
 cat > "$TMPFILE" << 'BODY_EOF'
 {consolidated_research_document}
 BODY_EOF
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github post-comment \
+node .claude/maxsim/bin/maxsim-tools.cjs github post-comment \
   --issue-number $PHASE_ISSUE_NUMBER --body-file "$TMPFILE" --type research
 ```
 

--- a/templates/workflows/plan.md
+++ b/templates/workflows/plan.md
@@ -8,9 +8,9 @@ are read or written by this orchestrator. All state is stored as GitHub Issue co
 by HTML markers: <!-- maxsim:type=context -->, <!-- maxsim:type=research -->, <!-- maxsim:type=plan -->.
 
 This file is the ORCHESTRATOR ONLY. Stage-specific logic lives in:
-- @~/.claude/maxsim/workflows/plan-discuss.md  (Discussion stage)
-- @~/.claude/maxsim/workflows/plan-research.md (Research stage)
-- @~/.claude/maxsim/workflows/plan-create.md   (Planning stage)
+- @.claude/maxsim/workflows/plan-discuss.md  (Discussion stage)
+- @.claude/maxsim/workflows/plan-research.md (Research stage)
+- @.claude/maxsim/workflows/plan-create.md   (Planning stage)
 </purpose>
 
 <critical_rules>
@@ -20,7 +20,7 @@ This file is the ORCHESTRATOR ONLY. Stage-specific logic lives in:
 - Plans are posted as GitHub Issue comments with <!-- maxsim:type=plan -->
 - Context is posted as: <!-- maxsim:type=context -->
 - Research is posted as: <!-- maxsim:type=research -->
-- Use `node ~/.claude/maxsim/bin/maxsim-tools.cjs` for all CLI operations
+- Use `node .claude/maxsim/bin/maxsim-tools.cjs` for all CLI operations
 </critical_rules>
 
 <process>
@@ -43,13 +43,12 @@ Use /maxsim:progress to see available phases.
 Load phase state in one call:
 
 ```bash
-INIT=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs init plan-phase "$PHASE")
+INIT=$(node .claude/maxsim/bin/maxsim-tools.cjs init plan-phase "$PHASE")
 ```
 
 Parse JSON for: `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`,
 `padded_phase`, `commit_docs`, `researcher_model`, `planner_model`, `checker_model`,
-`research_enabled`, `plan_checker_enabled`, `state_path`, `roadmap_path`, `requirements_path`,
-`phase_req_ids`, `phase_issue_number`.
+`research_enabled`, `plan_checker_enabled`, `phase_req_ids`, `phase_issue_number`.
 
 **If `phase_found` is false:**
 ```
@@ -59,13 +58,14 @@ Use /maxsim:progress to see available phases.
 ```
 Exit workflow.
 
-## 3. Resolve Model Profile
+## 3. Enter Plan Mode and Resolve Models
+
+Call `EnterPlanMode` before any research or planning steps.
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
-RESEARCHER_MODEL=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs resolve-model researcher --raw)
-PLANNER_MODEL=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs resolve-model planner --raw)
-CHECKER_MODEL=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs resolve-model planner --raw)
+RESEARCHER_MODEL=$(node .claude/maxsim/bin/maxsim-tools.cjs resolve-model researcher --raw)
+PLANNER_MODEL=$(node .claude/maxsim/bin/maxsim-tools.cjs resolve-model planner --raw)
+CHECKER_MODEL=$(node .claude/maxsim/bin/maxsim-tools.cjs resolve-model verifier --raw)
 ```
 
 ## 4. Stage Detection (GitHub-First)
@@ -76,7 +76,7 @@ Detect planning stage by querying the phase GitHub Issue.
 
 If no `phase_issue_number` in init context (phase not yet on GitHub):
 ```bash
-CREATE_RESULT=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs github create-phase \
+CREATE_RESULT=$(node .claude/maxsim/bin/maxsim-tools.cjs github create-phase \
   --phase-number "$PHASE_NUMBER" \
   --phase-name "$PHASE_NAME" \
   --goal "$GOAL" \
@@ -87,7 +87,7 @@ PHASE_ISSUE_NUMBER=$(echo "$CREATE_RESULT" | jq -r '.issue_number')
 
 **Step 4b -- Read issue with comments:**
 ```bash
-ISSUE_DATA=$(node ~/.claude/maxsim/bin/maxsim-tools.cjs github get-issue \
+ISSUE_DATA=$(node .claude/maxsim/bin/maxsim-tools.cjs github get-issue \
   --issue-number $PHASE_ISSUE_NUMBER \
   --include-comments)
 ```
@@ -135,7 +135,7 @@ Wait for user choice via natural conversation.
 
 - **View:** Display contents of each `type=plan` comment from the issue, then re-show options.
 - **Re-plan:** Delete existing plan/context/research comments from the phase issue (use
-  `node ~/.claude/maxsim/bin/maxsim-tools.cjs github delete-comments --issue-number $PHASE_ISSUE_NUMBER --type plan,context,research`),
+  `node .claude/maxsim/bin/maxsim-tools.cjs github delete-comments --issue-number $PHASE_ISSUE_NUMBER --type plan,context,research`),
   reset to Discussion stage (Step 6).
 - **Execute:** Display `/maxsim:execute {phase_number}` and exit.
 - **Done:** Exit workflow.
@@ -144,16 +144,16 @@ Wait for user choice via natural conversation.
 
 Delegate to the discussion sub-workflow for full discussion logic:
 
-@~/.claude/maxsim/workflows/plan-discuss.md
+@.claude/maxsim/workflows/plan-discuss.md
 
 Pass context: `phase_number`, `phase_name`, `phase_dir`, `padded_phase`, `phase_slug`,
-`commit_docs`, `roadmap_path`, `state_path`, `phase_issue_number`.
+`commit_docs`, `phase_issue_number`.
 
 **After discussion completes (context posted as GitHub comment):**
 
 Re-query the phase issue to verify the `type=context` comment now exists:
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github get-issue \
+node .claude/maxsim/bin/maxsim-tools.cjs github get-issue \
   --issue-number $PHASE_ISSUE_NUMBER --include-comments
 ```
 
@@ -181,18 +181,18 @@ Wait for user response via natural conversation.
 
 Delegate to the research sub-workflow:
 
-@~/.claude/maxsim/workflows/plan-research.md
+@.claude/maxsim/workflows/plan-research.md
 
 Pass context: `phase_number`, `phase_name`, `phase_dir`, `padded_phase`, `phase_slug`,
-`commit_docs`, `researcher_model`, `research_enabled`, `has_research`, `state_path`,
-`roadmap_path`, `requirements_path`, `phase_req_ids`, `phase_issue_number`.
+`commit_docs`, `researcher_model`, `research_enabled`, `has_research`,
+`phase_req_ids`, `phase_issue_number`.
 Also pass the `--force-research` flag if present in $ARGUMENTS.
 
 **After research completes (research posted as GitHub comment or already exists):**
 
 Re-query the phase issue to verify the `type=research` comment now exists:
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github get-issue \
+node .claude/maxsim/bin/maxsim-tools.cjs github get-issue \
   --issue-number $PHASE_ISSUE_NUMBER --include-comments
 ```
 
@@ -217,18 +217,18 @@ Wait for user response via natural conversation.
 
 Delegate to the planning sub-workflow:
 
-@~/.claude/maxsim/workflows/plan-create.md
+@.claude/maxsim/workflows/plan-create.md
 
 Pass context: `phase_number`, `phase_name`, `phase_dir`, `padded_phase`, `phase_slug`,
-`commit_docs`, `planner_model`, `checker_model`, `plan_checker_enabled`, `state_path`,
-`roadmap_path`, `requirements_path`, `phase_req_ids`, `phase_issue_number`.
+`commit_docs`, `planner_model`, `checker_model`, `plan_checker_enabled`,
+`phase_req_ids`, `phase_issue_number`.
 Also pass the `--skip-verify` flag if present in $ARGUMENTS.
 
 **After planning completes (plans posted as GitHub comments and task sub-issues created):**
 
 Re-query the phase issue to verify `type=plan` comments exist:
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github get-issue \
+node .claude/maxsim/bin/maxsim-tools.cjs github get-issue \
   --issue-number $PHASE_ISSUE_NUMBER --include-comments
 ```
 
@@ -272,7 +272,7 @@ cat > "$TMPFILE" << 'BODY_EOF'
 **Resume from:** {next_stage}
 **Timestamp:** {ISO timestamp}
 BODY_EOF
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github post-comment \
+node .claude/maxsim/bin/maxsim-tools.cjs github post-comment \
   --issue-number $PHASE_ISSUE_NUMBER --body-file "$TMPFILE" --type checkpoint
 ```
 
@@ -287,16 +287,6 @@ from GitHub and resume from {next_stage}.
 
 Stage detection in Step 4 handles resume automatically -- completed stages produce marker
 comments that are detected on re-entry.
-
-## 10. Update State
-
-After all stages complete:
-
-```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs state record-session \
-  --stopped-at "Phase ${PHASE} planned" \
-  --resume-file "GitHub Issue #${phase_issue_number}"
-```
 
 </process>
 


### PR DESCRIPTION
## Summary

- Replace all `~/.claude/maxsim/` with `.claude/maxsim/` across all four plan workflow files
- Fix `CHECKER_MODEL` to use `resolve-model verifier` instead of `resolve-model planner`
- Add `EnterPlanMode` call at workflow start in `plan.md`
- Remove dead `.planning/config.json` read and `state record-session` call from `plan.md`
- Drop stale `state_path`, `roadmap_path`, `requirements_path` variables from orchestrator pass-context and sub-workflow prerequisites/prompts
- Fix `verification-gates` skill reference to `verification` in `plan-create.md`
- Remove duplicate model resolution step from `plan-create.md` (orchestrator already resolves and passes models)

## Test plan

- [x] E2E grep: `grep -rn "~/.claude/maxsim/\|\.planning/" templates/workflows/plan*.md` returns 0 lines
- [x] Build passes (`npm run build`)
- [x] Unit tests pass (81/81)

🤖 Generated with [Claude Code](https://claude.com/claude-code)