### PR TITLE
docs(website): fix core docs — skills, hooks, models, paths, and content

### DIFF
--- a/packages/website/src/content/docs/agents-overview.md
+++ b/packages/website/src/content/docs/agents-overview.md
@@ -4,9 +4,9 @@ title: How Agents Work
 group: Agents
 ---
 
-MaxsimCLI uses four generic agents: executor, planner, researcher, and verifier. Each agent is a markdown prompt file stored in `~/.claude/agents/`. They are not executable binaries. They are specifications that the AI reads and executes with a fresh context window.
+MaxsimCLI uses four generic agents: executor, planner, researcher, and verifier. Each agent is a markdown prompt file stored in `.claude/agents/`. They are not executable binaries. They are specifications that the AI reads and executes with a fresh context window.
 
-Specialization comes from prompts and preloaded skills, not from having many dedicated agents. The planner agent loads brainstorming and roadmap-writing skills. The researcher loads evidence-collection methodology. The executor loads commit conventions and verification rules. This approach keeps the agent count small while allowing each one to handle a wide range of tasks through its skill set.
+Specialization comes from prompts and preloaded skills, not from having many dedicated agents. The planner agent loads brainstorming and roadmap-writing skills. The researcher loads the research skill. The executor loads commit conventions and verification rules. This approach keeps the agent count small while allowing each one to handle a wide range of tasks through its skill set.
 
 Agents do not spawn subagents. The orchestrator dispatches agents directly. Each agent runs in isolation using worktree mode, with only its specific skills loaded. When an agent finishes, control returns to the orchestrator, which decides what happens next.
 

--- a/packages/website/src/content/docs/agents-reference.md
+++ b/packages/website/src/content/docs/agents-reference.md
@@ -4,7 +4,7 @@ title: Agent Reference
 group: Agents
 ---
 
-{% doctable headers=["Agent", "Role", "Preloaded Skills"] rows=[["executor", "Implements code changes according to the phase plan", "tool-priority-guide, commit-conventions, verification-before-completion"], ["planner", "Creates detailed phase plans from research findings", "brainstorming, sdd, roadmap-writing"], ["researcher", "Investigates codebase and gathers context for planning", "research-methodology, evidence-collection"], ["verifier", "Reviews completed work against spec and quality gates", "code-review, verification-gates, input-validation"]] %}
+{% doctable headers=["Agent", "Role", "Preloaded Skills"] rows=[["executor", "Implements code changes according to the phase plan", "commit-conventions, verification, handoff-contract"], ["planner", "Creates detailed phase plans from research findings", "brainstorming, roadmap-writing, handoff-contract"], ["researcher", "Investigates codebase and gathers context for planning", "research, handoff-contract"], ["verifier", "Reviews completed work against spec and quality gates", "code-review, verification, handoff-contract"]] %}
 {% /doctable %}
 
 All agents follow the same pattern: receive a handoff contract, do focused work with their preloaded skills, produce a structured output, and hand control back to the orchestrator. Agents run in isolation using worktree mode. They never communicate directly with each other. The orchestrator manages all dispatch and sequencing.

--- a/packages/website/src/content/docs/hook-system.md
+++ b/packages/website/src/content/docs/hook-system.md
@@ -6,13 +6,15 @@ group: Advanced
 
 MaxsimCLI installs hooks into your AI runtime's hook system via the `.claude/hooks/` directory. These run automatically without any command. They are background utilities that improve your development experience.
 
-{% doctable headers=["Hook", "Event", "Description"] rows=[["check-update", "Session start", "Checks for new MaxsimCLI version on npm, notifies once per day"], ["statusline", "Every session", "Configures Claude Code status line to show model, task, directory, and context info"], ["notification-sound", "Task completion", "Plays a notification sound when a task completes"], ["stop-sound", "Session stop", "Plays a sound when the session stops"]] %}
+{% doctable headers=["Hook", "Event", "Description"] rows=[["maxsim-check-update", "SessionStart", "Checks for new MaxsimCLI version on npm, notifies once per day"], ["maxsim-statusline", "SessionStart", "Configures Claude Code status line to show model, task, directory, and context info"], ["maxsim-notification-sound", "Notification", "Plays a notification sound when a task completes"], ["maxsim-stop-sound", "Stop", "Plays a sound when the session stops"], ["maxsim-capture-learnings", "Stop", "Captures session learnings to agent memory"]] %}
 {% /doctable %}
 
-The statusline hook reads from STATE.md to show the current task and phase in your terminal prompt. This gives you a quick glance at where MaxsimCLI thinks you are without opening the dashboard.
+The maxsim-statusline hook shows the current task and phase in your terminal prompt. This gives you a quick glance at where MaxsimCLI thinks you are without opening the dashboard.
 
-The check-update hook runs once at session start and checks npm for a newer version of MaxsimCLI. If an update is available, it prints a one-line notification. It checks only once per day to avoid unnecessary network calls.
+The maxsim-check-update hook runs once at session start and checks npm for a newer version of MaxsimCLI. If an update is available, it prints a one-line notification. It checks only once per day to avoid unnecessary network calls.
 
-The notification-sound and stop-sound hooks provide audio feedback so you know when work finishes or a session ends, even if you have switched away from the terminal.
+The maxsim-notification-sound and maxsim-stop-sound hooks provide audio feedback so you know when work finishes or a session ends, even if you have switched away from the terminal.
 
-A `sync-reminder` hook exists in the codebase but is currently a no-op.
+The maxsim-capture-learnings hook runs at session stop and writes any notable findings or decisions from the session into agent memory for future context.
+
+A `maxsim-sync-reminder` hook exists in the codebase but is currently a no-op.

--- a/packages/website/src/content/docs/installation.md
+++ b/packages/website/src/content/docs/installation.md
@@ -25,7 +25,12 @@ MaxsimCLI installs into `.claude/` at your project root:
 ├── commands/maxsim/      # 9 user-facing commands (/maxsim:*)
 ├── agents/               # 4 specialized subagent prompts
 ├── skills/               # 14 reusable skill modules
+├── rules/                # Standing rules loaded into every session
+├── agent-memory/         # Per-agent persistent memory files
+├── settings.json         # Project-level Claude Code settings
+├── settings.local.json   # Local overrides (gitignored)
 └── maxsim/
+    ├── hooks/            # Lifecycle hooks (maxsim-check-update, maxsim-statusline, etc.)
     ├── workflows/        # Workflow orchestration templates
     ├── references/       # Reference documents for agents
     └── templates/        # Document templates

--- a/packages/website/src/content/docs/model-profiles.md
+++ b/packages/website/src/content/docs/model-profiles.md
@@ -6,10 +6,10 @@ group: Configuration
 
 Model profiles control which Claude model each agent uses. Pick a profile that matches your priorities: best results, cost efficiency, or a middle ground.
 
-{% doctable headers=["Agent", "quality", "balanced", "budget", "tokenburner"] rows=[["executor", "opus", "sonnet", "sonnet", "opus"], ["planner", "opus", "opus", "sonnet", "opus"], ["researcher", "opus", "sonnet", "haiku", "opus"], ["verifier", "sonnet", "sonnet", "haiku", "opus"], ["debugger", "sonnet", "sonnet", "haiku", "opus"]] %}
+{% doctable headers=["Agent", "quality", "balanced", "budget"] rows=[["executor", "opus", "sonnet", "sonnet"], ["planner", "opus", "opus", "sonnet"], ["researcher", "sonnet", "sonnet", "haiku"], ["verifier", "opus", "sonnet", "sonnet"]] %}
 {% /doctable %}
 
-The `balanced` profile (default) gives you Opus-quality planning with Sonnet for execution and research. It is a good trade-off between results and cost. The `quality` profile upgrades the executor and researcher to Opus. The `budget` profile uses Sonnet for planning and execution, Haiku for everything else, giving the lowest cost. The `tokenburner` profile uses Opus for every agent: maximum quality, maximum cost.
+The `balanced` profile (default) gives you Opus-quality planning with Sonnet for execution and research. It is a good trade-off between results and cost. The `quality` profile upgrades the executor, planner, and verifier to Opus. The `budget` profile uses Sonnet for planning and execution, Haiku for research, giving the lowest cost.
 
 To switch profiles, use `/maxsim:settings`:
 
@@ -17,5 +17,4 @@ To switch profiles, use `/maxsim:settings`:
 /maxsim:settings profile quality
 /maxsim:settings profile balanced
 /maxsim:settings profile budget
-/maxsim:settings profile tokenburner
 {% /codeblock %}

--- a/packages/website/src/content/docs/quick-start.md
+++ b/packages/website/src/content/docs/quick-start.md
@@ -22,7 +22,7 @@ The core MaxsimCLI workflow follows four steps. Each step is a slash command tha
 /maxsim:execute 1
 {% /codeblock %}
 
-After execution, phase state and decisions are tracked as GitHub Issue comments. You can run `/maxsim:progress` any time to see where you are and what to do next.
+After execution, state persists across multiple surfaces in GitHub: phase decisions and blocker notes are recorded as Issue comments, open/closed Issue status reflects whether a phase is active or complete, milestones track overall project completion percentage, and GitHub Project Board columns show the current workflow stage (Backlog, In Progress, Done). You can run `/maxsim:progress` any time to see where you are and what to do next.
 
 {% callout type="tip" %}
 Run /maxsim:plan before /maxsim:execute. The plan command manages discussion, research, and planning stages, surfacing assumptions and gray areas before you start building.

--- a/packages/website/src/content/docs/what-is-maxsim.md
+++ b/packages/website/src/content/docs/what-is-maxsim.md
@@ -10,6 +10,10 @@ When you work with an AI coding agent for hours, the context window fills up wit
 
 MaxsimCLI solves this by offloading each discrete unit of work to a fresh-context subagent. Instead of one long conversation that degrades over time, you get a series of focused agents: a researcher that knows nothing except the phase it needs to study, an executor that sees only the plan it needs to implement, a verifier that checks only whether the deliverables match the promise. Each agent starts clean, works with full attention, and hands off a structured artifact to the next.
 
+The core structure is a Plan→Execute→Verify cycle. The planner produces a phase plan with explicit deliverables. The executor implements only what the plan specifies. The verifier checks every deliverable against the plan before the phase closes. This cycle enforces quality at each handoff and prevents the model from drifting away from the original intent.
+
+Quality control is built into the cycle through verification gates. A phase cannot close until the verifier confirms all deliverables are met. If verification fails, the phase loops back: the failure is documented, the executor is dispatched again with the failure details, and the verifier checks again. Nothing ships until it passes.
+
 MaxsimCLI is built exclusively for Claude Code. It uses GitHub as its source of truth — phase plans, decisions, blockers, and task state are tracked as GitHub Issues and comments rather than local files.
 
 MaxsimCLI ships as an npm package and installs markdown files (9 commands, 4 agent definitions, 14 skill modules, and workflow templates) into your project's `.claude/` directory. The "runtime" for MaxsimCLI is Claude Code itself. You use it through slash commands like `/maxsim:plan` and `/maxsim:execute`, not through a CLI binary you keep running.


### PR DESCRIPTION
## Summary

- **agents-reference**: replace all pre-merge skill names with current ones (`research`, `verification`, `handoff-contract`); add `handoff-contract` to all four agent rows
- **agents-overview**: fix path from `~/.claude/agents/` to `.claude/agents/` (project-local); fix stale `evidence-collection` reference to `research` skill
- **model-profiles**: remove `tokenburner` profile and `debugger` agent row; fix model assignments for quality (researcher=sonnet, verifier=opus) and budget (verifier=sonnet) profiles
- **hook-system**: add `maxsim-` prefix to all hook names; fix event names to Claude Code identifiers (`SessionStart`, `Notification`, `Stop`); add `maxsim-capture-learnings` hook; remove `STATE.md` reference
- **installation**: add missing file tree entries (`settings.json`, `settings.local.json`, `rules/`, `maxsim/hooks/`, `agent-memory/`)
- **what-is-maxsim**: add Plan→Execute→Verify cycle and verification gates problem framing
- **quick-start**: expand state persistence to cover GitHub Project Board columns, issue open/closed status, and milestone completion

## Test plan

- [x] `grep` for pre-merge skill names in `agents-reference.md` returns 0 matches
- [x] `grep` for `~/.claude/` in `agents-overview.md` returns 0 matches
- [x] Build passes (81 unit tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)