### PR TITLE
fix(workflows): project-local paths, Plan Mode gates, and milestone constraints

### DIFF
--- a/templates/workflows/go.md
+++ b/templates/workflows/go.md
@@ -44,7 +44,7 @@ Gather all signals in parallel for speed. Run these simultaneously:
 **1. Live GitHub project board state (primary source of truth):**
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github status
+node .claude/maxsim/bin/maxsim-tools.cjs github status
 ```
 
 Returns: `phase_number`, `title`, `issue_number`, `total_tasks`, `completed_tasks`, `remaining_tasks`, `status` (GitHub board column: To Do / In Progress / In Review / Done), and any interrupted phase detection.
@@ -87,7 +87,7 @@ Check for problems BEFORE suggesting any action. All problems are blocking — s
 Check if any phase issue is stuck in "In Review" with a verification FAIL comment. Query the current phase issue comments:
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github get-issue --issue-number N --include-comments
+node .claude/maxsim/bin/maxsim-tools.cjs github get-issue --issue-number N --include-comments
 ```
 
 If a FAIL is found:
@@ -165,7 +165,7 @@ Rule 6: All phases status = "Done"?
   -> Reasoning: "All phases complete. Milestone ready for review."
 
 Rule 7: None of the above?
-  -> Action: Show interactive menu (see Step 6)
+  -> Action: Show interactive menu (see Step 7)
   -> Reasoning: "Project state is ambiguous."
 ```
 </step>
@@ -173,7 +173,7 @@ Rule 7: None of the above?
 <step name="show_and_act">
 ## Step 6: Show + Act
 
-Once a rule matches (Rules 1–6), display detection reasoning FIRST, then invoke the Skill tool to run the recommended command. Do NOT ask for confirmation — the user can Ctrl+C if the detection is wrong.
+Once a rule matches (Rules 1–6), call EnterPlanMode, then display detection reasoning and the proposed action. Wait for user approval before proceeding.
 
 **Display format:**
 
@@ -185,10 +185,20 @@ Current phase: Phase {N} — {name} (GitHub Issue #{issue_number})
 GitHub status: {board column}
 Tasks:         {completed}/{total} complete
 
-Action: Running /maxsim:{command} {args}...
+Proposed action: /maxsim:{command} {args}
+
+Proceed?
 ```
 
-Then invoke the Skill tool with the recommended command.
+After the user approves, call ExitPlanMode, then invoke the Skill tool with the recommended command.
+
+**Result reporting:** After the Skill tool completes, print a one-line summary:
+
+```
+Done: /maxsim:{command} {args} completed successfully.
+```
+
+If it fails, print the error and suggest a recovery command.
 </step>
 
 <step name="interactive_menu">
@@ -230,11 +240,12 @@ Wait for user selection, then invoke the Skill tool for the chosen command.
 - No SlashCommand tool — use the Skill tool to invoke commands
 - GitHub Issues is the SOLE source of truth for phase state
 - No local .planning/ directory references anywhere
-- Use `node ~/.claude/maxsim/bin/maxsim-tools.cjs` for all CLI operations
-- Never ask for confirmation before dispatching (Show + Act, not Show + Ask)
+- Use `node .claude/maxsim/bin/maxsim-tools.cjs` for all CLI operations
+- EnterPlanMode must be called before presenting the proposed action; ExitPlanMode must be called after user approves
 - Always surface problems BEFORE suggesting actions
 - All problems are blocking — no warnings, no severity tiers
 - No arguments accepted — this is pure auto-detection
 - Show "Analyzing..." before heavy operations
 - If GitHub is unavailable, fail explicitly — do not fall back to local files
+- Report the result of the dispatched command after it completes
 </constraints>

--- a/templates/workflows/init-existing.md
+++ b/templates/workflows/init-existing.md
@@ -132,7 +132,7 @@ Execute in sequence:
 **4a. Ensure labels:**
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github ensure-labels
+node .claude/maxsim/bin/maxsim-tools.cjs github ensure-labels
 ```
 
 **4b. Create GitHub Project Board:**
@@ -150,7 +150,7 @@ Capture the project number.
 **4c. Store project board number:**
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github set-project --number {PROJECT_NUMBER}
+node .claude/maxsim/bin/maxsim-tools.cjs github set-project --number {PROJECT_NUMBER}
 ```
 
 **4d. Create initial milestone:**
@@ -166,6 +166,8 @@ gh api repos/$REPO/milestones \
 Capture the milestone number.
 
 ## Phase 5: Local Setup
+
+Call EnterPlanMode before writing any local files.
 
 **5a. Write .claude/maxsim/config.json:**
 
@@ -199,12 +201,12 @@ Create `.claude/maxsim/config.json` with:
 **5b. Write or update CLAUDE.md:**
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs install write-claude-md \
+node .claude/maxsim/bin/maxsim-tools.cjs install write-claude-md \
   --project-name "{project_name}" \
   --description "{description}"
 ```
 
-If unavailable, write `.claude/maxsim/PROJECT.md` directly with full project context.
+If unavailable, add the project context to the project root `CLAUDE.md` directly, or create a GitHub Wiki page for persistent reference.
 
 **5c. Commit initialization files:**
 
@@ -212,6 +214,8 @@ If unavailable, write `.claude/maxsim/PROJECT.md` directly with full project con
 git add .claude/
 git commit -m "chore: initialize MAXSIM v6"
 ```
+
+Call ExitPlanMode after committing initialization files.
 
 ## Phase 6: Roadmap (Optional)
 
@@ -263,7 +267,7 @@ After creating all issues, add each to the GitHub Project Board:
   gh project item-add {PROJECT_NUMBER} --owner {OWNER} --url {issue_url}
 
 Set each issue status to 'To Do':
-  node ~/.claude/maxsim/bin/maxsim-tools.cjs github set-status --issue-number {N} --status 'To Do'
+  node .claude/maxsim/bin/maxsim-tools.cjs github set-status --issue-number {N} --status 'To Do'
 
 Return the list of created issue numbers and titles."
 
@@ -292,8 +296,8 @@ Next step: /maxsim:go
 - Tool name is Agent (NOT Task)
 - No SlashCommand tool
 - GitHub Issues is the SOLE source of truth — no local .planning/ directory
-- Use `node ~/.claude/maxsim/bin/maxsim-tools.cjs` for CLI operations
-- EnterPlanMode must be used before any code-modifying execution steps
+- Use `node .claude/maxsim/bin/maxsim-tools.cjs` for CLI operations
+- EnterPlanMode must be called before Phase 5 (local file writes); ExitPlanMode must be called after the commit
 - Agent spawning uses: Agent tool with isolation:"worktree", run_in_background:true (for parallel scan) or run_in_background:false (for sequential roadmap work)
 - Self-contained agent prompts — every agent prompt includes all context it needs inline, no external references
 - Maximum 4 questions per AskUserQuestion call

--- a/templates/workflows/init.md
+++ b/templates/workflows/init.md
@@ -3,8 +3,8 @@ Unified initialization router. Detects current project and repo state, then dele
 
 Routes:
 - Already initialized -> show status, offer reinit
-- GitHub repo exists with code -> @~/.claude/maxsim/workflows/init-existing.md
-- New or empty repo -> @~/.claude/maxsim/workflows/new-project.md
+- GitHub repo exists with code -> .claude/maxsim/workflows/init-existing.md
+- New or empty repo -> .claude/maxsim/workflows/new-project.md
 </purpose>
 
 <process>
@@ -72,7 +72,7 @@ Display:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-Delegate to @~/.claude/maxsim/workflows/new-project.md. Execute that workflow end-to-end. Pass through all $ARGUMENTS.
+Delegate to .claude/maxsim/workflows/new-project.md. Execute that workflow end-to-end. Pass through all $ARGUMENTS.
 
 After completion:
 
@@ -90,7 +90,7 @@ Display:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-Delegate to @~/.claude/maxsim/workflows/init-existing.md. Execute that workflow end-to-end. Pass through all $ARGUMENTS.
+Delegate to .claude/maxsim/workflows/init-existing.md. Execute that workflow end-to-end. Pass through all $ARGUMENTS.
 
 After completion:
 
@@ -106,6 +106,6 @@ Project initialized. Run /maxsim:go to start working.
 - No SlashCommand tool
 - GitHub Issues is the SOLE source of truth
 - No local .planning/ directory references
-- Use `node ~/.claude/maxsim/bin/maxsim-tools.cjs` for CLI operations
+- Use `node .claude/maxsim/bin/maxsim-tools.cjs` for CLI operations
 - Do not inline or duplicate logic from new-project.md or init-existing.md
 </constraints>

--- a/templates/workflows/new-milestone.md
+++ b/templates/workflows/new-milestone.md
@@ -32,8 +32,10 @@ Store as `$MILESTONE_NAME`, `$MILESTONE_DESCRIPTION`, `$MILESTONE_DUE`.
 
 ## Step 2: Create GitHub Milestone
 
+Call EnterPlanMode before creating any GitHub resources.
+
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github create-milestone \
+node .claude/maxsim/bin/maxsim-tools.cjs github create-milestone \
   --title "$MILESTONE_NAME" \
   --description "$MILESTONE_DESCRIPTION" \
   --due-date "$MILESTONE_DUE"
@@ -106,7 +108,7 @@ For each phase, run `github create-phase` sequentially:
 
 ```bash
 # For each phase (1-indexed):
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github create-phase \
+node .claude/maxsim/bin/maxsim-tools.cjs github create-phase \
   --phase-number "[N]" \
   --phase-name "[Phase Name]" \
   --goal "[Phase Goal]" \
@@ -118,12 +120,14 @@ Track results. If any creation fails, warn and provide the manual creation comma
 After all phases are created, add each issue to the project board in the "To Do" column:
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github move-issue \
+node .claude/maxsim/bin/maxsim-tools.cjs github set-status \
   --issue-number [ISSUE_NUM] \
   --status "To Do"
 ```
 
 ---
+
+Call ExitPlanMode after all phase issues are created and added to the board.
 
 ## Step 5: Display completion summary
 
@@ -159,3 +163,12 @@ Start planning the first phase:
 - [ ] All phase issues added to project board as "To Do"
 - [ ] Summary displayed with issue numbers and next step
 </success_criteria>
+
+<constraints>
+- Tool name is Agent (NOT Task)
+- GitHub Issues is the SOLE source of truth — no local planning files are created
+- EnterPlanMode must be used before creating any GitHub resources
+- ExitPlanMode must be called after all GitHub resources are created
+- Use `node .claude/maxsim/bin/maxsim-tools.cjs` for CLI operations
+- Use `github set-status` (not `github move-issue`) to set board column status
+</constraints>

--- a/templates/workflows/new-project.md
+++ b/templates/workflows/new-project.md
@@ -134,7 +134,7 @@ Execute in sequence:
 **4a. Ensure labels:**
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github ensure-labels
+node .claude/maxsim/bin/maxsim-tools.cjs github ensure-labels
 ```
 
 This creates the standard MAXSIM label set (phase:N, status:*, priority:*, bug, etc.).
@@ -154,7 +154,7 @@ Capture the project number from the output.
 **4c. Store project board number in config:**
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github set-project --number {PROJECT_NUMBER}
+node .claude/maxsim/bin/maxsim-tools.cjs github set-project --number {PROJECT_NUMBER}
 ```
 
 **4d. Create initial milestone:**
@@ -168,6 +168,8 @@ gh api repos/$REPO/milestones \
 ```
 
 ## Phase 5: Local Setup
+
+Call EnterPlanMode before writing any local files.
 
 **5a. Write .claude/maxsim/config.json:**
 
@@ -197,12 +199,12 @@ Create `.claude/maxsim/config.json` with:
 Use the install system to write project-level CLAUDE.md context:
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs install write-claude-md \
+node .claude/maxsim/bin/maxsim-tools.cjs install write-claude-md \
   --project-name "{project_name}" \
   --description "{description}"
 ```
 
-If the command is unavailable, write `.claude/maxsim/PROJECT.md` directly with the full project context gathered in the interview phase.
+If the command is unavailable, add the project context to the project root `CLAUDE.md` directly, or create a GitHub Wiki page for persistent reference.
 
 **5c. Commit initialization files:**
 
@@ -210,6 +212,8 @@ If the command is unavailable, write `.claude/maxsim/PROJECT.md` directly with t
 git add .claude/
 git commit -m "chore: initialize MAXSIM v6"
 ```
+
+Call ExitPlanMode after committing initialization files.
 
 ## Phase 6: Roadmap (Optional)
 
@@ -246,7 +250,7 @@ After creating all issues, add each one to the GitHub Project Board:
 gh project item-add {PROJECT_NUMBER} --owner {OWNER} --url {issue_url}
 
 Set each issue status to 'To Do' on the board using:
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github set-status --issue-number {N} --status 'To Do'
+node .claude/maxsim/bin/maxsim-tools.cjs github set-status --issue-number {N} --status 'To Do'
 
 Return the list of created issue numbers and titles."
 
@@ -274,8 +278,8 @@ Next step: /maxsim:go
 - Tool name is Agent (NOT Task)
 - No SlashCommand tool
 - GitHub Issues is the SOLE source of truth — no local .planning/ directory
-- Use `node ~/.claude/maxsim/bin/maxsim-tools.cjs` for CLI operations
-- EnterPlanMode must be used before any code-modifying execution steps
+- Use `node .claude/maxsim/bin/maxsim-tools.cjs` for CLI operations
+- EnterPlanMode must be called before Phase 5 (local file writes); ExitPlanMode must be called after the commit
 - Agent spawning uses: Agent tool with isolation:"worktree", run_in_background:true (for parallel research) or run_in_background:false (for sequential work)
 - Self-contained agent prompts — include all context the agent needs inline
 - Maximum 4 questions per AskUserQuestion call


### PR DESCRIPTION
## Summary

- Replace all `~/.claude/maxsim/` with `.claude/maxsim/` across `go.md`, `init.md`, `init-existing.md`, `new-project.md`, `new-milestone.md` (project-local, not global)
- Remove `@` prefix from workflow references in `init.md` (spec prohibits `@` imports)
- Add `EnterPlanMode`/`ExitPlanMode` gates to `go.md` (call before presenting proposed action, exit after user approves); add result-reporting step
- Add `EnterPlanMode` before Phase 5 and `ExitPlanMode` after commit in `init-existing.md` and `new-project.md`; update constraints to match
- Remove `.claude/maxsim/PROJECT.md` fallback in Phase 5b — write to project root `CLAUDE.md` or GitHub Wiki instead
- Add `<constraints>` block to `new-milestone.md` (was the only workflow without one); includes Tool-name, GitHub-as-truth, Plan Mode, and `set-status` rules
- Fix `github move-issue` to `github set-status` in `new-milestone.md` for consistency
- Fix decision tree Rule 7 cross-reference: was "see Step 6", now correctly "see Step 7"

## Test plan

- [x] `grep -rn "~/.claude/maxsim/"` on all five files returns 0 matches
- [x] `grep -n "@~/"` on `init.md`, `init-existing.md`, `new-project.md` returns 0 matches
- [x] `EnterPlanMode` and `ExitPlanMode` present in all four modified workflow files
- [x] `github move-issue` no longer appears as a command in `new-milestone.md`
- [x] `<constraints>` block present in `new-milestone.md`
- [x] All 81 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)