### PR TITLE
docs(website): replace .planning/ references with GitHub as source of truth

### DIFF
--- a/packages/website/src/content/docs/branching-strategies.md
+++ b/packages/website/src/content/docs/branching-strategies.md
@@ -4,23 +4,26 @@ title: Branching Strategies
 group: Configuration
 ---
 
-MaxsimCLI can manage git branches automatically during execution. Set `branching_strategy` in config.json to one of three options.
+MaxsimCLI manages git branches automatically. There is no user-configurable branching strategy — branches are created per task, not per phase or milestone.
 
-{% doctable headers=["Strategy", "Branch created", "Template"] rows=[["none", "All work on current branch (default)", "N/A"], ["phase", "One branch per phase", "maxsim/phase-{phase}-{slug}"], ["milestone", "One branch per milestone", "maxsim/{milestone}-{slug}"]] %}
-{% /doctable %}
+### Automatic worktree branches
 
-{% codeblock language="json" %}
-{
-  "branching_strategy": "phase",
-  "phase_branch_template": "maxsim/phase-{phase}-{slug}",
-  "milestone_branch_template": "maxsim/{milestone}-{slug}"
-}
+Every task executed by `/maxsim:execute` gets its own git worktree and branch. The branch name follows a fixed template:
+
+{% codeblock language="text" %}
+maxsim/phase-{N}-task-{id}
 {% /codeblock %}
 
-With `phase` branching, the executor creates a branch from the template before execution and leaves it for you to review and merge. The `{phase}` placeholder is replaced with the phase number. `{slug}` is replaced with a sanitized version of the phase name. With `milestone` branching, the branch spans all phases in the milestone. `{milestone}` is replaced with the milestone identifier.
+For example, task 3 in phase 2 runs on branch `maxsim/phase-2-task-3` inside a worktree at `.maxsim-worktrees/{taskId}/`. Parallel tasks in the same wave each get their own branch and worktree, so they never conflict.
 
-You can customize the branch name templates by setting `phase_branch_template` or `milestone_branch_template` in config.json. The default templates shown above work for most projects.
+### Automatic merge after verification
+
+When verification passes for a task, MaxsimCLI merges the task branch into the base branch and removes the worktree automatically. You do not need to merge branches manually. If verification fails, the branch is retained so you can inspect the work.
+
+### No configuration required
+
+There is no `branching_strategy` field in config.json. The worktree-per-task model is always active unless you pass `--no-worktrees` to `/maxsim:execute`, in which case all work runs on the current branch.
 
 {% callout type="note" %}
-Branching strategies require a clean working tree before execution. MaxsimCLI will warn you if there are uncommitted changes that would block branch creation.
+Worktree creation requires a clean working tree. MaxsimCLI will warn you if uncommitted changes would block worktree setup.
 {% /callout %}

--- a/packages/website/src/content/docs/codebase-mapping.md
+++ b/packages/website/src/content/docs/codebase-mapping.md
@@ -13,7 +13,7 @@ Codebase mapping runs automatically as part of the `/maxsim:init --existing` wor
 /maxsim:init --existing
 {% /codeblock %}
 
-Multiple codebase-mapper agents run in parallel, each covering a different area of the codebase. One covers data models, another covers API routes, another covers frontend components, another covers infrastructure. Their outputs are synthesized into a unified analysis in `.planning/codebase/`.
+Multiple codebase-mapper agents run in parallel, each covering a different area of the codebase. One covers data models, another covers API routes, another covers frontend components, another covers infrastructure. Their outputs are synthesized into a unified analysis stored in the GitHub Wiki and cached in `.claude/agent-memory/` for fast agent access.
 
 The codebase analysis is loaded automatically by phase-researcher agents. When planning a phase in an existing codebase, the researcher reads the analysis to understand existing patterns, conventions, and potential integration points instead of re-discovering them from scratch.
 

--- a/packages/website/src/content/docs/debug-sessions.md
+++ b/packages/website/src/content/docs/debug-sessions.md
@@ -4,7 +4,7 @@ title: Debug Sessions
 group: Advanced
 ---
 
-`/maxsim:debug` runs the debugger agent with persistent state. Unlike a regular conversation, debugging state is written to a file after each step. If the context window fills up, you can start a fresh session and continue from where you stopped.
+`/maxsim:debug` runs the debugger agent with persistent state. Unlike a regular conversation, debugging state is written after each step so that if the context window fills up, you can start a fresh session and continue from where you stopped.
 
 {% codeblock language="bash" %}
 # Start a debug session
@@ -16,6 +16,8 @@ group: Advanced
 
 The `--hierarchical` flag is designed for bugs that span multiple layers of the stack. It decomposes the problem into sub-investigations, each tracked separately, and synthesizes findings across layers to identify root causes that would not be visible from any single layer.
 
-The debugger uses a scientific method approach: it forms a hypothesis, tests it, records the result, and forms the next hypothesis based on evidence. Each step is committed to the debug state file. If the issue spans multiple sessions, the next session reads the existing state and continues the investigation.
+The debugger uses a scientific method approach: it forms a hypothesis, tests it, records the result, and forms the next hypothesis based on evidence. Each step is persisted so that the next session can continue the investigation.
 
-Debugging state is stored in `.planning/debug/`. Each debug session has a slug derived from the issue description. You can have multiple concurrent debug sessions for different issues.
+### Debugging state storage
+
+Debugging state is stored as a GitHub Issue with label `debug`, or in `.claude/agent-memory/` for offline sessions. Each debug session has a slug derived from the issue description. You can have multiple concurrent debug sessions for different issues — each gets its own Issue or memory file. The session record includes the hypothesis log, evidence gathered, and current investigation position.

--- a/packages/website/src/content/docs/execute-phase.md
+++ b/packages/website/src/content/docs/execute-phase.md
@@ -4,7 +4,7 @@ title: Execute Phase
 group: Workflow
 ---
 
-`/maxsim:execute` is the core execution engine. It reads all PLAN.md files for a phase, groups them by wave, and runs each wave's plans in parallel using isolated worktrees.
+`/maxsim:execute` is the core execution engine. It reads task sub-Issues from the GitHub phase Issue, groups them by wave, and runs each wave's tasks in parallel using isolated worktrees.
 
 {% codeblock language="bash" %}
 /maxsim:execute
@@ -16,17 +16,27 @@ group: Workflow
 /maxsim:execute --worktrees
 {% /codeblock %}
 
-By default, execution runs parallel agents in isolated git worktrees. Each agent gets its own working directory, so agents never conflict with each other or your main checkout. Use `--no-worktrees` if your project setup requires all work to happen in the main tree.
+### Plan Mode approval gate
 
-Each executor agent works atomically: it commits after every completed task, writes a SUMMARY.md when all tasks finish, and updates STATE.md with decisions and metrics. Auto-verify runs at the end of execution to validate deliverables against success criteria.
+Before any code is written, `/maxsim:execute` enters Plan Mode (`EnterPlanMode`). The orchestrator presents the full execution plan — tasks, wave grouping, file targets — and waits for your approval. Only after you approve does execution begin (`ExitPlanMode`). This gate prevents agents from taking actions you did not intend.
 
-Deviation handling is built into the executor. When it encounters bugs, missing error handling, or blocking issues, it auto-fixes them (Rules 1-3) without asking for permission. When it encounters architectural decisions or new tables, it pauses and returns a structured checkpoint for you to review (Rule 4). All deviations are documented in SUMMARY.md.
+### Worktree branches
+
+By default, execution runs parallel agents in isolated git worktrees. Each worktree is created at `.maxsim-worktrees/{taskId}/` with a dedicated branch named `maxsim/phase-{N}-task-{id}`. Agents never conflict with each other or your main checkout. After verification passes, the branch is merged automatically and the worktree removed. Use `--no-worktrees` if your project setup requires all work to happen in the main tree.
+
+Each executor agent works atomically: it commits after every completed task, posts a progress comment on the task's GitHub Issue, and updates the phase Issue with decisions and metrics. Auto-verify runs at the end of execution to validate deliverables against success criteria.
+
+### Retry logic
+
+If a task fails, the executor retries up to 3 times before escalating. Each retry is logged as a comment on the task's GitHub Issue. After 3 failed attempts, the task is flagged for human review and execution continues with the remaining tasks in the wave.
+
+Deviation handling is built into the executor. When it encounters bugs, missing error handling, or blocking issues, it auto-fixes them (Rules 1-3) without asking for permission. When it encounters architectural decisions or new tables, it pauses and returns a structured checkpoint for you to review (Rule 4). All deviations are documented in a comment on the phase GitHub Issue.
 
 ### Deviation rules
 
-{% doctable headers=["Rule", "Trigger", "Action"] rows=[["Rule 1", "Code doesn't work as intended", "Auto-fix inline, track in SUMMARY"], ["Rule 2", "Missing critical functionality (auth, validation)", "Auto-add, track in SUMMARY"], ["Rule 3", "Something blocks task completion", "Auto-fix blocker, track in SUMMARY"], ["Rule 4", "Architectural change required", "STOP — return checkpoint for human decision"]] %}
+{% doctable headers=["Rule", "Trigger", "Action"] rows=[["Rule 1", "Code doesn't work as intended", "Auto-fix inline, log in phase Issue comment"], ["Rule 2", "Missing critical functionality (auth, validation)", "Auto-add, log in phase Issue comment"], ["Rule 3", "Something blocks task completion", "Auto-fix blocker, log in phase Issue comment"], ["Rule 4", "Architectural change required", "STOP — return checkpoint for human decision"]] %}
 {% /doctable %}
 
 {% callout type="note" %}
-Wave parallelization requires Claude's subagent features. If your runtime doesn't support parallel subagents, plans execute sequentially in wave order.
+Wave parallelization requires Claude's subagent features. If your runtime doesn't support parallel subagents, tasks execute sequentially in wave order.
 {% /callout %}

--- a/packages/website/src/content/docs/milestones.md
+++ b/packages/website/src/content/docs/milestones.md
@@ -15,7 +15,7 @@ Milestones group phases into shippable deliverables. The milestone lifecycle (cr
 
 ### Milestone lifecycle
 
-{% doctable headers=["Operation", "What Happens"] rows=[["New milestone", "Adds a new milestone to ROADMAP.md with placeholder phases"], ["Audit milestone", "Reads all phase SUMMARYs and requirements, identifies unmet deliverables"], ["Plan gaps", "Creates one new phase per gap with full PLAN.md files ready to execute"], ["Complete milestone", "Archives milestone phases and advances to the next milestone"]] %}
+{% doctable headers=["Operation", "What Happens"] rows=[["New milestone", "Creates a GitHub Milestone and links placeholder phase Issues to it"], ["Audit milestone", "Reads all phase completion comments and the GitHub Wiki requirements page, identifies unmet deliverables"], ["Plan gaps", "Creates one new phase Issue per gap with task sub-Issues ready to execute"], ["Complete milestone", "Closes all phase Issues under the milestone and marks the GitHub Milestone as complete"]] %}
 {% /doctable %}
 
-The audit reads all phase SUMMARY.md files and original REQUIREMENTS.md entries for the milestone. It then identifies unmet requirements, partially implemented features, and missing deliverables. The result is a structured audit report that feeds directly into gap planning.
+The audit reads phase completion comments on each GitHub Issue and the original requirements from the GitHub Wiki requirements page for the milestone. It then identifies unmet requirements, partially implemented features, and missing deliverables. The result is a structured audit report written as a GitHub Issue comment that feeds directly into gap planning.

--- a/packages/website/src/content/docs/phases.md
+++ b/packages/website/src/content/docs/phases.md
@@ -4,9 +4,9 @@ title: Phases
 group: Core Concepts
 ---
 
-A phase is a cohesive unit of work that advances the project toward a milestone. Phases are defined in ROADMAP.md and tracked in STATE.md. Each phase contains one or more plans. A plan is a specific task breakdown for one workstream within the phase.
+A phase is a cohesive unit of work that advances the project toward a milestone. Phases are defined as GitHub Issues with label `type:phase` and tracked on the GitHub Project Board. Each phase contains one or more task sub-Issues. A task is a specific unit of work within the phase.
 
-Phases have a lifecycle: planned, researched, executing, complete. The lifecycle is tracked in ROADMAP.md with status symbols. You can query current status any time with `/maxsim:progress`.
+Phases have a lifecycle: planned, researched, executing, complete. The lifecycle is tracked via GitHub Issue labels and Project Board column position. You can query current status any time with `/maxsim:progress`.
 
 ### Phase numbering
 
@@ -20,8 +20,9 @@ Sort order is: 01 < 01A < 01B < 01.1 < 01.2 < 02. The `normalizePhaseName()` fun
 ### Phase lifecycle
 
 {% codeblock language="text" %}
-planned     → Phase exists in ROADMAP.md, not yet researched
-researched  → /maxsim:plan has run, RESEARCH.md and PLAN.md exist
-executing   → /maxsim:execute is in progress
-complete    → All plans have SUMMARY.md, verification passed
+planned     → Phase Issue exists on Project Board (Backlog column)
+researched  → Discussion and research comments posted on phase Issue (To Do column)
+executing   → Executor agents running (In Progress column)
+complete    → All task sub-Issues closed, verification passed, phase completion
+              comment written on the GitHub Issue (Done column)
 {% /codeblock %}

--- a/packages/website/src/content/docs/plan-phase.md
+++ b/packages/website/src/content/docs/plan-phase.md
@@ -10,6 +10,10 @@ group: Workflow
 /maxsim:plan 1
 {% /codeblock %}
 
+### Plan Mode approval gate
+
+Before planning output is finalized, `/maxsim:plan` enters Plan Mode (`EnterPlanMode`). The planner presents the proposed task breakdown — Issues, acceptance criteria, wave grouping, dependencies — and waits for your explicit approval before writing anything to GitHub. Approve to proceed or reject to send the planner back for revisions. `ExitPlanMode` fires only when you approve. This gate applies to each stage: discussion, research, and planning each have their own approval step.
+
 ### Discussion stage
 
 The discussion agent reads your roadmap and phase context from GitHub, then asks targeted questions about the phase. Questions adapt based on your answers. If you mention a third-party API, it asks about rate limits and authentication. If you mention real-time features, it asks about WebSocket vs. polling tradeoffs. Discussion output is written as a comment on the phase GitHub Issue.

--- a/packages/website/src/content/docs/planning-directory.md
+++ b/packages/website/src/content/docs/planning-directory.md
@@ -1,35 +1,59 @@
 ---
 id: planning-directory
-title: Planning Directory
+title: GitHub Project Board
 group: Core Concepts
 ---
 
-Every MaxsimCLI project has a `.planning/` directory at the project root. This directory is the persistent memory of your project. It stores everything from the initial vision through per-task execution summaries.
+The GitHub Project Board is MaxsimCLI's persistent memory. There are no local planning files. GitHub is the sole source of truth for project state, phase plans, research findings, decisions, and progress.
 
-{% codeblock language="text" %}
-.planning/
-├── config.json              # model_profile, workflow flags, branching strategy
-├── PROJECT.md               # Vision document (always loaded by agents)
-├── REQUIREMENTS.md          # v1/v2/out-of-scope requirements with traceability
-├── ROADMAP.md               # Phase structure with milestone groupings
-├── STATE.md                 # Live memory: decisions, blockers, metrics, progress
-├── phases/
-│   └── 01-Foundation/
-│       ├── 01-CONTEXT.md        # Decisions made in discuss-phase
-│       ├── 01-RESEARCH.md       # Phase research findings
-│       ├── 01-01-PLAN.md        # First plan (numbered per attempt)
-│       ├── 01-01-SUMMARY.md     # Completion record with deviations
-│       ├── 01-VERIFICATION.md   # Post-execution verification results
-│       └── 01-UAT.md            # User acceptance test transcript
-└── todos/
-    ├── pending/                 # Active todo items
-    └── completed/               # Archived todos
+### Kanban columns
+
+The Project Board uses a five-column Kanban layout that mirrors the phase lifecycle:
+
+{% doctable headers=["Column", "Meaning"] rows=[["Backlog", "Phases defined but not yet started"], ["To Do", "Phases ready to execute — plan approved"], ["In Progress", "Phases currently being executed by agents"], ["In Review", "Execution complete — verification running or awaiting review"], ["Done", "Verification passed — phase closed"]] %}
+{% /doctable %}
+
+Moving an Issue between columns is how MaxsimCLI tracks progress. Agents update column position automatically as they work. You can move Issues manually in GitHub when you make decisions outside the normal flow.
+
+### Issues as phase and task records
+
+Each phase is a GitHub Issue with label `type:phase`. Each task within a phase is a sub-Issue linked to the phase Issue. The Issue body holds the phase description, deliverables, and success criteria. Labels carry status (`status:planned`, `status:executing`, `status:complete`) and type metadata.
+
+### Comments as persistent context
+
+All agent-written context lives in Issue comments. A phase Issue accumulates comments over its lifetime:
+
+{% codeblock language="markdown" %}
+<!-- Discussion agent writes: -->
+## Discussion — Phase 02
+
+Q: Will the API require authentication on all routes?
+A: Yes, JWT with refresh tokens.
+
+---
+
+<!-- Research agent writes: -->
+## Research Findings — Phase 02
+
+Existing auth middleware at src/middleware/auth.ts uses jose 4.x.
+Recommend extending rather than replacing.
+
+---
+
+<!-- Executor agent writes: -->
+## Session Update — 2026-02-15
+
+**Current Position:** task 3 of 7
+**Completed:** JWT middleware
+**Next:** refresh endpoint
 {% /codeblock %}
 
-The `config.json` file controls model selection, workflow agent toggles, and branching strategy. PROJECT.md is loaded into every agent context automatically. It is the one document that every agent reads.
+Each new agent session reads the full comment thread before starting. This is how context survives across sessions, context-window resets, and team handoffs.
 
-Phase directories are named `NN-Name` (e.g., `01-Foundation`). Files within them use the phase number as prefix. This naming scheme makes the directory scannable and supports the decimal gap-closure phases (01.1, 01.2) that verification creates.
+### Milestones group phases
+
+GitHub Milestones group related phase Issues into shippable deliverables. The Milestone completion percentage (open vs. closed Issues) is the roadmap progress indicator. When all phase Issues in a Milestone are closed and verified, the Milestone is marked complete.
 
 {% callout type="tip" %}
-Commit your .planning/ directory to git. It is the institutional memory of your project. SUMMARY.md files, decisions in STATE.md, and RESEARCH.md files are all valuable artifacts that should be versioned alongside your code.
+You never need to create or edit local planning files. Any local planning directory left over from a previous version of MaxsimCLI should be removed. GitHub is the only place project state lives.
 {% /callout %}

--- a/packages/website/src/content/docs/project-state.md
+++ b/packages/website/src/content/docs/project-state.md
@@ -6,7 +6,14 @@ group: Core Concepts
 
 GitHub Issues and comments are MaxsimCLI's cross-session memory. Every agent writes decisions, blockers, and progress notes as comments on the relevant phase Issue. Every orchestrator reads GitHub before starting a new session. It answers the question: "where are we and why did we make the decisions we made?"
 
-Phase Issues track four categories of information: decisions (architectural choices and the reasoning behind them), blockers (unresolved issues that need human input), performance metrics (task counts, duration, file counts per plan), and current position (which task was last active, what the next action is).
+### State model
+
+Project state is derived entirely from GitHub — there are no local state files:
+
+{% doctable headers=["State dimension", "GitHub source"] rows=[["Phase status", "Project Board column position (Backlog / To Do / In Progress / In Review / Done)"], ["Task progress", "Open vs. closed task sub-Issues on the phase Issue"], ["Roadmap progress", "GitHub Milestone completion percentage (open vs. closed phase Issues)"], ["Decisions and context", "Comments on phase and task Issues"], ["Requirements", "GitHub Wiki requirements page for the milestone"], ["Discussions", "GitHub Discussions for open questions and architectural decisions"]] %}
+{% /doctable %}
+
+Phase Issues track four categories of information: decisions (architectural choices and the reasoning behind them), blockers (unresolved issues that need human input), performance metrics (task counts, duration, file counts per task), and current position (which task was last active, what the next action is).
 
 {% codeblock language="markdown" %}
 <!-- Example phase Issue comment written by an executor agent -->

--- a/packages/website/src/content/docs/verify-work.md
+++ b/packages/website/src/content/docs/verify-work.md
@@ -4,17 +4,28 @@ title: Verify Work
 group: Workflow
 ---
 
-Verification is built into `/maxsim:execute` and runs automatically after execution completes. The verifier reads ROADMAP.md and all SUMMARY.md files for the phase, then checks each deliverable against the original plan's success criteria.
+Verification is built into `/maxsim:execute` and runs automatically after execution completes. The verifier reads the GitHub phase Issue and all task sub-Issues, then checks each deliverable against the original success criteria.
 
 You do not need to run verification manually in most cases. When you use `/maxsim:execute` or `/maxsim:go`, verification happens as part of the workflow.
+
+### Verification checks
+
+Every verification run performs six checks:
+
+{% doctable headers=["Check", "Pass Condition"] rows=[["Tests pass", "All test suites exit 0"], ["Build succeeds", "Production build completes without errors"], ["Lint clean", "No lint errors (warnings allowed)"], ["Spec compliance", "All deliverables listed in the phase Issue are accounted for"], ["Code review", "Parallel reviewer agents find no blocking issues"], ["Evidence block", "Verifier writes a structured CLAIM/EVIDENCE/OUTPUT/VERDICT block as a GitHub Issue comment"]] %}
+{% /doctable %}
+
+The evidence block format records what was claimed, what evidence was gathered, what output was observed, and the final verdict. This block becomes part of the permanent phase record on the GitHub Issue.
+
+### Retry logic and Guard pattern
+
+If verification fails, the executor retries the failing tasks up to 3 attempts before creating gap sub-phases. The Guard pattern runs a final check after each retry: if the same check fails twice in a row, the executor stops retrying and creates a gap phase Issue instead of looping indefinitely.
+
+For every broken item found beyond the retry limit, verification creates a decimal fix phase Issue. If phase 1 has two broken items, you get phase Issues 1.1 and 1.2, each with focused task sub-Issues. Run `/maxsim:execute` to close the gaps, then verification confirms the fix.
 
 ### Manual verification
 
 If you need to re-verify a phase independently, the verify workflow is available as a standalone option. This is useful when you want to re-check after manual changes or after closing gaps outside the normal execution flow.
-
-Verification runs in two passes. First, the integration checker validates that cross-phase connections are intact: APIs that phase 2 depends on were correctly built in phase 1. Second, the verifier runs a UAT-style session where it exercises actual functionality and records pass/fail against specific acceptance criteria.
-
-For every broken item found, verification creates a decimal fix phase. If phase 1 has two broken items, you get phases 1.1 and 1.2, each with its own focused PLAN.md. Run `/maxsim:execute` to close the gaps, then verification confirms the fix.
 
 {% callout type="tip" %}
 Auto-verify catches integration issues that individual executor tests miss, especially cross-phase contract violations and edge cases in user flows that were not explicitly specified.


### PR DESCRIPTION
## Summary

- Rewrites `planning-directory.md` from a description of the `.planning/` directory into a page about the GitHub Project Board as the project's persistent memory (Kanban columns, Issues, Comments, Milestones)
- Updates `phases.md`, `milestones.md`, `execute-phase.md`, `verify-work.md`, `debug-sessions.md`, `branching-strategies.md`, `codebase-mapping.md`, `project-state.md`, and `plan-phase.md` to remove all `.planning/` file references and replace them with GitHub equivalents
- Adds Plan Mode approval gate documentation to `execute-phase.md` and `plan-phase.md`, worktree branch naming (`maxsim/phase-{N}-task-{id}`), retry logic, the six-check verification table, Guard pattern, and the full state model table

## Test plan

- [x] E2E grep check: `grep -rn "\.planning/"` across all 8 targeted files returns 0 results (excluding explanatory "must not/does NOT/abolished" context)
- [x] Build passes (`npm run build`)
- [x] All 81 unit tests pass
- [x] Lint clean (only pre-existing style infos, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)