### PR TITLE
fix(github): resolve critical audit findings in GitHub integration module

### DIFF
--- a/packages/cli/src/github/client.ts
+++ b/packages/cli/src/github/client.ts
@@ -110,7 +110,7 @@ export function ghJson<T>(args: string[]): GhResult<T> {
     try {
       return { ok: true, data: JSON.parse(stdout) as T };
     } catch {
-      return { ok: true, data: stdout.trim() as unknown as T };
+      return { ok: false, error: 'Unexpected non-JSON response', code: 'UNKNOWN' };
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -159,7 +159,10 @@ export async function withGhResult<T>(
 
     if (status === 404) return { ok: false, error: msg, code: 'NOT_FOUND' };
     if (status === 401) return { ok: false, error: msg, code: 'UNAUTHORIZED' };
-    if (status === 403) return { ok: false, error: msg, code: 'RATE_LIMITED' };
+    if (status === 403) {
+      const code = msg.toLowerCase().includes('rate limit') ? 'RATE_LIMITED' : 'FORBIDDEN';
+      return { ok: false, error: msg, code };
+    }
     if (status === 422) return { ok: false, error: msg, code: 'VALIDATION' };
 
     return { ok: false, error: msg, code: 'UNKNOWN' };

--- a/packages/cli/src/github/comments.ts
+++ b/packages/cli/src/github/comments.ts
@@ -135,7 +135,7 @@ export function formatIssueState(state: MaxsimIssueState): string {
 export function formatCommentHeader(meta: MaxsimCommentMeta): string {
   const entries = Object.entries(meta)
     .filter(([k]) => k !== 'type')
-    .map(([k, v]) => `${k}=${v}`)
+    .map(([k, v]) => /^\w+$/.test(String(v)) ? `${k}=${v}` : `${k}="${v}"`)
     .join(' ');
   return `<!-- maxsim:type=${meta.type}${entries ? ` ${entries}` : ''} -->`;
 }

--- a/packages/cli/src/github/index.ts
+++ b/packages/cli/src/github/index.ts
@@ -18,7 +18,7 @@ export {
 
 // Issues
 export {
-  getIssueIds, createIssue, getIssue, updateIssue,
+  listIssues, createIssue, getIssue, updateIssue,
   listComments, addComment, addSubIssue, listSubIssues, closeIssue,
 } from './issues.js';
 
@@ -26,15 +26,15 @@ export {
 export {
   createProject, listProjects, findProject,
   listProjectFields, getStatusField, getFieldOptionId,
-  addItemToProject, moveItemToStatus, setItemNumberField,
+  addItemToProject, moveItemToStatus, listItems,
   ensureProjectBoard,
 } from './projects.js';
 
 // Milestones
 export {
   createMilestone, listMilestones, findMilestone,
-  ensureMilestone, updateMilestone,
+  ensureMilestone, updateMilestone, deleteMilestone,
 } from './milestones.js';
 
 // Labels
-export { ensureLabels, getLabel, createLabel } from './labels.js';
+export { ensureLabels, getLabel, createLabel, updateLabel } from './labels.js';

--- a/packages/cli/src/github/issues.ts
+++ b/packages/cli/src/github/issues.ts
@@ -4,7 +4,7 @@
  */
 
 import { getOctokit, getRepoInfo, withGhResult } from './client.js';
-import type { GhIssue, GhComment, GhResult, IssueIds, RepoInfo } from './types.js';
+import type { GhIssue, GhComment, GhResult, RepoInfo } from './types.js';
 
 /** Map Octokit issue response to our GhIssue type. */
 function mapIssue(raw: Record<string, unknown>): GhIssue {
@@ -54,22 +54,29 @@ function mapIssue(raw: Record<string, unknown>): GhIssue {
   };
 }
 
-/** Get all three ID forms for an issue. */
-export async function getIssueIds(issueNumber: number, repo?: RepoInfo): Promise<GhResult<IssueIds>> {
+/** List issues in the repository with optional filtering. */
+export async function listIssues(
+  params: {
+    state?: 'open' | 'closed' | 'all';
+    labels?: string;
+    milestone?: number;
+  } = {},
+  repo?: RepoInfo,
+): Promise<GhResult<GhIssue[]>> {
   const { owner, repo: repoName } = repo ?? getRepoInfo();
   const octokit = getOctokit();
 
   return withGhResult(async () => {
-    const { data } = await octokit.rest.issues.get({
+    const issues = await octokit.paginate(octokit.rest.issues.listForRepo, {
       owner,
       repo: repoName,
-      issue_number: issueNumber,
+      state: params.state ?? 'open',
+      labels: params.labels,
+      milestone: params.milestone !== undefined ? String(params.milestone) : undefined,
+      per_page: 100,
     });
-    return {
-      number: data.number,
-      id: data.id,
-      nodeId: data.node_id,
-    };
+
+    return issues.map((i) => mapIssue(i as unknown as Record<string, unknown>));
   });
 }
 
@@ -131,12 +138,13 @@ export async function updateIssue(
   const octokit = getOctokit();
 
   return withGhResult(async () => {
+    const { stateReason, ...rest } = params;
     const { data } = await octokit.rest.issues.update({
       owner,
       repo: repoName,
       issue_number: issueNumber,
-      ...params,
-      state_reason: params.stateReason,
+      ...rest,
+      state_reason: stateReason,
     });
     return mapIssue(data as unknown as Record<string, unknown>);
   });
@@ -226,8 +234,8 @@ export async function addSubIssue(
     });
     const childInternalId = childResult.data.id;
 
-    // Add as sub-issue using the internal ID
-await (octokit.rest.issues as Record<string, (...args: never[]) => Promise<unknown>>).addSubIssue({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await octokit.request('POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues' as any, {
       owner,
       repo: repoName,
       issue_number: parentNumber,
@@ -245,15 +253,13 @@ export async function listSubIssues(
   const octokit = getOctokit();
 
   return withGhResult(async () => {
-    const subIssues = await octokit.paginate(
-    (octokit.rest.issues as Record<string, (...args: never[]) => Promise<unknown>>).listSubIssues as Parameters<typeof octokit.paginate>[0],
-      {
-        owner,
-        repo: repoName,
-        issue_number: parentNumber,
-        per_page: 100,
-      },
-    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const subIssues = await octokit.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues' as any, {
+      owner,
+      repo: repoName,
+      issue_number: parentNumber,
+      per_page: 100,
+    });
 
     return (subIssues as Record<string, unknown>[]).map(mapIssue);
   });

--- a/packages/cli/src/github/labels.ts
+++ b/packages/cli/src/github/labels.ts
@@ -70,6 +70,34 @@ export async function getLabel(
   });
 }
 
+/** Update an existing label's name, color, or description. */
+export async function updateLabel(
+  name: string,
+  updates: { new_name?: string; color?: string; description?: string },
+  repo?: RepoInfo,
+): Promise<GhResult<GhLabel>> {
+  const { owner, repo: repoName } = repo ?? getRepoInfo();
+  const octokit = getOctokit();
+
+  return withGhResult(async () => {
+    const { data } = await octokit.rest.issues.updateLabel({
+      owner,
+      repo: repoName,
+      name,
+      new_name: updates.new_name,
+      color: updates.color,
+      description: updates.description,
+    });
+    return {
+      id: data.id,
+      nodeId: data.node_id,
+      name: data.name,
+      description: data.description ?? '',
+      color: data.color,
+    };
+  });
+}
+
 /** Create a custom label. */
 export async function createLabel(
   label: LabelDef,

--- a/packages/cli/src/github/milestones.ts
+++ b/packages/cli/src/github/milestones.ts
@@ -108,6 +108,23 @@ export async function ensureMilestone(
   return createMilestone(params, repo);
 }
 
+/** Delete a milestone by its number. */
+export async function deleteMilestone(
+  milestoneNumber: number,
+  repo?: RepoInfo,
+): Promise<GhResult<void>> {
+  const { owner, repo: repoName } = repo ?? getRepoInfo();
+  const octokit = getOctokit();
+
+  return withGhResult(async () => {
+    await octokit.rest.issues.deleteMilestone({
+      owner,
+      repo: repoName,
+      milestone_number: milestoneNumber,
+    });
+  });
+}
+
 /** Update a milestone. */
 export async function updateMilestone(
   milestoneNumber: number,

--- a/packages/cli/src/github/projects.ts
+++ b/packages/cli/src/github/projects.ts
@@ -7,6 +7,7 @@ import { getRepoInfo, ghJson, ghExec } from './client.js';
 import type {
   GhProject,
   GhProjectField,
+  GhProjectItem,
   GhResult,
 } from './types.js';
 import { BOARD_COLUMNS } from './types.js';
@@ -224,6 +225,40 @@ export function setItemNumberField(
   return { ok: true, data: undefined };
 }
 
+/** List all items on a project board with their field values. */
+export function listItems(
+  projectNumber: number,
+  owner?: string,
+): GhResult<GhProjectItem[]> {
+  const { owner: repoOwner } = getRepoInfo();
+  const projectOwner = owner ?? repoOwner;
+
+  const result = ghJson<{
+    items: Array<{
+      id: string;
+      content?: { id?: string; type?: string; number?: number; title?: string };
+      title?: string;
+      archived?: boolean;
+    }>;
+  }>(
+    ['project', 'item-list', String(projectNumber), '--owner', projectOwner, '--format', 'json', '--limit', '500'],
+  );
+
+  if (!result.ok) return result;
+
+  return {
+    ok: true,
+    data: (result.data.items ?? []).map((item) => ({
+      id: item.id,
+      contentNodeId: item.content?.id ?? '',
+      contentType: (item.content?.type ?? 'Issue') as GhProjectItem['contentType'],
+      issueNumber: item.content?.number,
+      title: item.content?.title ?? item.title ?? '',
+      isArchived: item.archived ?? false,
+    })),
+  };
+}
+
 // ── Board Setup ───────────────────────────────────────────────────────
 
 /** Ensure a project board exists with the correct Status field options. */
@@ -231,22 +266,24 @@ export async function ensureProjectBoard(
   projectTitle: string,
   owner?: string,
 ): Promise<GhResult<{ project: GhProject; statusField: GhProjectField }>> {
-  // Find or create project
+  const { owner: repoOwner } = getRepoInfo();
+  const projectOwner = owner ?? repoOwner;
+
   let project: GhProject;
 
-  const findResult = findProject(projectTitle, owner);
+  const findResult = findProject(projectTitle, projectOwner);
   if (!findResult.ok) return findResult;
 
   if (findResult.data) {
     project = findResult.data;
   } else {
-    const createResult = createProject(projectTitle, owner);
+    const createResult = createProject(projectTitle, projectOwner);
     if (!createResult.ok) return createResult;
     project = createResult.data;
   }
 
   // Get Status field
-  const statusResult = getStatusField(project.number, owner);
+  const statusResult = getStatusField(project.number, projectOwner);
   if (!statusResult.ok) return statusResult;
 
   if (!statusResult.data) {
@@ -258,12 +295,20 @@ export async function ensureProjectBoard(
   const missingColumns = BOARD_COLUMNS.filter((col) => !existingOptions.has(col.name));
 
   if (missingColumns.length > 0) {
-    // Note: Adding single-select options requires GraphQL updateProjectV2Field mutation.
-    // For now, log a warning. Full implementation will use GraphQL.
-    console.warn(
-      `Warning: Missing board columns: ${missingColumns.map((c) => c.name).join(', ')}. ` +
-      'These must be added manually or via GraphQL updateProjectV2Field mutation.',
-    );
+    for (const col of missingColumns) {
+      const createResult = ghExec([
+        'project', 'field-create', String(project.number),
+        '--owner', projectOwner,
+        '--name', col.name,
+        '--data-type', 'SINGLE_SELECT',
+      ]);
+      if (!createResult.ok) {
+        console.warn(
+          `Warning: Failed to create board column "${col.name}": ${createResult.error}. ` +
+          'You may need to add it manually via the GitHub Projects UI.',
+        );
+      }
+    }
   }
 
   return { ok: true, data: { project, statusField: statusResult.data } };

--- a/packages/cli/src/github/types.ts
+++ b/packages/cli/src/github/types.ts
@@ -201,7 +201,7 @@ export interface RepoInfo {
 
 // ── Operation Results ─────────────────────────────────────────────────
 
-export type GhResultCode = 'NOT_FOUND' | 'UNAUTHORIZED' | 'RATE_LIMITED' | 'VALIDATION' | 'UNKNOWN';
+export type GhResultCode = 'NOT_FOUND' | 'UNAUTHORIZED' | 'RATE_LIMITED' | 'FORBIDDEN' | 'VALIDATION' | 'UNKNOWN';
 
 export type GhResult<T> =
   | { ok: true; data: T }


### PR DESCRIPTION
## Summary

- **client.ts**: Fix HTTP 403 classification — now correctly distinguishes `RATE_LIMITED` (message contains 'rate limit') from `FORBIDDEN` (all other 403s); fix `ghJson` non-JSON fallback to return an error result instead of an unsafe cast through `unknown`
- **types.ts**: Add `FORBIDDEN` to the `GhResultCode` union type
- **issues.ts**: Add `listIssues()` with state/labels/milestone filtering; remove dead `getIssueIds()` (superseded by `getIssue`); fix `updateIssue` to destructure `stateReason` before spreading params, preventing both camelCase and snake_case being sent; replace unsafe `Record<string, never[]>` cast chains in `addSubIssue`/`listSubIssues` with proper `octokit.request()`/`octokit.paginate()` string-route calls
- **milestones.ts**: Add `deleteMilestone()`
- **labels.ts**: Add `updateLabel()` with `new_name`/`color`/`description` support
- **comments.ts**: Fix `formatCommentHeader` to quote only attribute values containing non-word characters (e.g. spaces, colons), leaving numeric/simple values unquoted
- **projects.ts**: Add `listItems()` using `gh project item-list`; implement actual column creation logic in `ensureProjectBoard` using `gh project field-create` instead of a warning-only stub; eliminate redundant `getRepoInfo()` call inside the column creation loop
- **index.ts**: Export `listIssues`, `deleteMilestone`, `updateLabel`, `listItems`; remove `getIssueIds` and `setItemNumberField` from public exports

## Test plan

- [x] All 81 unit tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Type-check clean on worktree (only pre-existing `client.ts` throttle handler type mismatch remains)
- [x] `formatCommentHeader` correctly quotes values with spaces/special chars, leaves numbers unquoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)