### PR TITLE
fix(skills): correct paths, descriptions, and agent-skill mappings

### DIFF
--- a/templates/skills/github-operations/SKILL.md
+++ b/templates/skills/github-operations/SKILL.md
@@ -3,6 +3,8 @@ name: github-operations
 description: Unified GitHub interaction covering artifact types, comment conventions, CLI commands, and issue lifecycle. Use when reading from or writing to GitHub Issues, managing the project board, or posting structured comments.
 ---
 
+# GitHub Operations
+
 ## GitHub as Source of Truth
 
 All project state lives on GitHub. No local `.planning/` files. The canonical record for every phase, task, decision, and progress update is an Issue or Issue comment on the configured repository.
@@ -34,7 +36,7 @@ Every artifact posted to GitHub must include a type marker as the first line of 
 All commands use the MAXSIM tools router:
 
 ```bash
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github <command> [--flag value]
+node .claude/maxsim/bin/maxsim-tools.cjs github <command> [--flag value]
 ```
 
 Add `--raw` to any command for machine-readable JSON output: `{"ok": true, "result": "...", "rawValue": {...}}`.
@@ -96,7 +98,7 @@ cat > "$TMPFILE" << 'EOF'
 ## Summary
 Content here...
 EOF
-node ~/.claude/maxsim/bin/maxsim-tools.cjs github post-comment --issue-number 42 --body-file "$TMPFILE"
+node .claude/maxsim/bin/maxsim-tools.cjs github post-comment --issue-number 42 --body-file "$TMPFILE"
 rm "$TMPFILE"
 ```
 

--- a/templates/skills/maxsim-simplify/SKILL.md
+++ b/templates/skills/maxsim-simplify/SKILL.md
@@ -112,4 +112,4 @@ Before reporting completion:
 - [ ] All tests pass after simplification
 - [ ] No behavioral changes introduced
 
-See also: `/code-review` for correctness review covering security, interfaces, and test coverage.
+See also: `code-review` for correctness review covering security, interfaces, and test coverage.

--- a/templates/skills/using-maxsim/SKILL.md
+++ b/templates/skills/using-maxsim/SKILL.md
@@ -43,16 +43,16 @@ GitHub Issues with label `maxsim:lesson` or `maxsim:decision` are the source of 
 
 ## Skills Per Agent Type
 
-Skills load on-demand based on the current task. Each agent type draws from a different set.
+Skills are matched to agents by semantic description. Each agent type is associated with a different set.
 
 | Agent | Primary Skills |
 |-------|---------------|
-| Planner | `research`, `brainstorming`, `roadmap-writing`, `project-memory` |
-| Executor | `tdd`, `systematic-debugging`, `verification`, `maxsim-simplify` |
-| Verifier | `verification`, `code-review`, `systematic-debugging` |
-| Researcher | `research`, `project-memory` |
+| Planner | `handoff-contract`, `roadmap-writing` |
+| Executor | `handoff-contract`, `commit-conventions` |
+| Verifier | `handoff-contract`, `verification`, `code-review` |
+| Researcher | `handoff-contract`, `research` |
 
-Skills are not auto-loaded. They activate when invoked directly (e.g., `/research`) or when the orchestrator spawns an agent with explicit skill instructions.
+Skills are auto-loaded by Claude Code based on semantic description matching.
 
 ---
 

--- a/templates/skills/verification/SKILL.md
+++ b/templates/skills/verification/SKILL.md
@@ -3,6 +3,8 @@ name: verification
 description: Evidence-based verification with quality gates, anti-rationalization enforcement, and retry escalation. Merges gate framework, evidence collection, and completion verification into one authoritative source. Use when completing tasks, verifying implementations, or before claiming work is done.
 ---
 
+# Verification
+
 ## The Iron Law
 
 No completion claim is valid without fresh verification evidence produced in THIS session. Evidence from a prior session, a prior attempt, or reasoning about what "should" be true does not count. If the evidence was not collected by running a tool call in the current session, it does not exist.


### PR DESCRIPTION
## Summary

- `github-operations/SKILL.md`: Replace global `~/.claude/maxsim/bin/maxsim-tools.cjs` path with project-local `.claude/maxsim/bin/maxsim-tools.cjs` (two occurrences); add `# GitHub Operations` H1 title after frontmatter
- `using-maxsim/SKILL.md`: Correct skills-per-agent table to canonical mappings (Planner, Executor, Researcher each get `handoff-contract` plus one domain skill; Verifier keeps `verification`, `code-review`); replace "Skills are not auto-loaded" with accurate auto-load description; fix intro sentence to be consistent
- `verification/SKILL.md`: Add `# Verification` H1 title after frontmatter to match other skill files
- `maxsim-simplify/SKILL.md`: Replace `/code-review` slash-command notation with `` `code-review` `` backtick skill name on the "See also" line

## Test plan

- [x] All 77 unit tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Lint clean (2 pre-existing warnings unrelated to this change)
- [ ] E2E skipped — template-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)