### PR TITLE
fix(ci): add PR workflow and fix GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Description
       description: A clear and concise description of what the bug is.
-      placeholder: "When I run `npx maxsimcli@latest install`, it fails with..."
+      placeholder: "When I run `npx maxsimcli@latest`, it fails with..."
     validations:
       required: true
 
@@ -22,7 +22,7 @@ body:
       label: Steps to Reproduce
       description: Step-by-step instructions to reproduce the issue.
       placeholder: |
-        1. Run `npx maxsimcli@latest install`
+        1. Run `npx maxsimcli@latest`
         2. Select runtime "Claude Code"
         3. See error output
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -37,10 +37,10 @@ body:
       description: Which part of MAXSIM does this affect?
       options:
         - CLI / install
-        - Commands (packages/cli/src/commands/ or templates/)
+        - Commands (templates/commands/maxsim/)
         - Workflows (templates/workflows/)
         - Agents (templates/agents/)
-        - Dashboard
+        - Skills (templates/skills/)
         - Hooks
         - Core tooling (cli.ts / core modules)
         - Documentation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,6 +31,7 @@ Closes #<!-- issue number -->
 ## Checklist
 
 - [ ] `npm run build` passes with no errors
+- [ ] `npm run lint` passes
 - [ ] `npm test` passes
 - [ ] Commit message(s) follow [Conventional Commits](https://www.conventionalcommits.org/) format
 - [ ] I have not edited `packages/cli/README.md` directly (it is auto-generated)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,3 @@
 #!/usr/bin/env sh
-npm run build
+# Run lint before pushing to catch style issues early.
 npm run lint
-node scripts/pre-push-docs-check.cjs
-npm test


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` — a CI workflow that runs on `pull_request` to `main` with checkout → setup-node (22) → npm ci → build → lint → test (no release step)
- Fix `bug_report.yml` lines 15 and 25: remove nonexistent `install` subcommand from `npx maxsimcli@latest install` → `npx maxsimcli@latest`
- Fix `feature_request.yml` line 40: update Commands option path to `templates/commands/maxsim/`; line 43: replace nonexistent "Dashboard" option with "Skills (templates/skills/)"
- Add `- [ ] \`npm run lint\` passes` to the PR template checklist
- Simplify `.husky/pre-push` to only run `npm run lint` — removes obsolete v5 `.planning/` doc-check and redundant build/test steps (CI covers those)

## Test plan

- [x] All 77 unit tests pass (`npm test`)
- [x] E2E skipped — CI/template change only
- [x] YAML syntax valid (GitHub Actions format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)