### PR TITLE
fix(project): correct homepage domain and remove multi-runtime references

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -27,7 +27,7 @@ maxsimcli/                        ← repo root
 │   │   ├── tsdown.config.ts
 │   │   ├── vitest.config.ts
 │   │   └── package.json
-│   └── website/                  ← maxsimcli.com (React + Vite + Tailwind)
+│   └── website/                  ← maxsimcli.dev (React + Vite + Tailwind)
 ├── templates/                    ← source templates (copied to dist/ at build time)
 │   ├── agents/                   ← 4 agent definitions
 │   ├── commands/maxsim/          ← 9 slash commands

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/cli",
     "packages/website"
   ],
-  "description": "A meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode, Gemini and Codex by MayStudios.",
+  "description": "A meta-prompting, context engineering and spec-driven development system for Claude Code by MayStudios.",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "git+https://github.com/maystudios/maxsimcli.git"
   },
-  "homepage": "https://maxsimcli.com",
+  "homepage": "https://maxsimcli.dev",
   "bugs": {
     "url": "https://github.com/maystudios/maxsimcli/issues"
   },

--- a/packages/website/src/App.tsx
+++ b/packages/website/src/App.tsx
@@ -38,14 +38,14 @@ export default function App() {
     <>
       <Helmet>
         <title>MaxsimCLI: Meta-Prompting and Context Engineering for AI Coding Agents</title>
-        <meta name="description" content="MaxsimCLI brings spec-driven development to Claude Code, OpenCode, Gemini CLI, and Codex. Fresh-context subagents and structured planning keep your projects on track." />
+        <meta name="description" content="MaxsimCLI brings spec-driven development to Claude Code. Fresh-context subagents and structured planning keep your projects on track." />
         <link rel="canonical" href="https://maxsimcli.dev/" />
         <meta property="og:url" content="https://maxsimcli.dev/" />
         <meta property="og:title" content="MaxsimCLI: Meta-Prompting and Context Engineering for AI Coding Agents" />
-        <meta property="og:description" content="MaxsimCLI brings spec-driven development to Claude Code, OpenCode, Gemini CLI, and Codex. Fresh-context subagents and structured planning keep your projects on track." />
+        <meta property="og:description" content="MaxsimCLI brings spec-driven development to Claude Code. Fresh-context subagents and structured planning keep your projects on track." />
         <meta name="twitter:url" content="https://maxsimcli.dev/" />
         <meta name="twitter:title" content="MaxsimCLI: Meta-Prompting and Context Engineering for AI Coding Agents" />
-        <meta name="twitter:description" content="MaxsimCLI brings spec-driven development to Claude Code, OpenCode, Gemini CLI, and Codex. Fresh-context subagents and structured planning keep your projects on track." />
+        <meta name="twitter:description" content="MaxsimCLI brings spec-driven development to Claude Code. Fresh-context subagents and structured planning keep your projects on track." />
       </Helmet>
       <main className="min-h-screen bg-background text-foreground font-sans antialiased">
         <Navbar />


### PR DESCRIPTION
## Summary
- Changed `homepage` in `packages/cli/package.json` from `maxsimcli.com` to `maxsimcli.dev`
- Updated `INTERNALS.md` directory tree comment from `maxsimcli.com` to `maxsimcli.dev`
- Removed OpenCode, Gemini, and Codex references from root `package.json` description
- Removed OpenCode, Gemini CLI, and Codex references from all three meta tag descriptions in `packages/website/src/App.tsx`

## Test plan
- [x] `npm run test` — all 67 unit tests pass
- [x] `grep -rn "maxsimcli\.com" packages/cli/package.json INTERNALS.md` returns 0 results
- [x] `grep -rn "OpenCode\|Gemini\|Codex" package.json packages/website/src/App.tsx` returns 0 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)