### PR TITLE
docs: add 4 missing commands to skill and CLAUDE.md generator

### DIFF
--- a/packages/cli/src/install/claudemd.ts
+++ b/packages/cli/src/install/claudemd.ts
@@ -26,6 +26,10 @@ This project uses [MaxsimCLI](https://maxsimcli.dev) for structured development.
 | \`/maxsim:execute [N]\` | Execute a planned phase |
 | \`/maxsim:debug [desc]\` | Debug a specific issue |
 | \`/maxsim:quick [desc]\` | Quick task (simplified flow) |
+| \`/maxsim:improve [desc]\` | Autonomous optimization loop |
+| \`/maxsim:fix-loop [desc]\` | Iteratively fix until zero errors |
+| \`/maxsim:debug-loop [desc]\` | Scientific bug hunting loop |
+| \`/maxsim:security\` | Security audit (STRIDE + OWASP) |
 | \`/maxsim:progress\` | Show project status + recommendation |
 | \`/maxsim:settings\` | Configure MaxsimCLI |
 | \`/maxsim:help\` | Show help |

--- a/templates/skills/using-maxsim/SKILL.md
+++ b/templates/skills/using-maxsim/SKILL.md
@@ -23,6 +23,10 @@ Determine user intent, then route to the correct command.
 | Execute planned work | `/maxsim:execute N` |
 | Fix a bug | `/maxsim:debug` |
 | Quick one-off task | `/maxsim:quick` |
+| Optimize code against a metric | `/maxsim:improve` |
+| Fix errors in a loop until clean | `/maxsim:fix-loop` |
+| Hunt down a bug scientifically | `/maxsim:debug-loop` |
+| Run a security audit | `/maxsim:security` |
 | Check progress | `/maxsim:progress` |
 | Change settings | `/maxsim:settings` |
 | See all commands | `/maxsim:help` |


### PR DESCRIPTION
## Summary
- Added `improve`, `fix-loop`, `debug-loop`, and `security` commands to the `using-maxsim` skill routing table
- Added the same 4 commands to the `claudemd.ts` generator that produces the project-root CLAUDE.md
- Both files now reference all 13 commands (up from 9)

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (325 tests)
- [x] `npm run lint` passes (warnings only, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)