### PR TITLE
fix: inject version from package.json at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "npm run build:cli",
-    "build:cli": "cd packages/cli && npx tsdown && node scripts/copy-assets.cjs",
+    "build:cli": "cd packages/cli && node scripts/inject-version.cjs && npx tsdown && node scripts/copy-assets.cjs",
     "test": "cd packages/cli && npx vitest run",
     "e2e": "cd packages/cli && npx vitest run --config vitest.e2e.config.ts",
     "lint": "biome check .",

--- a/packages/cli/scripts/inject-version.cjs
+++ b/packages/cli/scripts/inject-version.cjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Pre-build version injection for @maxsim/cli
+ *
+ * Reads the version from packages/cli/package.json and writes it into
+ * src/core/version.ts so the built bundle always matches the npm version.
+ *
+ * This runs automatically as part of `npm run build` and ensures
+ * semantic-release version bumps propagate to the compiled output.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const pkgCliRoot = path.resolve(__dirname, '..');
+const pkgJsonPath = path.join(pkgCliRoot, 'package.json');
+const versionTsPath = path.join(pkgCliRoot, 'src', 'core', 'version.ts');
+
+const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+const version = pkg.version;
+
+const content = `/** MaxsimCLI version — auto-injected from package.json at build time. */\nexport const VERSION = '${version}';\n`;
+
+const existing = fs.existsSync(versionTsPath)
+  ? fs.readFileSync(versionTsPath, 'utf8')
+  : '';
+
+if (existing === content) {
+  console.log(`  [version] version.ts already up-to-date (${version})`);
+} else {
+  fs.writeFileSync(versionTsPath, content, 'utf8');
+  console.log(`  [version] Injected version ${version} -> src/core/version.ts`);
+}

--- a/packages/cli/src/core/version.ts
+++ b/packages/cli/src/core/version.ts
@@ -1,2 +1,2 @@
-/** MaxsimCLI version — updated by semantic-release. */
-export const VERSION = '5.2.2';
+/** MaxsimCLI version — auto-injected from package.json at build time. */
+export const VERSION = '5.2.4';


### PR DESCRIPTION
## Summary
- Added `packages/cli/scripts/inject-version.cjs` prebuild script that reads the version from `packages/cli/package.json` and writes it into `src/core/version.ts`
- Updated root `package.json` build:cli script to run inject-version.cjs before tsdown
- Fixed version.ts from stale 5.2.2 to current 5.2.4

This ensures semantic-release version bumps in package.json automatically propagate to the compiled CLI output, eliminating the manual sync that was always drifting.

## Test plan
- [x] `npm run build` succeeds and inject-version.cjs prints the correct version
- [x] Built output (`dist/install.cjs`) contains VERSION = '5.2.4'
- [x] `npm test` — 325 tests pass
- [x] `npm run lint` — no errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)