### PR TITLE
fix: reduce label taxonomy from 19 to 6 per PROJECT.md §5.3

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -226,19 +226,17 @@ Milestone CRUD using `octokit.paginate` for listing.
 
 ### labels.ts
 
-Enforces the 19-label taxonomy defined in `github/types.ts::MAXSIM_LABELS`.
+Enforces the 6-label taxonomy defined in `github/types.ts::MAXSIM_LABELS`.
 
 - `ensureLabels` — paginates existing labels, creates any that are missing.
 - `getLabel`, `createLabel` — individual label operations.
 
-Label taxonomy (19 labels, 4 namespaces):
+Label taxonomy (6 labels, 2 namespaces):
 
-| Namespace   | Labels                                                      |
-|-------------|-------------------------------------------------------------|
-| `type:`     | phase, task, bug, quick, user-issue                         |
-| `priority:` | p0, p1, p2, p3                                              |
-| `status:`   | planning, planned, in-progress, in-review, blocked, escalated |
-| `maxsim:`   | auto-created, needs-triage, lesson, decision                |
+| Namespace   | Labels                  |
+|-------------|-------------------------|
+| `type:`     | phase, task, bug, quick |
+| `maxsim:`   | auto, user              |
 
 ### comments.ts
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ MAXSIM tracks phase and plan progress through GitHub Issues. Execution progress 
 Configured during `/maxsim:init`:
 
 1. Creates a "MAXSIM Task Board" project with 5 columns (Backlog, To Do, In Progress, In Review, Done)
-2. Creates 19 labels in 4 namespaces (`type:phase`, `type:task`, `type:bug`, `priority:p0-critical`, `status:planning`, `status:in-progress`, etc.)
+2. Creates 6 labels in 2 namespaces (`type:phase`, `type:task`, `type:bug`, `type:quick`, `maxsim:auto`, `maxsim:user`)
 3. Optionally creates a GitHub Milestone
 
 ### How It Works

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -243,7 +243,7 @@ MAXSIM tracks phase and plan progress through GitHub Issues. Execution progress 
 Configured during `/maxsim:init`:
 
 1. Creates a "MAXSIM Task Board" project with 5 columns (Backlog, To Do, In Progress, In Review, Done)
-2. Creates 19 labels in 4 namespaces (`type:phase`, `type:task`, `type:bug`, `priority:p0-critical`, `status:planning`, `status:in-progress`, etc.)
+2. Creates 6 labels in 2 namespaces (`type:phase`, `type:task`, `type:bug`, `type:quick`, `maxsim:auto`, `maxsim:user`)
 3. Optionally creates a GitHub Milestone
 
 ### How It Works

--- a/packages/cli/src/github/types.ts
+++ b/packages/cli/src/github/types.ts
@@ -150,31 +150,16 @@ export interface LabelDef {
   color: string;
 }
 
-/** Complete label taxonomy for MaxsimCLI projects. */
+/** Complete label taxonomy for MaxsimCLI projects — 6 labels in 2 namespaces (§5.3). */
 export const MAXSIM_LABELS: LabelDef[] = [
-  // Type labels (5)
+  // Type labels (4)
   { name: 'type:phase', description: 'A Phase Issue representing a major deliverable', color: '0075ca' },
   { name: 'type:task', description: 'A Task sub-issue within a phase', color: '1d76db' },
   { name: 'type:bug', description: 'Something is broken', color: 'd73a4a' },
   { name: 'type:quick', description: 'A quick, self-contained task', color: '5319e7' },
-  { name: 'type:user-issue', description: 'Created by the user, not by MaxsimCLI', color: '0e8a16' },
-  // Priority labels (4)
-  { name: 'priority:p0-critical', description: 'Blocks all other work; must fix immediately', color: 'b60205' },
-  { name: 'priority:p1-high', description: 'Important; schedule for next execution window', color: 'e4e669' },
-  { name: 'priority:p2-medium', description: 'Standard priority', color: 'fbca04' },
-  { name: 'priority:p3-low', description: 'Nice to have; deferred if needed', color: 'c5def5' },
-  // Status labels (6) — matches spec §8.1
-  { name: 'status:planning', description: 'In the planning stage', color: 'bfd4f2' },
-  { name: 'status:planned', description: 'Plan approved, ready to execute', color: '0e8a16' },
-  { name: 'status:in-progress', description: 'Execution underway', color: 'e4e669' },
-  { name: 'status:in-review', description: 'Undergoing verification', color: 'd4c5f9' },
-  { name: 'status:blocked', description: 'Cannot proceed; dependency not met', color: 'ee0701' },
-  { name: 'status:escalated', description: 'Failed 3 retries; needs human intervention', color: 'b60205' },
-  // MaxsimCLI meta labels (4) — auto-created/needs-triage from spec, lesson/decision kept for project-memory
-  { name: 'maxsim:auto-created', description: 'Created by MaxsimCLI automation', color: 'ededed' },
-  { name: 'maxsim:needs-triage', description: 'User issue awaiting integration into plan', color: 'ededed' },
-  { name: 'maxsim:lesson', description: 'Project learning captured for project-memory', color: 'f9d0c4' },
-  { name: 'maxsim:decision', description: 'Architecture decision captured for project-memory', color: 'd4c5f9' },
+  // MaxsimCLI meta labels (2)
+  { name: 'maxsim:auto', description: 'Created by MaxsimCLI automation', color: 'ededed' },
+  { name: 'maxsim:user', description: 'Created by the user, not by MaxsimCLI', color: '0e8a16' },
 ];
 
 // ── Board Configuration ───────────────────────────────────────────────

--- a/packages/cli/tests/unit/github-labels.test.ts
+++ b/packages/cli/tests/unit/github-labels.test.ts
@@ -71,60 +71,33 @@ function makeRawLabel(overrides: Partial<{
 // ── MAXSIM_LABELS constant ────────────────────────────────────────────────────
 
 describe('MAXSIM_LABELS constant', () => {
-  it('has exactly 19 entries', () => {
-    expect(MAXSIM_LABELS).toHaveLength(19);
+  it('has exactly 6 entries', () => {
+    expect(MAXSIM_LABELS).toHaveLength(6);
   });
 
-  it('contains all type: namespace labels (5 entries)', () => {
+  it('contains all type: namespace labels (4 entries)', () => {
     const typeLabels = MAXSIM_LABELS.filter((l) => l.name.startsWith('type:'));
-    expect(typeLabels).toHaveLength(5);
+    expect(typeLabels).toHaveLength(4);
     const names = typeLabels.map((l) => l.name);
     expect(names).toContain('type:phase');
     expect(names).toContain('type:task');
     expect(names).toContain('type:bug');
     expect(names).toContain('type:quick');
-    expect(names).toContain('type:user-issue');
   });
 
-  it('contains all priority: namespace labels (4 entries)', () => {
-    const priorityLabels = MAXSIM_LABELS.filter((l) => l.name.startsWith('priority:'));
-    expect(priorityLabels).toHaveLength(4);
-    const names = priorityLabels.map((l) => l.name);
-    expect(names).toContain('priority:p0-critical');
-    expect(names).toContain('priority:p1-high');
-    expect(names).toContain('priority:p2-medium');
-    expect(names).toContain('priority:p3-low');
-  });
-
-  it('contains all status: namespace labels (6 entries)', () => {
-    const statusLabels = MAXSIM_LABELS.filter((l) => l.name.startsWith('status:'));
-    expect(statusLabels).toHaveLength(6);
-    const names = statusLabels.map((l) => l.name);
-    expect(names).toContain('status:planning');
-    expect(names).toContain('status:planned');
-    expect(names).toContain('status:in-progress');
-    expect(names).toContain('status:in-review');
-    expect(names).toContain('status:blocked');
-    expect(names).toContain('status:escalated');
-  });
-
-  it('contains all maxsim: namespace labels (4 entries)', () => {
+  it('contains all maxsim: namespace labels (2 entries)', () => {
     const maxsimLabels = MAXSIM_LABELS.filter((l) => l.name.startsWith('maxsim:'));
-    expect(maxsimLabels).toHaveLength(4);
+    expect(maxsimLabels).toHaveLength(2);
     const names = maxsimLabels.map((l) => l.name);
-    expect(names).toContain('maxsim:auto-created');
-    expect(names).toContain('maxsim:needs-triage');
-    expect(names).toContain('maxsim:lesson');
-    expect(names).toContain('maxsim:decision');
+    expect(names).toContain('maxsim:auto');
+    expect(names).toContain('maxsim:user');
   });
 
-  it('accounts for all 17 labels across the 4 namespaces', () => {
+  it('accounts for all 6 labels across the 2 namespaces', () => {
     const typeCount = MAXSIM_LABELS.filter((l) => l.name.startsWith('type:')).length;
-    const priorityCount = MAXSIM_LABELS.filter((l) => l.name.startsWith('priority:')).length;
-    const statusCount = MAXSIM_LABELS.filter((l) => l.name.startsWith('status:')).length;
     const maxsimCount = MAXSIM_LABELS.filter((l) => l.name.startsWith('maxsim:')).length;
-    // 5 type + 4 priority + 6 status + 4 maxsim = 19
-    expect(typeCount + priorityCount + statusCount + maxsimCount).toBe(19);
+    // 4 type + 2 maxsim = 6
+    expect(typeCount + maxsimCount).toBe(6);
   });
 
   it('every entry has non-empty name, description, and color', () => {
@@ -145,11 +118,6 @@ describe('MAXSIM_LABELS constant', () => {
     for (const label of MAXSIM_LABELS) {
       expect(label.color).toMatch(/^[0-9a-f]{6}$/i);
     }
-  });
-
-  it('contains status:escalated in the status: namespace', () => {
-    const names = MAXSIM_LABELS.map((l) => l.name);
-    expect(names).toContain('status:escalated');
   });
 });
 
@@ -179,14 +147,14 @@ describe('getLabel', () => {
   });
 
   it('passes the label name to the Octokit call', async () => {
-    const raw = makeRawLabel({ name: 'priority:p0-critical' });
+    const raw = makeRawLabel({ name: 'maxsim:auto' });
     mockGetLabel.mockResolvedValue({ data: raw });
 
-    await getLabel('priority:p0-critical');
+    await getLabel('maxsim:auto');
 
     expect(mockGetLabel).toHaveBeenCalledOnce();
     expect(mockGetLabel).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'priority:p0-critical' }),
+      expect.objectContaining({ name: 'maxsim:auto' }),
     );
   });
 
@@ -361,7 +329,7 @@ describe('ensureLabels', () => {
     vi.clearAllMocks();
   });
 
-  it('creates all 19 labels when the repo has none', async () => {
+  it('creates all 6 labels when the repo has none', async () => {
     mockPaginate.mockResolvedValue([]); // No existing labels
     mockCreateLabel.mockResolvedValue({ data: makeRawLabel() });
 
@@ -370,14 +338,14 @@ describe('ensureLabels', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error('Expected ok:true');
 
-    expect(result.data.created).toHaveLength(19);
+    expect(result.data.created).toHaveLength(6);
     expect(result.data.existing).toHaveLength(0);
-    expect(mockCreateLabel).toHaveBeenCalledTimes(19);
+    expect(mockCreateLabel).toHaveBeenCalledTimes(6);
   });
 
   it('skips existing labels and only creates missing ones', async () => {
-    // Simulate 4 labels already on the repo
-    const alreadyPresent = ['type:phase', 'type:task', 'priority:p0-critical', 'maxsim:auto-created'];
+    // Simulate 2 labels already on the repo
+    const alreadyPresent = ['type:phase', 'maxsim:auto'];
     mockPaginate.mockResolvedValue(alreadyPresent.map((name) => makeRawLabel({ name })));
     mockCreateLabel.mockResolvedValue({ data: makeRawLabel() });
 
@@ -386,14 +354,14 @@ describe('ensureLabels', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error('Expected ok:true');
 
-    expect(result.data.existing).toHaveLength(4);
+    expect(result.data.existing).toHaveLength(2);
     expect(result.data.existing).toEqual(expect.arrayContaining(alreadyPresent));
 
-    expect(result.data.created).toHaveLength(15); // 19 - 4
-    expect(mockCreateLabel).toHaveBeenCalledTimes(15);
+    expect(result.data.created).toHaveLength(4); // 6 - 2
+    expect(mockCreateLabel).toHaveBeenCalledTimes(4);
   });
 
-  it('skips all labels when all 19 already exist on the repo', async () => {
+  it('skips all labels when all 6 already exist on the repo', async () => {
     mockPaginate.mockResolvedValue(MAXSIM_LABELS.map((l) => makeRawLabel({ name: l.name })));
 
     const result = await ensureLabels();
@@ -401,7 +369,7 @@ describe('ensureLabels', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error('Expected ok:true');
 
-    expect(result.data.existing).toHaveLength(19);
+    expect(result.data.existing).toHaveLength(6);
     expect(result.data.created).toHaveLength(0);
     expect(mockCreateLabel).not.toHaveBeenCalled();
   });
@@ -484,7 +452,7 @@ describe('ensureLabels', () => {
   });
 
   it('creates each missing label with the correct name, description, and color from MAXSIM_LABELS', async () => {
-    // Only one label pre-exists; remaining 15 should be created.
+    // Only one label pre-exists; remaining 5 should be created.
     mockPaginate.mockResolvedValue([makeRawLabel({ name: 'type:phase' })]);
     mockCreateLabel.mockResolvedValue({ data: makeRawLabel() });
 

--- a/packages/website/src/content/docs/planning-directory.md
+++ b/packages/website/src/content/docs/planning-directory.md
@@ -17,7 +17,7 @@ Moving an Issue between columns is how MaxsimCLI tracks progress. Agents update 
 
 ### Issues as phase and task records
 
-Each phase is a GitHub Issue with label `type:phase`. Each task within a phase is a sub-Issue linked to the phase Issue. The Issue body holds the phase description, deliverables, and success criteria. Labels carry status (`status:planned`, `status:executing`, `status:complete`) and type metadata.
+Each phase is a GitHub Issue with label `type:phase`. Each task within a phase is a sub-Issue linked to the phase Issue. The Issue body holds the phase description, deliverables, and success criteria. Labels carry type metadata (`type:phase`, `type:task`, `type:bug`, `type:quick`) and origin tracking (`maxsim:auto`, `maxsim:user`).
 
 ### Comments as persistent context
 

--- a/templates/references/self-improvement.md
+++ b/templates/references/self-improvement.md
@@ -143,4 +143,4 @@ Promote a pattern to a target only after it appears in the "Worked" column three
 
 ## 8. GitHub-Native Complement
 
-The `project-memory` skill is the GitHub-native counterpart to this file's local memory approach. It records learnings, decisions, and lessons directly as GitHub Issues (labels `maxsim:lesson`, `maxsim:decision`) so they survive across machines and are visible to all agents without file access. Use `project-memory` when a learning is project-specific and should be shared; use this file's MEMORY.md when the learning is environment- or session-specific.
+The `project-memory` skill is the GitHub-native counterpart to this file's local memory approach. It records learnings, decisions, and lessons directly as GitHub Issue comments on the relevant phase/task issues (labels `maxsim:auto`, `maxsim:user`) so they survive across machines and are visible to all agents without file access. Use `project-memory` when a learning is project-specific and should be shared; use this file's MEMORY.md when the learning is environment- or session-specific.

--- a/templates/skills/github-operations/SKILL.md
+++ b/templates/skills/github-operations/SKILL.md
@@ -122,9 +122,8 @@ Backlog  →  To Do  →  In Progress  →  In Review  →  Done
 | `type:task` | Task sub-issues |
 | `type:bug` | Bug reports |
 | `type:quick` | Quick tasks |
-| `priority:p0-critical`, `priority:p1-high`, `priority:p2-medium`, `priority:p3-low` | All issues |
-| `status:blocked` | Blocked issues |
-| `maxsim:managed` | All issues created by MAXSIM |
+| `maxsim:auto` | All issues created by MAXSIM automation |
+| `maxsim:user` | Issues created by the user |
 
 ## Write Order
 

--- a/templates/skills/project-memory/SKILL.md
+++ b/templates/skills/project-memory/SKILL.md
@@ -29,14 +29,9 @@ Not everything is worth recording. Persist only information that would change be
 
 ## Storage: GitHub Issues
 
-All project memory lives as GitHub Issues in the project repository. Two labels are used:
+All project memory lives as GitHub Issues in the project repository. Use structured issue comments with `type:task` or `type:phase` labels to capture learnings and decisions inline within the relevant issue context.
 
-| Label | Purpose |
-|-------|---------|
-| `maxsim:lesson` | Something learned — what worked or what failed |
-| `maxsim:decision` | An architectural or design decision and its rationale |
-
-Create issues with `gh issue create`. Query them with `gh issue list --label maxsim:lesson`.
+Create issues with `gh issue create`. Query them with `gh issue list --label type:task`.
 
 ---
 
@@ -108,7 +103,7 @@ git log --oneline -20
 git log --oneline --since="7 days ago"
 ```
 
-This surfaces what changed recently without opening every file. Combine with `gh issue list --label maxsim:lesson` to get both code history and recorded learnings.
+This surfaces what changed recently without opening every file. Combine with `gh issue list --label maxsim:auto` to get both code history and recorded learnings.
 
 ---
 

--- a/templates/skills/using-maxsim/SKILL.md
+++ b/templates/skills/using-maxsim/SKILL.md
@@ -37,7 +37,7 @@ Before beginning any task in a session:
 2. Identify the active phase from GitHub Issues — if any phase is in progress, resume via `/maxsim:go`
 3. Route to the correct command using the table above
 
-GitHub Issues with label `maxsim:lesson` or `maxsim:decision` are the source of truth for project learnings and architectural decisions. Read them before planning.
+GitHub Issues with label `maxsim:auto` are the source of truth for automation-created content. Issues with label `maxsim:user` track user-created items. Read them before planning.
 
 ---
 
@@ -66,8 +66,8 @@ All persistent project state lives in GitHub, not in local files that disappear 
 | Phase plans | GitHub Sub-Issues on the phase Issue |
 | Roadmap | GitHub Milestones + Phase Issues |
 | Session state | GitHub Project Board column positions + Issue status |
-| Learnings | GitHub Issues — label `maxsim:lesson` |
-| Decisions | GitHub Issues — label `maxsim:decision` |
+| Learnings | GitHub Issue comments on relevant phase/task issues |
+| Decisions | GitHub Issue comments on relevant phase/task issues |
 
 ---
 
@@ -77,7 +77,7 @@ All persistent project state lives in GitHub, not in local files that disappear 
 - Skipping `/maxsim:init` because the project seems simple
 - Ignoring Project Board state and in-progress issues from previous sessions
 - Working outside the current phase without explicit user approval
-- Making architectural decisions without recording them as `maxsim:decision` issues
+- Making architectural decisions without recording them as comments on the relevant phase/task issue
 
 If any of these occur: stop, check the routing table, and follow the workflow.
 

--- a/templates/workflows/new-project.md
+++ b/templates/workflows/new-project.md
@@ -139,7 +139,7 @@ Execute in sequence:
 node .claude/maxsim/bin/maxsim-tools.cjs github ensure-labels
 ```
 
-This creates the standard MAXSIM label set (phase:N, status:*, priority:*, bug, etc.).
+This creates the standard MAXSIM label set (type:phase, type:task, type:bug, type:quick, maxsim:auto, maxsim:user).
 
 **4b. Create GitHub Project Board:**
 


### PR DESCRIPTION
## Summary
- Reduced `MAXSIM_LABELS` constant from 19 labels in 4 namespaces (`type:`, `priority:`, `status:`, `maxsim:`) to exactly 6 labels in 2 namespaces (`type:`, `maxsim:`), per PROJECT.md §5.3
- Removed all `priority:*` (4), `status:*` (6), and deprecated `maxsim:*` labels (needs-triage, lesson, decision); renamed `maxsim:auto-created` to `maxsim:auto`; replaced `type:user-issue` with `maxsim:user`
- Updated all 31 unit tests in `github-labels.test.ts` to match new label count and namespace structure
- Updated documentation references across 9 files (INTERNALS.md, README.md, website docs, skill templates, workflow templates)

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (322 tests, 31 label tests)
- [x] `npm run lint` passes (warnings only, all pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)