### PR TITLE
feat: add session-start, teammate-idle, task-completed hooks

### DIFF
--- a/packages/cli/src/hooks/maxsim-capture-learnings.ts
+++ b/packages/cli/src/hooks/maxsim-capture-learnings.ts
@@ -12,47 +12,13 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { spawnSync } from 'node:child_process';
-import { readStdinJson, CLAUDE_DIR } from './shared.js';
+import { readStdinJson, CLAUDE_DIR, isMaxsimProject, recentCommits } from './shared.js';
 
 interface StopInput {
   cwd?: string;
   session_id?: string;
   stop_reason?: string;
   [key: string]: unknown;
-}
-
-/** Returns true when .claude/maxsim/config.json exists in the given directory. */
-function isMaxsimProject(projectDir: string): boolean {
-  try {
-    return fs.existsSync(path.join(projectDir, CLAUDE_DIR, 'maxsim', 'config.json'));
-  } catch {
-    return false;
-  }
-}
-
-/** Reads the last N git commits as oneline strings. Returns empty array on failure. */
-function recentCommits(projectDir: string, n = 5): string[] {
-  try {
-    const result = spawnSync(
-      'git',
-      ['log', `--oneline`, `-${n}`],
-      {
-        cwd: projectDir,
-        encoding: 'utf8',
-        timeout: 4000,
-        stdio: ['ignore', 'pipe', 'ignore'],
-        windowsHide: true,
-      },
-    );
-    if (result.status !== 0) return [];
-    return (result.stdout ?? '')
-      .split('\n')
-      .map((l) => l.trim())
-      .filter(Boolean);
-  } catch {
-    return [];
-  }
 }
 
 /** Formats today's date as YYYY-MM-DD. */

--- a/packages/cli/src/hooks/maxsim-session-start.ts
+++ b/packages/cli/src/hooks/maxsim-session-start.ts
@@ -1,0 +1,101 @@
+/**
+ * SessionStart hook — inject orientation context at session start/resume/compact.
+ *
+ * Behaviour:
+ *  - Reads the SessionStart event JSON from stdin.
+ *  - Gathers recent git history (20 commits) for instant orientation.
+ *  - Reads the first 200 lines of MEMORY.md (learned patterns).
+ *  - Reads the last 10 lines of autoresearch-results.tsv (metric trends).
+ *  - Outputs all collected context to stdout for injection into Claude's context.
+ *  - Always exits 0 — never blocks the user's session.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { readStdinJson, CLAUDE_DIR, isMaxsimProject, recentCommits } from './shared.js';
+
+interface SessionStartInput {
+  session_id?: string;
+  cwd?: string;
+  [key: string]: unknown;
+}
+
+/** Reads the first N lines of a file. Returns empty string on any failure. */
+function readFirstLines(filePath: string, maxLines: number): string {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n').slice(0, maxLines);
+    return lines.join('\n').trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Reads the last N non-empty lines of a file. Returns empty string on any failure. */
+function readLastLines(filePath: string, maxLines: number): string {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n').filter(Boolean);
+    return lines.slice(-maxLines).join('\n').trim();
+  } catch {
+    return '';
+  }
+}
+
+readStdinJson<SessionStartInput>((input) => {
+  try {
+    const projectDir = input.cwd ?? process.cwd();
+
+    if (!isMaxsimProject(projectDir)) {
+      process.exit(0);
+    }
+
+    const sections: string[] = [];
+
+    const commits = recentCommits(projectDir, 20);
+    if (commits.length > 0) {
+      sections.push(
+        '## Recent Git History',
+        commits.map((c) => `  ${c}`).join('\n'),
+      );
+    }
+
+    const memoryPath = path.join(
+      projectDir,
+      CLAUDE_DIR,
+      'agent-memory',
+      'maxsim-learner',
+      'MEMORY.md',
+    );
+    const memoryContent = readFirstLines(memoryPath, 200);
+    if (memoryContent) {
+      sections.push(
+        '## Learned Patterns (MEMORY.md)',
+        memoryContent,
+      );
+    }
+
+    const tsvPath = path.join(
+      projectDir,
+      CLAUDE_DIR,
+      'agent-memory',
+      'maxsim-learner',
+      'autoresearch-results.tsv',
+    );
+    const tsvTail = readLastLines(tsvPath, 10);
+    if (tsvTail) {
+      sections.push(
+        '## Metric Trends (autoresearch-results.tsv)',
+        tsvTail,
+      );
+    }
+
+    if (sections.length > 0) {
+      process.stdout.write(`${sections.join('\n\n')}\n`);
+    }
+  } catch {
+    // Never crash — always let the session start cleanly
+  }
+
+  process.exit(0);
+});

--- a/packages/cli/src/hooks/maxsim-task-completed.ts
+++ b/packages/cli/src/hooks/maxsim-task-completed.ts
@@ -1,0 +1,114 @@
+/**
+ * TaskCompleted hook — run verification gates before allowing task completion.
+ *
+ * Behaviour:
+ *  - Reads the TaskCompleted event JSON from stdin.
+ *  - Detects the project's test/build/lint scripts from package.json.
+ *  - Runs npm test, npm run build, npm run lint (if each exists).
+ *  - If any gate fails: exits 2 with stderr containing the failure output.
+ *  - If all gates pass: exits 0 (allow completion).
+ *  - Always handles errors gracefully — never crashes.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { readStdinJson } from './shared.js';
+
+interface TaskCompletedInput {
+  task_id?: string;
+  task_subject?: string;
+  task_description?: string;
+  teammate_name?: string;
+  team_name?: string;
+  cwd?: string;
+  [key: string]: unknown;
+}
+
+interface PackageJson {
+  scripts?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+/** Read package.json scripts from a directory. Returns null if not found. */
+function readPackageScripts(projectDir: string): Record<string, string> | null {
+  try {
+    const pkgPath = path.join(projectDir, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as PackageJson;
+    return pkg.scripts ?? null;
+  } catch {
+    return null;
+  }
+}
+
+interface GateResult {
+  name: string;
+  passed: boolean;
+  output: string;
+}
+
+/** Run a single verification gate. Returns the result. */
+function runGate(name: string, command: string, args: string[], projectDir: string): GateResult {
+  try {
+    const result = spawnSync(command, args, {
+      cwd: projectDir,
+      encoding: 'utf8',
+      timeout: 120_000, // 2 minute timeout per gate
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+      shell: true,
+    });
+
+    const output = [result.stdout ?? '', result.stderr ?? ''].join('\n').trim();
+
+    return {
+      name,
+      passed: result.status === 0,
+      output,
+    };
+  } catch (err) {
+    return {
+      name,
+      passed: false,
+      output: `Gate "${name}" threw an error: ${String(err)}`,
+    };
+  }
+}
+
+readStdinJson<TaskCompletedInput>((input) => {
+  try {
+    const projectDir = input.cwd ?? process.cwd();
+    const scripts = readPackageScripts(projectDir);
+    const failures: GateResult[] = [];
+
+    // Gate 1: npm test (detect test runner)
+    if (scripts?.test) {
+      const result = runGate('test', 'npm', ['test'], projectDir);
+      if (!result.passed) failures.push(result);
+    }
+
+    // Gate 2: npm run build (if build script exists)
+    if (scripts?.build) {
+      const result = runGate('build', 'npm', ['run', 'build'], projectDir);
+      if (!result.passed) failures.push(result);
+    }
+
+    // Gate 3: npm run lint (if lint script exists)
+    if (scripts?.lint) {
+      const result = runGate('lint', 'npm', ['run', 'lint'], projectDir);
+      if (!result.passed) failures.push(result);
+    }
+
+    if (failures.length > 0) {
+      const report = failures
+        .map((f) => `=== ${f.name} FAILED ===\n${f.output}`)
+        .join('\n\n');
+      process.stderr.write(`${report}\n`);
+      process.exit(2);
+    }
+  } catch {
+    // Never crash — allow completion on unexpected error
+  }
+
+  process.exit(0);
+});

--- a/packages/cli/src/hooks/maxsim-teammate-idle.ts
+++ b/packages/cli/src/hooks/maxsim-teammate-idle.ts
@@ -1,0 +1,54 @@
+/**
+ * TeammateIdle hook — check for pending tasks before allowing teammate to go idle.
+ *
+ * Behaviour:
+ *  - Reads the TeammateIdle event JSON from stdin.
+ *  - Checks if there are pending tasks in ~/.claude/tasks/{team_name}/ directory.
+ *  - If pending tasks exist: exits 2 with stderr "Pick up the next available task."
+ *  - If no pending tasks: exits 0 (allow idle).
+ *  - Always handles errors gracefully — never crashes.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { readStdinJson } from './shared.js';
+
+interface TeammateIdleInput {
+  teammate_name?: string;
+  team_name?: string;
+  session_id?: string;
+  cwd?: string;
+  [key: string]: unknown;
+}
+
+/** Check if a directory has any files (non-recursively). */
+function hasPendingTasks(tasksDir: string): boolean {
+  try {
+    const entries = fs.readdirSync(tasksDir);
+    return entries.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+readStdinJson<TeammateIdleInput>((input) => {
+  try {
+    const teamName = input.team_name;
+    if (!teamName) {
+      // No team context — allow idle
+      process.exit(0);
+    }
+
+    const tasksDir = path.join(os.homedir(), '.claude', 'tasks', teamName);
+
+    if (hasPendingTasks(tasksDir)) {
+      process.stderr.write('Pick up the next available task.\n');
+      process.exit(2);
+    }
+  } catch {
+    // Never crash — allow idle on error
+  }
+
+  process.exit(0);
+});

--- a/packages/cli/src/hooks/shared.ts
+++ b/packages/cli/src/hooks/shared.ts
@@ -1,5 +1,6 @@
 /** Shared utilities for MAXSIM hooks. */
 
+import * as fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -21,6 +22,39 @@ export function readStdinJson<T>(callback: (data: T) => void): void {
 }
 
 export const CLAUDE_DIR = '.claude';
+
+/** Returns true when .claude/maxsim/config.json exists in the given directory. */
+export function isMaxsimProject(projectDir: string): boolean {
+  try {
+    return fs.existsSync(path.join(projectDir, CLAUDE_DIR, 'maxsim', 'config.json'));
+  } catch {
+    return false;
+  }
+}
+
+/** Reads the last N git commits as oneline strings. Returns empty array on failure. */
+export function recentCommits(projectDir: string, n = 5): string[] {
+  try {
+    const result = spawnSync(
+      'git',
+      ['log', '--oneline', `-${n}`],
+      {
+        cwd: projectDir,
+        encoding: 'utf8',
+        timeout: 4000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+        windowsHide: true,
+      },
+    );
+    if (result.status !== 0) return [];
+    return (result.stdout ?? '')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
 
 /** Returns true when running on Windows. */
 export function isWindows(): boolean {

--- a/packages/cli/src/install/hooks.ts
+++ b/packages/cli/src/install/hooks.ts
@@ -80,6 +80,27 @@ export function installHooks(projectDir: string): { installed: string[] } {
     installed.push('maxsim-capture-learnings (Stop)');
   }
 
+  // Register SessionStart hook (session context injection)
+  const sessionStartPath = path.join(hooksDestDir, 'maxsim-session-start.cjs');
+  if (fs.existsSync(sessionStartPath)) {
+    registerHook(settings, 'SessionStart', `node "${sessionStartPath}"`);
+    installed.push('maxsim-session-start (SessionStart)');
+  }
+
+  // Register TeammateIdle hook (pending task check)
+  const teammateIdlePath = path.join(hooksDestDir, 'maxsim-teammate-idle.cjs');
+  if (fs.existsSync(teammateIdlePath)) {
+    registerHook(settings, 'TeammateIdle', `node "${teammateIdlePath}"`);
+    installed.push('maxsim-teammate-idle (TeammateIdle)');
+  }
+
+  // Register TaskCompleted hook (verification gates)
+  const taskCompletedPath = path.join(hooksDestDir, 'maxsim-task-completed.cjs');
+  if (fs.existsSync(taskCompletedPath)) {
+    registerHook(settings, 'TaskCompleted', `node "${taskCompletedPath}"`);
+    installed.push('maxsim-task-completed (TaskCompleted)');
+  }
+
   // Register statusLine (only if not already set, or if it's already ours)
   const statusLinePath = path.join(hooksDestDir, 'maxsim-statusline.cjs');
   if (fs.existsSync(statusLinePath)) {

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -60,4 +60,19 @@ export default defineConfig([
     entry: { 'maxsim-capture-learnings': 'src/hooks/maxsim-capture-learnings.ts' },
     dts: false,
   },
+  {
+    ...hookShared,
+    entry: { 'maxsim-session-start': 'src/hooks/maxsim-session-start.ts' },
+    dts: false,
+  },
+  {
+    ...hookShared,
+    entry: { 'maxsim-teammate-idle': 'src/hooks/maxsim-teammate-idle.ts' },
+    dts: false,
+  },
+  {
+    ...hookShared,
+    entry: { 'maxsim-task-completed': 'src/hooks/maxsim-task-completed.ts' },
+    dts: false,
+  },
 ]);


### PR DESCRIPTION
## Summary
- **maxsim-session-start** (SessionStart): Injects git history (20 commits), first 200 lines of MEMORY.md, and last 10 lines of autoresearch-results.tsv into session context for instant orientation
- **maxsim-teammate-idle** (TeammateIdle): Checks `~/.claude/tasks/{team_name}/` for pending tasks; exits 2 to prevent idle when work is available
- **maxsim-task-completed** (TaskCompleted): Runs npm test/build/lint verification gates before allowing task completion; exits 2 with failure output on gate failure
- Refactored `isMaxsimProject` and `recentCommits` into `shared.ts` to eliminate duplication with `maxsim-capture-learnings.ts`
- Removed TOCTOU `existsSync`-before-read anti-patterns across all new hooks
- Added build entry points in `tsdown.config.ts` and hook registration in `hooks.ts`

## Test plan
- [x] `npm run build` compiles all 10 hooks successfully
- [x] `npm test` passes all 325 tests
- [x] `npm run lint` passes (only pre-existing warnings, no errors)
- [ ] Manual: run `maxsim install` and verify all 3 new hooks appear in `.claude/settings.json`
- [ ] Manual: start a session in a maxsim project and verify context injection appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)