### PR TITLE
feat: add autoresearch skill (#15 of 15)

### DIFF
--- a/templates/skills/autoresearch/SKILL.md
+++ b/templates/skills/autoresearch/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: autoresearch
+description: Autonomous optimization loop with reference workflows. Powers /maxsim:improve, /maxsim:fix-loop, /maxsim:debug-loop, /maxsim:security. Use when running autonomous optimization, error repair, bug hunting, or security audit loops.
+version: 1.0.0
+---
+
+# Autonomous Optimization Loop
+
+Constraint-driven autonomous iteration for any task. The agent modifies, verifies, keeps or discards, and repeats.
+
+## When to Activate
+
+- `/maxsim:improve` — run the optimization loop
+- `/maxsim:fix-loop` — iteratively repair errors until zero remain
+- `/maxsim:debug-loop` — autonomous bug hunting with scientific method
+- `/maxsim:security` — STRIDE + OWASP security audit loop
+- Any task requiring repeated iteration cycles with measurable outcomes
+
+## Subcommands
+
+| Command | Purpose | Reference |
+|---------|---------|-----------|
+| `/maxsim:improve` | Run the autonomous optimization loop (default) | This file |
+| `/maxsim:debug-loop` | Autonomous bug hunting: hypothesize, test, prove/disprove, repeat | `references/debug.md` |
+| `/maxsim:fix-loop` | Autonomous fix loop: detect, prioritize, fix one, verify, repeat | `references/fix.md` |
+| `/maxsim:security` | Security audit: STRIDE + OWASP + red-team adversarial analysis | `references/security.md` |
+
+## Interactive Setup Gate
+
+Before any command executes, the agent checks whether the user provided all required context inline. If any required context is missing, the agent collects it interactively before proceeding.
+
+| Command | Required Context |
+|---------|-----------------|
+| `/maxsim:improve` | Goal, Scope, Metric, Direction, Verify |
+| `/maxsim:debug-loop` | Issue/Symptom, Scope |
+| `/maxsim:fix-loop` | Target, Scope |
+| `/maxsim:security` | Scope, Depth |
+
+## Bounded Iterations
+
+By default, loops run until manually interrupted. To run exactly N iterations, the user adds `Iterations: N` to the inline config.
+
+After N iterations the agent stops and prints a final summary with baseline, current best, keeps/discards/crashes. If the goal is achieved before N iterations, the agent prints early completion and stops.
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Run overnight, review in morning | Unlimited (default) |
+| Quick improvement session | `Iterations: 10` |
+| Targeted fix with known scope | `Iterations: 5` |
+| Exploratory approach test | `Iterations: 15` |
+
+## Setup Phase
+
+If the user provides Goal, Scope, Metric, and Verify inline, the agent extracts them and proceeds to step 5 below. Otherwise the agent collects them interactively in two batched calls.
+
+**Batch 1 (4 questions):** Goal, Scope, Metric, Direction.
+
+**Batch 2 (3 questions):** Verify command, Guard command, Launch preference.
+
+After batch 2, the agent dry-runs the verify command. If it fails, the agent asks the user to fix or choose a different command.
+
+### Setup Steps (after config is complete)
+
+1. Read all in-scope files for full context before any modification.
+2. Define the goal from user input or inline config.
+3. Define scope constraints with validated file globs.
+4. Define guard (optional) for regression prevention.
+5. Create a results log per `references/results-logging.md`.
+6. Establish baseline by running verification on current state. Record as iteration 0.
+7. Confirm and begin the loop.
+
+## The Loop
+
+Full protocol details are in `references/loop-protocol.md`.
+
+```
+LOOP (FOREVER or N times):
+  1. Review: Read current state + git history + results log
+  2. Ideate: Pick next change based on goal, past results, what hasn't been tried
+  3. Modify: Make ONE focused change to in-scope files
+  4. Commit: Git commit the change (before verification)
+  5. Verify: Run the mechanical metric
+  6. Guard: If guard is set, run the guard command
+  7. Decide:
+     - IMPROVED + guard passed → Keep commit, log "keep"
+     - IMPROVED + guard FAILED → Revert, rework (max 2 attempts)
+     - SAME/WORSE → Git revert, log "discard"
+     - CRASHED → Try to fix (max 3 attempts), else log "crash"
+  8. Log: Record result in results log
+  9. Repeat
+```
+
+## Critical Rules
+
+1. **Loop until done** — Unbounded: loop until interrupted. Bounded: loop N times then summarize.
+2. **Read before write** — Always understand full context before modifying.
+3. **One change per iteration** — Atomic changes for clear causality.
+4. **Mechanical verification only** — No subjective judgments. Use metrics.
+5. **Automatic rollback** — Failed changes revert instantly via `git revert`.
+6. **Simplicity wins** — Equal results + less code = KEEP. Tiny improvement + ugly complexity = DISCARD.
+7. **Git is memory** — Every experiment committed with `experiment:` prefix. Use `git revert` (not `git reset --hard`) so failed experiments remain visible. The agent reads `git log` and `git diff` of kept commits before each iteration.
+8. **When stuck, think harder** — Re-read files, re-read goal, combine near-misses, try radical changes.
+
+## Principles Reference
+
+See `references/core-principles.md` for the 7 generalizable principles behind autonomous iteration.
+
+## Adapting to Different Domains
+
+| Domain | Metric | Scope | Verify Command | Guard |
+|--------|--------|-------|----------------|-------|
+| Backend code | Tests pass + coverage % | `src/**/*.ts` | `npm test` | -- |
+| Frontend UI | Lighthouse score | `src/components/**` | `npx lighthouse` | `npm test` |
+| Performance | Benchmark time (ms) | Target files | `npm run bench` | `npm test` |
+| Refactoring | Tests pass + LOC reduced | Target module | `npm test && wc -l` | `npm run typecheck` |
+| Security | OWASP + STRIDE coverage | API/auth/middleware | `/maxsim:security` | -- |
+| Debugging | Bugs found + coverage | Target files | `/maxsim:debug-loop` | -- |
+| Fixing | Error count (lower) | Target files | `/maxsim:fix-loop` | `npm test` |
+
+## Debug Loop Summary
+
+Autonomous bug-hunting loop applying the scientific method. Each iteration forms a falsifiable hypothesis, tests it, and classifies the result as confirmed, disproven, or inconclusive.
+
+**Phases:** Gather symptoms, Reconnaissance, Hypothesize, Test, Classify, Log, Repeat.
+
+The agent uses investigation techniques including direct inspection, trace execution, minimal reproduction, binary search, differential debugging, and pattern search.
+
+Full protocol: `references/debug.md`
+
+## Fix Loop Summary
+
+Autonomous fix loop that takes a broken state and iteratively repairs it. One fix per iteration, atomic, committed, verified, auto-reverted on failure.
+
+**Phases:** Detect errors, Prioritize (build > types > tests > lint), Fix ONE thing, Commit, Verify (did error count decrease?), Guard (did anything else break?), Decide, Log and Repeat.
+
+The agent fixes the implementation, never the tests. It never adds `@ts-ignore`, `eslint-disable`, or `any` type escapes.
+
+Full protocol: `references/fix.md`
+
+## Security Audit Summary
+
+Autonomous security auditing combining STRIDE threat modeling, OWASP Top 10 sweeps, and red-team adversarial analysis into a single loop.
+
+**Setup:** Codebase reconnaissance, asset identification, trust boundary mapping, STRIDE threat model, attack surface map, baseline.
+
+**Loop:** Each iteration picks one untested attack vector, analyzes the target code, validates with code evidence, classifies severity + OWASP + STRIDE category, and logs the result.
+
+**Key behaviors:**
+- Follows 4 red-team adversarial lenses (Security Adversary, Supply Chain, Insider Threat, Infrastructure)
+- Every finding requires code evidence (file:line + attack scenario)
+- Tracks OWASP Top 10 + STRIDE coverage, prints summary every 5 iterations
+- Composite metric: `(owasp_tested/10)*50 + (stride_tested/6)*30 + min(findings, 20)`
+
+**Flags:** `--diff` (delta mode), `--fix` (auto-remediate Critical/High), `--fail-on <severity>` (CI gate).
+
+Full protocol: `references/security.md`
+
+## Results Logging
+
+All loops use a TSV results log tracking every iteration. See `references/results-logging.md` for the format and protocol.
+
+```tsv
+iteration	commit	metric	delta	guard	status	description
+0	a1b2c3d	85.2	0.0	pass	baseline	initial state
+1	b2c3d4e	87.1	+1.9	pass	keep	add auth middleware tests
+2	-	86.5	-0.6	-	discard	refactor test helpers
+```
+
+Valid statuses: `baseline`, `keep`, `keep (reworked)`, `discard`, `crash`, `no-op`, `hook-blocked`.

--- a/templates/skills/autoresearch/references/core-principles.md
+++ b/templates/skills/autoresearch/references/core-principles.md
@@ -1,0 +1,68 @@
+# Core Principles
+
+Seven universal principles for autonomous iteration, applicable to any task domain.
+
+## 1. Constraint Equals Enabler
+
+Autonomy succeeds through intentional constraint, not despite it. Bounded scope fits the agent context, fixed iteration cost enables rapid feedback, and a single mechanical metric eliminates ambiguity.
+
+**Apply:** Before starting, define what files are in-scope, what the single metric is, and what the time budget per iteration is.
+
+## 2. Separate Strategy from Tactics
+
+Humans set direction. Agents execute iterations.
+
+| Strategic (Human) | Tactical (Agent) |
+|-------------------|------------------|
+| "Improve page load speed" | "Lazy-load images, code-split routes" |
+| "Increase test coverage" | "Add tests for uncovered edge cases" |
+| "Refactor auth module" | "Extract middleware, simplify handlers" |
+
+**Apply:** Get clear direction from the user. Then iterate autonomously on implementation.
+
+## 3. Metrics Must Be Mechanical
+
+If the agent cannot verify with a command, it cannot iterate autonomously. Valid metrics: tests pass/fail, benchmark time, coverage percentage, lighthouse score, file size, lines of code.
+
+Anti-pattern: "Looks better", "probably improved", "seems cleaner" — these kill autonomous loops because there is no decision function.
+
+**Apply:** Define the command that extracts the metric before starting.
+
+## 4. Verification Must Be Fast
+
+If verification takes longer than the work itself, incentives misalign.
+
+| Fast (enables iteration) | Slow (kills iteration) |
+|-------------------------|----------------------|
+| Unit tests (seconds) | Full E2E suite (minutes) |
+| Type check (seconds) | Manual QA (hours) |
+| Lint check (instant) | Code review (async) |
+
+**Apply:** Use the fastest verification that still catches real problems. Save slow verification for after the loop.
+
+## 5. Iteration Cost Shapes Behavior
+
+Cheap iteration leads to bold exploration and many experiments. Expensive iteration leads to conservative, few experiments.
+
+**Apply:** Minimize iteration cost. Use fast tests, incremental builds, targeted verification. Every minute saved means more experiments run.
+
+## 6. Git as Memory and Audit Trail
+
+Every successful change is committed. This enables causality tracking (which change drove improvement), stacking wins (each commit builds on prior successes), pattern learning (the agent sees what worked in this codebase), and human review.
+
+**Apply:** Commit before verify. Revert on failure. The agent reads its own git history to inform the next experiment.
+
+Key commands every iteration:
+- `git log --oneline -20` — see experiment sequence (kept vs reverted).
+- `git diff HEAD~1` — inspect last kept change to understand why it worked.
+- `git show <hash> --stat` — deep-dive a specific commit.
+
+## 7. Honest Limitations
+
+State what the system can and cannot do. If the agent hits a wall it cannot solve (missing permissions, external dependency, needs human judgment), it says so clearly instead of guessing.
+
+**Apply:** At setup, explicitly state constraints.
+
+## The Meta-Principle
+
+Autonomy scales when scope is constrained, success is clarified, verification is mechanized, and agents optimize tactics while humans optimize strategy.

--- a/templates/skills/autoresearch/references/debug.md
+++ b/templates/skills/autoresearch/references/debug.md
@@ -1,0 +1,99 @@
+# Debug Workflow
+
+Autonomous bug-hunting loop applying the scientific method iteratively. The agent keeps investigating until the codebase is clean or it is interrupted.
+
+## Trigger
+
+- User invokes `/maxsim:debug-loop`
+- User says "find all bugs", "debug this", "why is this failing", "hunt bugs", "investigate"
+
+## Interactive Setup
+
+If invoked without `--scope` or `--symptom`, the agent gathers context via a single batched call with 4 questions:
+
+| # | Header | Question |
+|---|--------|----------|
+| 1 | Issue | "What's the problem?" |
+| 2 | Scope | "Which files should I investigate?" |
+| 3 | Depth | "How deep should I investigate?" |
+| 4 | After | "When bugs are found, should I also fix them?" |
+
+## Phases
+
+### Phase 1: Gather — Symptoms and Context
+
+If the user provides symptoms, the agent collects: expected vs actual behavior, error messages, stack traces, reproduction steps, environment details.
+
+If no symptoms (autonomous hunt), the agent runs the test suite, linter, type checker, and build to detect failures. It scans for common anti-patterns (unhandled promises, unchecked nulls, race conditions).
+
+### Phase 2: Reconnaissance — Map the Error Surface
+
+The agent reads files from stack traces, traces call chains backward, identifies entry points, maps data flow, checks recent git changes, and identifies external dependencies.
+
+### Phase 3: Hypothesize — Form Falsifiable Hypothesis
+
+A good hypothesis is specific, testable, falsifiable, and prioritized by likelihood.
+
+**Priority order:** Error message literal, recent change, data flow trace, environment diff, dependency issue, race condition, edge case.
+
+**Cognitive bias guards:** The agent actively seeks evidence against its hypothesis, does not fixate on the first clue, abandons after 3 failed confirmations, and avoids assuming familiar patterns are the cause.
+
+### Phase 4: Test — Run Experiment
+
+One experiment per iteration. Methods include: direct inspection, trace execution, minimal reproduction, binary search, differential debugging, git bisect, input variation.
+
+### Phase 5: Classify
+
+| Result | Action |
+|--------|--------|
+| Bug confirmed | Record with full evidence, severity, location |
+| Hypothesis disproven | Log as eliminated, extract learnings |
+| Inconclusive | Refine hypothesis, re-test |
+| New lead | Log discovery, add to hypothesis queue |
+
+**Severity levels:** CRITICAL (data loss, security breach), HIGH (feature broken), MEDIUM (edge case failure), LOW (cosmetic).
+
+### Phase 6: Log
+
+Append to debug-results.tsv. Every 5 iterations, print progress summary.
+
+### Phase 7: Repeat
+
+Priority for next iteration: follow new leads, untested hypotheses, uninvestigated files, deeper root cause analysis, pattern-based search across codebase.
+
+## Composite Metric
+
+```
+debug_score = bugs_found * 15
+            + hypotheses_tested * 3
+            + (files_investigated / files_in_scope) * 40
+            + (techniques_used / 7) * 10
+```
+
+## Common Bug Patterns
+
+| Language | Classic Bug | Pattern |
+|----------|-------------|---------|
+| JavaScript | Unhandled promise rejection | `Promise` without `.catch` / missing `await` |
+| TypeScript | Lost type narrowing | `obj?.prop` then `obj.other` |
+| Python | Mutable default argument | `def f(x=[]):` |
+| Go | Goroutine leak | Goroutine blocks on unclosed channel |
+| Rust | Panic from `.unwrap()` | `Option::unwrap()` on `Err` path |
+
+## Investigation Techniques
+
+- **Binary Search:** Comment out half the suspicious code. If bug disappears, it is in that half.
+- **Differential Debugging:** Compare working state vs broken state via `git stash`, `git bisect`, or environment diff.
+- **Minimal Reproduction:** Strip away everything until the smallest possible failing case remains.
+- **Trace Execution:** Add strategic logging at key data flow points.
+- **Pattern Search:** Found one bug? Search for the same anti-pattern across the codebase.
+- **Working Backwards:** Start from the error output and trace backward.
+- **5 Whys:** Ask "why" recursively until reaching a permanently fixable root cause.
+
+## Chaining
+
+After the debug loop completes, the agent can chain to `/maxsim:fix-loop` targeting the discovered issues.
+
+## Output
+
+Creates `debug/{YYMMDD}-{HHMM}-{slug}/` with: `findings.md`, `eliminated.md`, `debug-results.tsv`, `summary.md`.

--- a/templates/skills/autoresearch/references/fix.md
+++ b/templates/skills/autoresearch/references/fix.md
@@ -1,0 +1,125 @@
+# Fix Workflow
+
+Autonomous fix loop that takes a broken state and iteratively repairs it until everything passes. One fix per iteration. Atomic, committed, verified, auto-reverted on failure.
+
+## Trigger
+
+- User invokes `/maxsim:fix-loop`
+- User says "fix all errors", "make tests pass", "fix the build", "clean up all warnings"
+
+## Interactive Setup
+
+If invoked without explicit `--target`, `--guard`, or `--scope`, the agent first auto-detects all failures (tests, types, lint, build), then collects user input via a single batched call with 4 questions:
+
+| # | Header | Question |
+|---|--------|----------|
+| 1 | Fix What | "Found [N] failures. What should I fix?" |
+| 2 | Guard | "What command must always pass?" |
+| 3 | Scope | "Which files can I modify?" |
+| 4 | Launch | "Ready to fix?" |
+
+## Phases
+
+### Phase 1: Detect — What Is Broken?
+
+The agent auto-detects failures by running: test suite, type checker, linter, build, and checking for debug findings.
+
+### Phase 2: Prioritize — Fix Order
+
+| Priority | Category | Rationale |
+|----------|----------|-----------|
+| 1 | Build failures | Nothing works if it does not compile |
+| 2 | Critical/High bugs | From debug findings |
+| 3 | Type errors | Type safety prevents cascading bugs |
+| 4 | Test failures | Tests verify correctness |
+| 5 | Medium/Low bugs | From debug findings |
+| 6 | Lint errors | Code quality |
+| 7 | Warnings | Polish |
+
+Within a category, the agent prioritizes by cascading impact, simplicity, and file locality.
+
+### Phase 3: Fix ONE Thing
+
+The agent picks the highest-priority unfixed item and makes one focused change.
+
+Rules:
+- ONE fix per iteration.
+- Fix the implementation, not the test (unless the test is genuinely wrong).
+- Never add `@ts-ignore`, `eslint-disable`, `# type: ignore` to suppress errors.
+- Never use `any` type to silence TypeScript.
+- Never delete tests.
+- Prefer minimal changes.
+
+**Fix strategies by language:**
+
+| Language | Never Do | Correct Pattern |
+|----------|----------|-----------------|
+| TypeScript | `any`, `@ts-ignore` | Proper interfaces, generics, discriminated unions |
+| Python | Bare `except:` | `except SpecificError:` with full type hints |
+| Go | Ignoring errors with `_` | `fmt.Errorf("context: %w", err)` |
+| Rust | `.unwrap()` in production | `Result<T, E>` propagation with `?` |
+
+### Phase 4: Commit
+
+```bash
+git add <modified-files>
+git commit -m "fix: [what was fixed] — [file:line]"
+```
+
+Commit before running verification for clean rollback.
+
+### Phase 5: Verify
+
+Re-run detection and compare: `delta = previous_errors - current_errors`. Expected: `delta > 0`.
+
+### Phase 6: Guard
+
+If a guard command is specified, the agent runs it to check for regressions.
+
+### Phase 7: Decide
+
+| Condition | Action | Status |
+|-----------|--------|--------|
+| `delta > 0` AND guard passes | KEEP | fixed |
+| `delta > 0` AND guard fails | REWORK (max 2 attempts) | rework |
+| `delta == 0` | DISCARD — revert | discard |
+| `delta < 0` | DISCARD — revert immediately | discard |
+| Crash | RECOVER (max 3 attempts) | recover |
+| 3rd attempt fails | SKIP to blocked list | blocked |
+
+### Phase 8: Log and Repeat
+
+Append to fix-results.tsv. Every 5 iterations, print progress. If error count reaches zero, stop even in unbounded mode.
+
+## Composite Metric
+
+```
+fix_score = ((baseline_errors - current_errors) / baseline_errors) * 60
+          + quality_deductions
+          + (guard_always_passed ? 25 : 0)
+          + bonus (zero_errors, no_discards)
+```
+
+**Quality deductions:** -5 per suppression used, -10 per deleted test, -3 per `any` type introduced.
+
+## Anti-Patterns
+
+| Anti-Pattern | Do This Instead |
+|--------------|-----------------|
+| Add `@ts-ignore` / `eslint-disable` | Fix the root cause |
+| Use `any` type | Use proper types, generics, or `unknown` |
+| Delete failing tests | Fix the implementation |
+| Empty `catch` blocks | Log at minimum; handle or re-throw |
+| Hardcode values to pass tests | Fix the logic |
+
+## Escalation Path
+
+After 3 failed attempts on the same error:
+1. Document what was tried and why each failed.
+2. Create minimal reproduction case.
+3. Skip to blocked list, continue with others.
+4. Note in summary — suggest `/maxsim:debug-loop` for root cause analysis.
+
+## Output
+
+Creates `fix/{YYMMDD}-{HHMM}-{slug}/` with: `fix-results.tsv`, `summary.md`, `blocked.md`, `impact-assessment.md`.

--- a/templates/skills/autoresearch/references/loop-protocol.md
+++ b/templates/skills/autoresearch/references/loop-protocol.md
@@ -1,0 +1,185 @@
+# Autonomous Loop Protocol
+
+Detailed protocol for the optimization iteration loop. The SKILL.md has the summary; this file has the full rules.
+
+## Loop Modes
+
+- **Unbounded (default):** Loop forever until manually interrupted.
+- **Bounded:** Loop exactly N times when `Iterations: N` is set in the inline config.
+
+When bounded, the agent tracks `current_iteration` against `max_iterations`. After the final iteration, it prints a summary and stops.
+
+## Phase 0: Precondition Checks
+
+The agent completes all checks before entering the loop. It fails fast if any check fails.
+
+1. Verify git repo exists (`git rev-parse --git-dir`).
+2. Check for dirty working tree (`git status --porcelain`). If dirty, warn user and ask to stash or commit first.
+3. Check for stale lock files (`.git/index.lock`).
+4. Check for detached HEAD (`git symbolic-ref HEAD`).
+5. Check for git hooks that might interfere (pre-commit, husky, pre-commit framework).
+
+If any FAIL: stop and inform user. If any WARN: log the warning, proceed with caution.
+
+## Phase 1: Review
+
+Before each iteration, the agent builds situational awareness by completing all 6 steps:
+
+1. Read current state of in-scope files (full context).
+2. Read last 10-20 entries from results log.
+3. Run `git log --oneline -20` to see recent changes.
+4. Run `git diff HEAD~1` (if last iteration was "keep") to review what worked.
+5. Identify what worked, what failed, what is untried — based on both results log and git history.
+6. If bounded: check current_iteration vs max_iterations.
+
+Git history is critical. After rollbacks, state may differ from expectations. The git log shows which experiments were kept vs reverted. The git diff of kept changes reveals what specifically improved the metric.
+
+## Phase 2: Ideate
+
+The agent picks the next change by consulting git history and results log first.
+
+**Priority order:**
+1. Fix crashes/failures from previous iteration first.
+2. Exploit successes — run `git diff` on last kept commit, try variants in same direction.
+3. Explore new approaches — cross-reference results log and git history for untried approaches.
+4. Combine near-misses — two changes that individually did not help might work together.
+5. Simplify — remove code while maintaining metric.
+6. Radical experiments — when incremental changes stall, try something dramatically different.
+
+**Anti-patterns:** Do not repeat an exact change that was already discarded. Do not make multiple unrelated changes at once. Do not chase marginal gains with ugly complexity.
+
+## Phase 3: Modify (One Atomic Change)
+
+- Make ONE focused change to in-scope files.
+- The change should be explainable in one sentence.
+- Write the description BEFORE making the change.
+
+One logical change may span multiple files if it serves a single purpose. The one-sentence test: if you need "and" to describe it, it is two changes — split them.
+
+## Phase 4: Commit (Before Verification)
+
+The agent commits before running verification to enable clean rollback.
+
+```bash
+git add <file1> <file2> ...
+git diff --cached --quiet  # exit 0 = no changes, skip commit
+git commit -m "experiment(<scope>): <description>"
+```
+
+Rules:
+- Never use `git add -A` — stage only specific in-scope files.
+- If no staged changes: log as `no-op`, skip verification, proceed to next iteration.
+- Use conventional commit format with `experiment` type.
+- If a pre-commit hook blocks the commit: fix the issue and retry (max 2 attempts). Never use `--no-verify`.
+
+**Rollback strategy:**
+```bash
+# Preferred: git revert (preserves history)
+git revert HEAD --no-edit
+
+# Fallback if revert conflicts:
+git revert --abort && git reset --hard HEAD~1
+```
+
+Prefer `git revert` over `git reset --hard` because revert preserves the experiment in history for learning.
+
+## Phase 5: Verify (Mechanical Only)
+
+Run the agreed-upon verification command. Capture output. Extract the metric number.
+
+If verification exceeds 2x normal time, kill and treat as crash.
+
+### Noise Handling (for Volatile Metrics)
+
+Some metrics are inherently noisy (benchmark times, ML accuracy). Strategies:
+
+- **Multi-run verification:** Run verify N times, use the median.
+- **Minimum improvement threshold:** Ignore improvements smaller than the noise floor.
+- **Confirmation run:** Re-verify before making a final keep decision.
+- **Environment pinning:** Pin random seeds, use deterministic test ordering, flush caches.
+
+## Phase 5.5: Guard (Regression Check)
+
+If a guard command was defined, the agent runs it after verification.
+
+- **Verify** answers: "Did the metric improve?"
+- **Guard** answers: "Did anything else break?"
+
+Guard rules:
+- Run only if a guard was defined.
+- Run after verify — no point checking guard if the metric did not improve.
+- Pass/fail only (exit code 0 = pass).
+- If guard fails, revert and rework (max 2 attempts).
+- Never modify guard/test files — adapt the implementation instead.
+
+## Phase 6: Decide
+
+```
+IF metric_improved AND (no guard OR guard_passed):
+    STATUS = "keep"
+ELIF metric_improved AND guard_failed:
+    Revert, then rework (max 2 attempts)
+    If still failing after 2 attempts: STATUS = "discard"
+ELIF metric_same_or_worse:
+    STATUS = "discard" — revert
+ELIF crashed:
+    Attempt fix (max 3 tries), else STATUS = "crash" — revert
+```
+
+**Simplicity override:** If metric barely improved (+<0.1%) but the change adds significant complexity, treat as "discard". If metric is unchanged but code is simpler, treat as "keep".
+
+## Phase 7: Log Results
+
+Append to results log (TSV format). See `results-logging.md` for the full protocol.
+
+Valid statuses: `keep`, `keep (reworked)`, `discard`, `crash`, `no-op`, `hook-blocked`.
+
+## Phase 8: Repeat
+
+### Unbounded Mode (default)
+
+Go to Phase 1. Never stop. Never ask if the agent should continue.
+
+### Bounded Mode
+
+```
+IF current_iteration < max_iterations:
+    Go to Phase 1
+ELIF goal_achieved:
+    Print early completion, print final summary, STOP
+ELSE:
+    Print final summary, STOP
+```
+
+**Final summary format:**
+```
+=== Optimization Complete (N/N iterations) ===
+Baseline: {baseline} → Final: {current} ({delta})
+Keeps: X | Discards: Y | Crashes: Z | Skipped: W
+Best iteration: #{n} — {description}
+```
+
+### When Stuck (>5 consecutive discards)
+
+1. Re-read all in-scope files from scratch.
+2. Re-read the original goal/direction.
+3. Review entire results log for patterns.
+4. Try combining 2-3 previously successful changes.
+5. Try the opposite of what has not been working.
+6. Try a radical architectural change.
+
+## Crash Recovery
+
+- Syntax error: fix immediately, do not count as separate iteration.
+- Runtime error: attempt fix (max 3 tries), then move on.
+- Resource exhaustion (OOM): revert, try smaller variant.
+- Infinite loop/hang: kill after timeout, revert, avoid that approach.
+- External dependency failure: skip, log, try different approach.
+
+## Communication
+
+- Do not ask "should I keep going?" In unbounded mode, always continue. In bounded mode, continue until N is reached.
+- Do not summarize after each iteration — just log and continue.
+- Print a brief one-line status every ~5 iterations.
+- Alert if something surprising or game-changing is discovered.
+- Print a final summary when bounded loop completes.

--- a/templates/skills/autoresearch/references/results-logging.md
+++ b/templates/skills/autoresearch/references/results-logging.md
@@ -1,0 +1,80 @@
+# Results Logging Protocol
+
+The agent tracks every iteration in a structured TSV log. This enables pattern recognition and prevents repeating failed experiments.
+
+## Setup and Initialization
+
+The agent creates the log automatically at Phase 0 (baseline):
+
+1. Create log file with metric direction header and column names.
+2. Add `autoresearch-results.tsv` to `.gitignore`.
+3. Run verify command to establish baseline metric.
+4. Record baseline as iteration 0.
+
+## Log Format (TSV)
+
+File: `autoresearch-results.tsv` in the working directory (gitignored).
+
+```tsv
+# metric_direction: higher_is_better
+iteration	commit	metric	delta	guard	status	description
+0	a1b2c3d	85.2	0.0	pass	baseline	initial state — coverage 85.2%
+1	b2c3d4e	87.1	+1.9	pass	keep	add auth middleware tests
+2	-	86.5	-0.6	-	discard	refactor test helpers
+```
+
+### Columns
+
+| Column | Type | Description |
+|--------|------|-------------|
+| iteration | int | Sequential counter starting at 0 (baseline) |
+| commit | string | Short git hash (7 chars), "-" if reverted |
+| metric | float | Measured value from verification |
+| delta | float | Change from previous best |
+| guard | enum | `pass`, `fail`, or `-` (no guard configured) |
+| status | enum | `baseline`, `keep`, `keep (reworked)`, `discard`, `crash`, `no-op`, `hook-blocked` |
+| description | string | One-sentence description of what was tried |
+
+## Reading and Using the Log
+
+At each iteration (Phase 1 Review), the agent reads the last 10-20 entries for pattern recognition:
+
+- Count outcomes for progress tracking (keeps, discards, crashes).
+- Detect stuck state: more than 5 consecutive discards triggers the "When Stuck" protocol.
+- Cross-reference "keep" rows with git log to find winning patterns.
+
+## Integration with the Loop
+
+```
+Phase 0 (Setup):    CREATE log file, record baseline (iteration 0)
+Phase 1 (Review):   READ last 10-20 log entries for pattern recognition
+Phase 3-6 (Loop):   Modify, Commit, Verify, Decide
+Phase 7 (Log):      APPEND new row after keep/discard/crash decision
+Phase 8 (Repeat):   Back to Phase 1 (reads updated log)
+```
+
+## Log Management
+
+- Create at setup (iteration 0 = baseline).
+- Append after every iteration (including crashes).
+- Do not commit this file to git (add to .gitignore).
+- Read last 10-20 entries at start of each iteration for context.
+
+## Summary Reporting
+
+Every 10 iterations (or at loop completion in bounded mode), the agent prints a brief summary:
+
+```
+=== Progress (iteration 20) ===
+Baseline: 85.2% → Current best: 92.1% (+6.9%)
+Keeps: 8 | Discards: 10 | Crashes: 2
+Last 5: keep, discard, discard, keep, keep
+```
+
+## Metric Direction
+
+Clarified at setup:
+- **Lower is better:** response time, bundle size, error count.
+- **Higher is better:** test coverage, lighthouse score, throughput.
+
+Recorded in the first line of the results log as a comment: `# metric_direction: higher_is_better`.

--- a/templates/skills/autoresearch/references/security.md
+++ b/templates/skills/autoresearch/references/security.md
@@ -1,0 +1,139 @@
+# Security Workflow
+
+Autonomous security auditing that uses the optimization loop to iteratively discover, validate, and report vulnerabilities. Combines STRIDE threat modeling, OWASP Top 10 sweeps, and red-team adversarial analysis.
+
+## Trigger
+
+- User invokes `/maxsim:security`
+- User says "security audit", "threat model", "find vulnerabilities", "red-team", "OWASP", "STRIDE"
+
+## Interactive Setup
+
+If invoked without `--diff`, scope, or focus, the agent scans the codebase first, then collects context via a single batched call with 3 questions:
+
+| # | Header | Question |
+|---|--------|----------|
+| 1 | Scope | "What should I audit?" |
+| 2 | Depth | "How thorough?" |
+| 3 | Action | "What should I do with confirmed vulnerabilities?" |
+
+## Setup Phase — Threat Model Generation
+
+### Step 1: Codebase Reconnaissance
+
+The agent scans: dependencies (package.json, requirements.txt, go.mod), secrets handling (.env.example, config), infrastructure (Dockerfile, docker-compose), API routes, auth/middleware, database schemas, CI/CD configs.
+
+### Step 2: Asset Identification
+
+| Asset Type | Priority |
+|------------|----------|
+| Data stores (DB, Redis, cookies) | Critical |
+| Authentication (JWT, OAuth, sessions) | Critical |
+| API endpoints (REST, GraphQL, webhooks) | High |
+| External services (payment, email, CDN) | High |
+| User input surfaces (forms, URL params, uploads) | High |
+| Configuration (env vars, CORS, feature flags) | Medium |
+
+### Step 3: Trust Boundary Mapping
+
+The agent identifies where trust levels change: browser/server, server/database, public/authenticated routes, user/admin roles, CI/CD/production, container/host.
+
+### Step 4: STRIDE Threat Model
+
+For each asset + trust boundary combination:
+
+| Threat | Question |
+|--------|----------|
+| **S**poofing | Can an attacker impersonate a user/service? |
+| **T**ampering | Can data be modified in transit or at rest? |
+| **R**epudiation | Can actions be denied without evidence? |
+| **I**nformation Disclosure | Can sensitive data leak? |
+| **D**enial of Service | Can the service be disrupted? |
+| **E**levation of Privilege | Can a user gain unauthorized access? |
+
+### Step 5: Attack Surface Map
+
+The agent generates an attack surface map showing entry points, data flows, and abuse paths.
+
+### Step 6: Baseline
+
+The agent runs existing security linting (`npm audit`, `eslint-plugin-security`, `bandit`, etc.) and records the count as baseline iteration 0.
+
+## The Security Loop
+
+Each iteration follows the optimization loop pattern adapted for security:
+
+1. **Review:** Read threat model + past findings + results log. Select next untested attack vector by priority: critical STRIDE threats, OWASP categories not covered, high-severity attack paths, dependency vulnerabilities, configuration weaknesses, business logic flaws.
+2. **Analyze:** Deep-dive into target code for the selected vector. Trace data flow, identify missing validation or access checks.
+3. **Validate:** Construct proof with vulnerable code location (file:line), attack scenario, triggering input, expected vs actual behavior, impact assessment, confidence level (Confirmed/Likely/Possible).
+4. **Classify:** Assign severity (Critical/High/Medium/Low/Info) + OWASP category + STRIDE category.
+5. **Log:** Append to security-audit-results.tsv.
+6. **Repeat.**
+
+Every 5 iterations, print coverage summary showing STRIDE and OWASP coverage.
+
+## OWASP Top 10 Checks
+
+| ID | Category | Key Checks |
+|----|----------|-----------|
+| A01 | Broken Access Control | IDOR, missing auth middleware, privilege escalation, CORS |
+| A02 | Cryptographic Failures | Plaintext secrets, weak hashing, hardcoded keys |
+| A03 | Injection | SQL/NoSQL, command injection, XSS, template injection |
+| A04 | Insecure Design | Missing rate limiting, no account lockout, race conditions, CSRF |
+| A05 | Security Misconfiguration | Debug mode, default credentials, verbose errors, missing headers |
+| A06 | Vulnerable Components | Known CVEs, outdated frameworks, unmaintained deps |
+| A07 | Auth Failures | Weak passwords, no MFA, JWT vulnerabilities, session fixation |
+| A08 | Data Integrity Failures | Missing CI/CD integrity checks, insecure deserialization |
+| A09 | Logging Failures | Missing audit logs, sensitive data in logs, log injection |
+| A10 | SSRF | Unvalidated URLs, DNS rebinding, missing allowlists |
+
+## Red-Team Adversarial Lenses
+
+| Persona | Mindset | Focus |
+|---------|---------|-------|
+| Security Adversary | "I am a hacker breaching this system" | Auth bypass, injection, data exposure |
+| Supply Chain Attacker | "I am compromising dependencies or build pipeline" | Dependency CVEs, CI/CD weaknesses |
+| Insider Threat | "I am a malicious employee" | Privilege escalation, data exfiltration |
+| Infrastructure Attacker | "I am attacking the deployment" | Container escape, exposed services, env secrets |
+
+## Composite Metric
+
+```
+metric = (owasp_categories_tested / 10) * 50
+       + (stride_categories_tested / 6) * 30
+       + min(finding_count, 20)
+```
+
+Direction: higher is better. Maximum: 100.
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--diff` | Delta mode — only audit files changed since last audit |
+| `--fix` | After audit, auto-fix confirmed Critical/High findings |
+| `--fail-on <severity>` | Exit non-zero if findings meet threshold (for CI gating) |
+
+### Delta Mode (`--diff`)
+
+The agent finds the latest previous audit, parses its findings, runs `git diff` to find changed files, and scopes the current audit to only those files. Findings are marked as New, Fixed, or Recurring.
+
+### Auto-Fix (`--fix`)
+
+After the audit, the agent filters for Confirmed Critical/High findings and switches to the fix loop targeting those issues. Safety rules: never fix Low/Info automatically, never modify test files, max 3 attempts per finding.
+
+### Severity Gate (`--fail-on`)
+
+After generating the report, the agent checks findings against the threshold. If met, it exits non-zero for CI pipeline blocking.
+
+## Anti-Patterns
+
+- Do not report theoretical risks without code evidence.
+- Do not skip categories — aim for 100% OWASP + STRIDE coverage.
+- Do not test against live production — analyze code statically.
+- Do not report the same finding twice.
+- Do not prioritize quantity over quality — 5 confirmed critical findings outweigh 50 theoretical lows.
+
+## Output
+
+Creates `security/{YYMMDD}-{HHMM}-{slug}/` with: `overview.md`, `threat-model.md`, `attack-surface-map.md`, `findings.md`, `owasp-coverage.md`, `dependency-audit.md`, `recommendations.md`, `security-audit-results.tsv`.


### PR DESCRIPTION
## Summary

- Adds the autoresearch skill (skill #15 of 15) to `templates/skills/autoresearch/`
- Adapted from the source autoresearch claude-plugin for MaxsimCLI conventions: YAML frontmatter with spec description, `/maxsim:` command names, no `@` imports, third-person descriptions, under 500 lines
- Includes SKILL.md (169 lines) and 6 reference workflows: `loop-protocol.md`, `debug.md`, `fix.md`, `security.md`, `results-logging.md`, `core-principles.md`
- Powers `/maxsim:improve`, `/maxsim:fix-loop`, `/maxsim:debug-loop`, `/maxsim:security` commands

## Test plan

- [x] `npm run build` passes (89 template files copied to dist/assets/)
- [x] `npm test` passes (325 tests)
- [x] `npm run lint` passes (only pre-existing warnings)
- [x] SKILL.md references match actual file names in `references/`
- [x] No `@` imports in any file
- [x] SKILL.md under 500 lines (169 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)