### PR TITLE
feat: add 4 missing slash commands (improve, fix-loop, debug-loop, security)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,6 @@ docs/*
 !docs/multi-runtime-architecture.md
 analysis/
 gaps.md
-improve.md
+/improve.md
 philosophy.md
 autoresearch-results.tsv

--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -30,7 +30,7 @@ maxsimcli/                        ← repo root
 │   └── website/                  ← maxsimcli.dev (React + Vite + Tailwind)
 ├── templates/                    ← source templates (copied to dist/ at build time)
 │   ├── agents/                   ← 4 agent definitions
-│   ├── commands/maxsim/          ← 9 slash commands
+│   ├── commands/maxsim/          ← 13 slash commands
 │   ├── skills/                   ← 14 skill modules
 │   ├── workflows/                ← 18 workflow orchestrators
 │   ├── references/               ← reference documents
@@ -118,21 +118,25 @@ Layer 3 — AGENT
 Commands are the only user-facing surface. Workflows are never invoked
 directly. Agents are spawned by workflows, not by commands.
 
-### Commands (9)
+### Commands (13)
 
 Located at `templates/commands/maxsim/`:
 
-| Command    | Workflow loaded        | Purpose                                  |
-|------------|------------------------|------------------------------------------|
-| `go`       | `go.md`                | Auto-detect project state and dispatch   |
-| `init`     | `init.md`              | Initialize project + GitHub structure    |
-| `plan`     | `plan.md`              | Plan a phase (Discussion→Research→Plan)  |
-| `execute`  | `execute.md`           | Execute a phase with agents + worktrees  |
-| `debug`    | `debug.md`             | Systematic debugging flow                |
-| `quick`    | `quick.md`             | Single-issue quick task                  |
-| `progress` | `progress.md`          | Show board status + next recommendation  |
-| `settings` | `settings.md`          | Configure model profile + options        |
-| `help`     | `help.md`              | Command reference                        |
+| Command      | Workflow loaded        | Purpose                                  |
+|--------------|------------------------|------------------------------------------|
+| `go`         | `go.md`                | Auto-detect project state and dispatch   |
+| `init`       | `init.md`              | Initialize project + GitHub structure    |
+| `plan`       | `plan.md`              | Plan a phase (Discussion→Research→Plan)  |
+| `execute`    | `execute.md`           | Execute a phase with agents + worktrees  |
+| `debug`      | `debug.md`             | Systematic debugging flow                |
+| `quick`      | `quick.md`             | Single-issue quick task                  |
+| `improve`    | `improve.md`           | Autoresearch optimization loop           |
+| `fix-loop`   | `fix-loop.md`          | Autonomous error repair loop             |
+| `debug-loop` | `debug-loop.md`        | Scientific method bug hunting loop       |
+| `security`   | `security.md`          | STRIDE + OWASP + red-team audit          |
+| `progress`   | `progress.md`          | Show board status + next recommendation  |
+| `settings`   | `settings.md`          | Configure model profile + options        |
+| `help`       | `help.md`              | Command reference                        |
 
 ### Workflows (18)
 
@@ -382,7 +386,7 @@ directly — it is copied into `dist/assets/templates/` during the build.
 
 ```
 .claude/
-├── commands/maxsim/       ← 9 slash commands (from templates/commands/maxsim/)
+├── commands/maxsim/       ← 13 slash commands (from templates/commands/maxsim/)
 ├── agents/                ← 4 agent definitions + AGENTS.md
 ├── skills/                ← 14 skill modules (one subdirectory each)
 ├── rules/                 ← conventions + verification protocol

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -71,7 +71,7 @@ One command. Installs project-locally into `.claude/`. No global installation.
 ```
 .claude/
 ├── settings.json          # Claude Code settings (hooks, permissions, env)
-├── commands/maxsim/       # 9 slash commands
+├── commands/maxsim/       # 13 slash commands
 ├── agents/                # 4 agent definitions + AGENTS.md registry
 ├── skills/                # 15 skill modules
 ├── rules/                 # Conventions + verification protocol
@@ -743,7 +743,7 @@ maxsimcli/
 │   └── website/          # Landing page + documentation (React + Vite)
 ├── templates/            # Source templates (copied to .claude/ during install)
 │   ├── agents/           # 4 agent definitions + AGENTS.md registry
-│   ├── commands/maxsim/  # 9 slash commands
+│   ├── commands/maxsim/  # 13 slash commands
 │   ├── skills/           # 14 skill modules
 │   ├── workflows/        # Workflow definitions
 │   ├── references/       # Reference documents
@@ -887,10 +887,10 @@ REMOVED: commands.ts (functionality covered by client.ts + individual modules)
 **Commit:** `feat: install system with complete uninstall`
 
 ### Phase 4: Commands + Workflows
-**Goal:** 9 slash commands with correct tool names and GitHub-first workflows.
+**Goal:** 13 slash commands with correct tool names and GitHub-first workflows.
 **Spec:** PROJECT.md §6, `docs/spec/init-process-design.md`, `docs/spec/wave-execution-design.md`
 ```
-1. templates/commands/maxsim/ — All 9 commands (correct frontmatter)
+1. templates/commands/maxsim/ — All 13 commands (correct frontmatter)
    - Use 'Agent' tool (NOT 'Task')
    - Use correct allowed-tools
    - Correct argument-hint on all commands

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ That is the core loop. Init, plan, execute, verify. Each phase is isolated, each
 
 ## What You Get
 
-MAXSIM ships 9 slash commands, 4 agents, 14 skills, and 18 workflows. Here is what that means in practice.
+MAXSIM ships 13 slash commands, 4 agents, 14 skills, and 18 workflows. Here is what that means in practice.
 
 **Spec-driven development.** All work flows through GitHub — phase Issues, sub-issue tasks, Project Board columns, and structured comments. The GitHub Project Board is the single source of truth. Agents read from it and update it as they work.
 
@@ -101,7 +101,7 @@ Run this from your project root. Everything goes into `.claude/`.
 
 The installer copies these files into `.claude/`:
 
-- 9 slash commands (`/maxsim:init`, `/maxsim:plan`, etc.)
+- 13 slash commands (`/maxsim:init`, `/maxsim:plan`, etc.)
 - 4 agent definitions (executor, planner, researcher, verifier)
 - 14 skills (TDD, debugging, code review, and more)
 - 18 workflow files
@@ -114,7 +114,7 @@ The installer copies these files into `.claude/`:
 
 ```
 .claude/
-├── commands/maxsim/          # 9 slash commands
+├── commands/maxsim/          # 13 slash commands
 ├── maxsim/
 │   ├── bin/maxsim-tools.cjs  # Tool binary
 │   ├── workflows/            # 18 workflows

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -60,7 +60,7 @@ That is the core loop. Init, plan, execute, verify. Each phase is isolated, each
 
 ## What You Get
 
-MAXSIM ships 9 slash commands, 4 agents, 14 skills, and 18 workflows. Here is what that means in practice.
+MAXSIM ships 13 slash commands, 4 agents, 14 skills, and 18 workflows. Here is what that means in practice.
 
 **Spec-driven development.** All work flows through GitHub — phase Issues, sub-issue tasks, Project Board columns, and structured comments. The GitHub Project Board is the single source of truth. Agents read from it and update it as they work.
 
@@ -101,7 +101,7 @@ Run this from your project root. Everything goes into `.claude/`.
 
 The installer copies these files into `.claude/`:
 
-- 9 slash commands (`/maxsim:init`, `/maxsim:plan`, etc.)
+- 13 slash commands (`/maxsim:init`, `/maxsim:plan`, etc.)
 - 4 agent definitions (executor, planner, researcher, verifier)
 - 14 skills (TDD, debugging, code review, and more)
 - 18 workflow files
@@ -114,7 +114,7 @@ The installer copies these files into `.claude/`:
 
 ```
 .claude/
-├── commands/maxsim/          # 9 slash commands
+├── commands/maxsim/          # 13 slash commands
 ├── maxsim/
 │   ├── bin/maxsim-tools.cjs  # Tool binary
 │   ├── workflows/            # 18 workflows

--- a/packages/cli/src/install/claudemd.ts
+++ b/packages/cli/src/install/claudemd.ts
@@ -26,6 +26,10 @@ This project uses [MaxsimCLI](https://maxsimcli.dev) for structured development.
 | \`/maxsim:execute [N]\` | Execute a planned phase |
 | \`/maxsim:debug [desc]\` | Debug a specific issue |
 | \`/maxsim:quick [desc]\` | Quick task (simplified flow) |
+| \`/maxsim:improve [metric]\` | Autonomous optimization loop |
+| \`/maxsim:fix-loop [cmd]\` | Autonomous error repair |
+| \`/maxsim:debug-loop [symptom]\` | Autonomous bug hunting |
+| \`/maxsim:security [scope]\` | Security audit (read-only) |
 | \`/maxsim:progress\` | Show project status + recommendation |
 | \`/maxsim:settings\` | Configure MaxsimCLI |
 | \`/maxsim:help\` | Show help |

--- a/packages/cli/tests/unit/install.test.ts
+++ b/packages/cli/tests/unit/install.test.ts
@@ -64,9 +64,9 @@ describe('generateClaudeMd', () => {
     expect(md).toContain('/maxsim:execute');
   });
 
-  it('includes all 9 commands', () => {
+  it('includes all 13 commands', () => {
     const md = generateClaudeMd('test');
-    const commands = [':go', ':init', ':plan', ':execute', ':debug', ':quick', ':progress', ':settings', ':help'];
+    const commands = [':go', ':init', ':plan', ':execute', ':debug', ':quick', ':improve', ':fix-loop', ':debug-loop', ':security', ':progress', ':settings', ':help'];
     for (const cmd of commands) {
       expect(md).toContain(cmd);
     }

--- a/packages/website/src/components/sections/Docs.tsx
+++ b/packages/website/src/components/sections/Docs.tsx
@@ -199,7 +199,7 @@ function GettingStarted() {
         <CodeBlock
           language="text"
           code={`.claude/
-├── commands/maxsim/   # 9 user-facing commands (/maxsim:*)
+├── commands/maxsim/   # 13 user-facing commands (/maxsim:*)
 ├── agents/            # 4 specialized agent prompts
 └── hooks/             # Pre/post hooks for automation`}
         />
@@ -349,7 +349,7 @@ agents/*.md                # Specialized subagent prompts (4 agents)`}
         <CodeBlock
           language="text"
           code={`.claude/
-├── commands/maxsim/       # 9 slash commands
+├── commands/maxsim/       # 13 slash commands
 ├── agents/                # 4 agent definitions + AGENTS.md
 ├── skills/                # 14 skill modules
 ├── rules/                 # Conventions + verification

--- a/packages/website/src/content/docs/installation.md
+++ b/packages/website/src/content/docs/installation.md
@@ -22,7 +22,7 @@ MaxsimCLI installs into `.claude/` at your project root:
 
 {% codeblock language="text" %}
 .claude/
-├── commands/maxsim/      # 9 user-facing commands (/maxsim:*)
+├── commands/maxsim/      # 13 user-facing commands (/maxsim:*)
 ├── agents/               # 4 specialized subagent prompts
 ├── skills/               # 14 reusable skill modules
 ├── rules/                # Standing rules loaded into every session

--- a/packages/website/src/content/docs/what-is-maxsim.md
+++ b/packages/website/src/content/docs/what-is-maxsim.md
@@ -16,4 +16,4 @@ Quality control is built into the cycle through verification gates. A phase cann
 
 MaxsimCLI is built exclusively for Claude Code. It uses GitHub as its source of truth — phase plans, decisions, blockers, and task state are tracked as GitHub Issues and comments rather than local files.
 
-MaxsimCLI ships as an npm package and installs markdown files (9 commands, 4 agent definitions, 14 skill modules, and workflow templates) into your project's `.claude/` directory. The "runtime" for MaxsimCLI is Claude Code itself. You use it through slash commands like `/maxsim:plan` and `/maxsim:execute`, not through a CLI binary you keep running.
+MaxsimCLI ships as an npm package and installs markdown files (13 commands, 4 agent definitions, 14 skill modules, and workflow templates) into your project's `.claude/` directory. The "runtime" for MaxsimCLI is Claude Code itself. You use it through slash commands like `/maxsim:plan` and `/maxsim:execute`, not through a CLI binary you keep running.

--- a/templates/commands/maxsim/debug-loop.md
+++ b/templates/commands/maxsim/debug-loop.md
@@ -1,0 +1,78 @@
+---
+name: maxsim:debug-loop
+description: Autonomous bug hunting — scientific method with hypothesis testing
+argument-hint: "[symptom]"
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion, EnterPlanMode, ExitPlanMode]
+---
+
+<objective>
+Autonomously hunt down bugs using the scientific method: reproduce the symptom, form hypotheses, test each hypothesis, fix confirmed root causes, and verify the fix. Loop until the bug is resolved or all hypotheses are exhausted.
+</objective>
+
+<context>
+Arguments: $ARGUMENTS
+
+If $ARGUMENTS is provided, treat it as the symptom description.
+
+GitHub is the sole source of truth. Debug sessions are tracked as GitHub Issues (label: `debug`). Results are tracked in `.claude/agent-memory/maxsim-learner/autoresearch-results.tsv`.
+
+This command uses Plan Mode to gather symptom details before autonomous investigation begins.
+</context>
+
+<process>
+Invoke the `autoresearch` skill (debug workflow) to drive the investigation loop. Invoke the `systematic-debugging` skill for the reproduce-hypothesize-isolate-verify-fix cycle at each iteration.
+
+**Phase 1 — Setup (Plan Mode)**
+
+1. Enter Plan Mode via EnterPlanMode
+2. Gather symptom details via AskUserQuestion:
+   - **Symptom** — what is the observed incorrect behavior (from $ARGUMENTS or ask)
+   - **Expected behavior** — what should happen instead
+   - **Reproduction steps** — how to trigger the bug (command, input, sequence)
+   - **Reproduction command** — a single command that demonstrates the bug (e.g., `npm test -- --grep "failing test"`)
+   - **Scope** — which files/directories are likely involved (or "unknown")
+3. Attempt initial reproduction — run the reproduction command to confirm the bug exists
+4. Create a GitHub Issue labeled `debug` to track the session
+5. Show the investigation plan and confirm with user
+6. Exit Plan Mode via ExitPlanMode
+
+**Phase 2 — Debug Loop**
+
+Repeat until the bug is fixed or hypotheses are exhausted:
+
+1. **Reproduce** — run the reproduction command, capture the exact error output
+   - If not reproducible: gather more data, check environment, check recent changes
+2. **Hypothesize** — form ONE clear hypothesis: "I think X is the root cause because Y"
+   - Read error messages completely (stack traces, line numbers, exit codes)
+   - Check recent changes: `git diff`, `git log --oneline -10`
+   - Trace data flow from symptom back to origin
+   - Do NOT reuse a previously disproven hypothesis
+3. **Test Hypothesis** — design a minimal experiment to confirm or reject
+   - "If X is the cause, then changing Z should produce W"
+   - Make the smallest possible change to test (diagnostic logging, assertion, minimal code change)
+   - Run the experiment and compare expected vs. actual result
+4. **Evaluate** — did the test confirm the hypothesis?
+   - **Confirmed** → proceed to Fix
+   - **Rejected** → log the disproven hypothesis, return to step 2 with a new hypothesis
+5. **Fix** — implement the minimal fix addressing the confirmed root cause
+   - Write a failing test that reproduces the bug (when applicable)
+   - Fix only the identified issue — no "while I'm here" changes
+   - Commit with message `fix(<scope>): <root-cause-description>`
+6. **Verify** — run the reproduction command: the bug must be gone
+   - Run the full test suite: no regressions
+   - If fix introduced regressions → rework or `git revert HEAD --no-edit`
+7. **Log** — append result to TSV (date, iteration, hypothesis, confirmed/rejected, fix-applied, commit-hash, notes)
+
+**Hypothesis Exhaustion:**
+If 5+ hypotheses have been tested and rejected:
+1. Re-read ALL potentially involved files with fresh eyes
+2. Check for environmental factors (config, dependencies, OS-specific)
+3. Try bisecting with `git bisect` to find the introducing commit
+4. If still stuck → update the GitHub debug Issue with all findings and escalate to user
+
+**Termination:**
+Stop when the bug is confirmed fixed, all hypotheses are exhausted, or user interrupts (Ctrl+C).
+
+**Final Report:**
+Display a summary: root cause found (yes/no), hypotheses tested (confirmed/rejected), fix applied, verification evidence. Close the GitHub debug Issue with the resolution summary.
+</process>

--- a/templates/commands/maxsim/fix-loop.md
+++ b/templates/commands/maxsim/fix-loop.md
@@ -1,0 +1,67 @@
+---
+name: maxsim:fix-loop
+description: Autonomous error repair — iteratively fix until zero errors remain
+argument-hint: "[error-command]"
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion, EnterPlanMode, ExitPlanMode]
+---
+
+<objective>
+Autonomously fix all errors reported by a user-specified command. Loop: run the command, parse errors, fix one error at a time, verify the fix, repeat until zero errors remain or the iteration budget is exhausted.
+</objective>
+
+<context>
+Arguments: $ARGUMENTS
+
+If $ARGUMENTS is provided, treat it as the error command (e.g., `npm run build`, `npm test`, `npm run lint`, `tsc --noEmit`).
+
+GitHub is the sole source of truth. Each fix iteration produces an atomic commit. Results are tracked in `.claude/agent-memory/maxsim-learner/autoresearch-results.tsv`.
+
+This command uses Plan Mode to configure the loop parameters before execution begins.
+</context>
+
+<process>
+Invoke the `autoresearch` skill (fix workflow) to drive the repair loop. Invoke the `systematic-debugging` skill when root-cause analysis is needed for non-obvious errors.
+
+**Phase 1 — Setup (Plan Mode)**
+
+1. Enter Plan Mode via EnterPlanMode
+2. Gather loop parameters via AskUserQuestion:
+   - **Error command** — the command that reports errors (from $ARGUMENTS or ask)
+   - **Guard command** — optional regression check that must stay green (e.g., `npm test` when fixing lint errors)
+   - **Iteration budget** — max fix attempts before stopping (default: 30)
+   - **Scope** — which files/directories are in-scope for modification (default: auto-detect from errors)
+3. Run the error command once to establish the baseline error count
+4. Show the proposed loop configuration, baseline error count, and confirm with user
+5. Exit Plan Mode via ExitPlanMode
+
+**Phase 2 — Fix Loop**
+
+Repeat until zero errors or budget exhausted:
+
+1. **Run** — execute the error command, capture full output
+2. **Parse** — extract individual errors with file paths, line numbers, and messages
+3. **Prioritize** — pick ONE error to fix (prefer: blocking errors first, then cascading errors that may resolve others, then simplest)
+4. **Analyze** — read the relevant code, understand the root cause (invoke `systematic-debugging` skill if non-obvious)
+5. **Fix** — make the minimal change to resolve the error (never modify test/guard files)
+6. **Commit** — atomic commit with message `fix(<scope>): <error-description>`
+7. **Verify** — re-run the error command, confirm the targeted error is gone
+   - If the fix introduced new errors → `git revert HEAD --no-edit`, log failure, try a different approach
+   - If the fix resolved the error → proceed
+8. **Guard** — if a guard command is configured, run it to check for regressions
+   - Guard failure → rework (max 2 attempts), then revert and skip this error
+9. **Log** — append result to TSV (date, iteration, error-fixed, error-count-before, error-count-after, commit-hash, notes)
+10. **Progress** — display: errors remaining, errors fixed this session, iteration count
+
+**Stuck Detection:**
+If the same error persists after 3 fix attempts with different approaches:
+1. Log the error as resistant
+2. Skip it and move to the next error
+3. After all other errors are addressed, revisit resistant errors with full context
+4. If still stuck → create a GitHub Issue describing the resistant error and escalate to user
+
+**Termination:**
+Stop when zero errors remain, iteration budget is exhausted, all remaining errors are resistant, or user interrupts (Ctrl+C).
+
+**Final Report:**
+Display a summary: total errors at start, errors fixed, errors remaining (with details), iterations used, resistant errors (if any).
+</process>

--- a/templates/commands/maxsim/improve.md
+++ b/templates/commands/maxsim/improve.md
@@ -1,0 +1,68 @@
+---
+name: maxsim:improve
+description: Autonomous optimization loop — modify→verify→keep/discard cycle against any metric
+argument-hint: "[metric-command]"
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion, EnterPlanMode, ExitPlanMode]
+---
+
+<objective>
+Run the autoresearch 8-phase optimization loop: make ONE atomic change per iteration, verify against a user-defined metric, guard against regressions, keep or discard via git revert. Loop until the target is met or the iteration budget is exhausted.
+</objective>
+
+<context>
+Arguments: $ARGUMENTS
+
+If $ARGUMENTS is provided, treat it as the metric command (e.g., `npm run benchmark`, `wc -l src/**/*.ts`, `npm test -- --coverage`).
+
+GitHub is the sole source of truth. Results are tracked in `.claude/agent-memory/maxsim-learner/autoresearch-results.tsv` (7-column TSV). Git history is the memory — every iteration produces a commit or a revert.
+
+This command uses Plan Mode to configure the loop parameters before execution begins.
+</context>
+
+<process>
+Invoke the `autoresearch` skill to drive the optimization loop. Invoke the `verification` skill for evidence-based confirmation at each iteration.
+
+**Phase 1 — Setup (Plan Mode)**
+
+1. Enter Plan Mode via EnterPlanMode
+2. Gather loop parameters via AskUserQuestion:
+   - **Metric command** — the command whose output is the optimization target (from $ARGUMENTS or ask)
+   - **Guard command** — regression check that must always pass (e.g., `npm test`)
+   - **Direction** — minimize or maximize the metric
+   - **Iteration budget** — max iterations before stopping (default: 20)
+   - **Scope** — which files/directories are in-scope for modification
+3. Show the proposed loop configuration and confirm with user
+4. Exit Plan Mode via ExitPlanMode
+
+**Phase 2 — Optimization Loop**
+
+Run the 8-phase autoresearch loop, one iteration at a time:
+
+1. **Review** — read `git log --oneline -10`, the TSV results file, and recent diffs to understand current state
+2. **Ideate** — exploit successful past approaches, avoid repeated failures, try untried angles
+3. **Modify** — make ONE atomic change to in-scope files (never modify guard/test files)
+4. **Commit** — commit before verification with prefix `experiment(<scope>):`
+5. **Verify** — run the metric command, extract the numeric result, compare to previous best
+6. **Guard** — run the guard command to check for regressions
+   - Guard failure + verify pass → rework (max 2 attempts), then discard
+7. **Decide** — metric improved AND guard passed → keep; otherwise → `git revert HEAD --no-edit`
+8. **Log** — append iteration result to the TSV file (date, iteration, approach, metric-value, outcome, commit-hash, notes)
+
+**Stuck Detection:**
+After 5 consecutive discards:
+1. Re-read ALL in-scope files (full context reload)
+2. Re-read original goal and review entire TSV log for patterns
+3. Try combining 2-3 successful past changes
+4. Try the OPPOSITE approach
+5. Try a radical architectural change
+6. If still stuck → create a diagnostic GitHub Issue and escalate to user
+
+**Noise Handling:**
+For volatile metrics: 3-run median for 1-5% variance, 5-run median for >5% variance. Apply a minimum-delta threshold to filter noise.
+
+**Termination:**
+Stop when iteration budget is exhausted, target metric is reached, or user interrupts (Ctrl+C).
+
+**Final Report:**
+Display a summary: iterations run, best metric achieved, total improvements kept, approaches that worked vs. failed.
+</process>

--- a/templates/commands/maxsim/security.md
+++ b/templates/commands/maxsim/security.md
@@ -1,0 +1,87 @@
+---
+name: maxsim:security
+description: Security audit — STRIDE + OWASP Top 10 + red-team analysis (read-only)
+argument-hint: "[scope]"
+allowed-tools: [Read, Bash, Grep, Glob, WebSearch, WebFetch]
+---
+
+<objective>
+Perform a comprehensive read-only security audit of the codebase using three complementary frameworks: STRIDE threat modeling, OWASP Top 10 vulnerability check, and red-team attack surface analysis. Produce a structured security report with findings ranked by severity.
+</objective>
+
+<context>
+Arguments: $ARGUMENTS
+
+If $ARGUMENTS is provided, treat it as the audit scope (e.g., `src/auth/`, `api endpoints`, `the entire project`). If not provided, audit the entire project.
+
+This is a READ-ONLY command. No code modifications, no commits, no Plan Mode. The allowed tools are restricted to read-only operations.
+
+GitHub is the sole source of truth. The audit report is posted as a GitHub Issue labeled `security-audit`.
+</context>
+
+<process>
+Invoke the `autoresearch` skill (security workflow) to structure the audit.
+
+**Phase 1 — Reconnaissance**
+
+1. Scan the project structure to understand the tech stack, entry points, and architecture
+2. Identify the scope boundary (from $ARGUMENTS or full project)
+3. Map data flows: where does user input enter, how does it flow through the system, where does it exit
+4. Identify trust boundaries: client/server, internal/external, authenticated/unauthenticated
+5. Catalog dependencies and their versions (`package.json`, `go.mod`, `requirements.txt`, etc.)
+
+**Phase 2 — STRIDE Threat Modeling**
+
+For each component in scope, evaluate against STRIDE:
+
+| Threat | Question |
+|--------|----------|
+| **S**poofing | Can an attacker impersonate a user or component? |
+| **T**ampering | Can data be modified in transit or at rest without detection? |
+| **R**epudiation | Can actions be performed without audit trail? |
+| **I**nformation Disclosure | Can sensitive data leak (logs, errors, responses, source)? |
+| **D**enial of Service | Can the system be overwhelmed or made unavailable? |
+| **E**levation of Privilege | Can a user gain unauthorized access or permissions? |
+
+**Phase 3 — OWASP Top 10 Check**
+
+Scan the codebase for patterns matching the OWASP Top 10 (2021):
+
+1. **A01 Broken Access Control** — missing auth checks, IDOR, path traversal
+2. **A02 Cryptographic Failures** — hardcoded secrets, weak algorithms, plaintext storage
+3. **A03 Injection** — SQL, command, template injection; unsanitized input
+4. **A04 Insecure Design** — missing rate limits, no input validation, trust violations
+5. **A05 Security Misconfiguration** — default credentials, verbose errors, unnecessary features
+6. **A06 Vulnerable Components** — known CVEs in dependencies
+7. **A07 Authentication Failures** — weak passwords, missing MFA, session issues
+8. **A08 Data Integrity Failures** — unsigned updates, deserialization, CI/CD pipeline gaps
+9. **A09 Logging Failures** — missing audit logs, sensitive data in logs
+10. **A10 SSRF** — unvalidated URLs, internal network access
+
+**Phase 4 — Red-Team Analysis**
+
+Think like an attacker:
+
+1. Identify the highest-value targets (credentials, PII, admin access, payment data)
+2. Map realistic attack paths from public entry points to high-value targets
+3. Assess each path: what controls exist, what gaps remain
+4. Check for common red-team findings: exposed debug endpoints, information leakage in error messages, insecure defaults, privilege escalation chains
+
+**Phase 5 — Report**
+
+Generate a structured security report:
+
+1. **Executive Summary** — overall risk posture (Critical / High / Medium / Low)
+2. **Findings Table** — each finding with:
+   - Severity (Critical / High / Medium / Low / Info)
+   - Category (STRIDE letter / OWASP number / Red-team)
+   - Location (file path and line number)
+   - Description (what the vulnerability is)
+   - Impact (what an attacker could achieve)
+   - Recommendation (how to fix it)
+3. **Positive Findings** — security controls that are correctly implemented
+4. **Dependency Audit** — known CVEs in dependencies (if any)
+5. **Recommendations** — prioritized list of remediations
+
+Post the report as a GitHub Issue labeled `security-audit` with the current date in the title.
+</process>

--- a/templates/skills/using-maxsim/SKILL.md
+++ b/templates/skills/using-maxsim/SKILL.md
@@ -23,6 +23,10 @@ Determine user intent, then route to the correct command.
 | Execute planned work | `/maxsim:execute N` |
 | Fix a bug | `/maxsim:debug` |
 | Quick one-off task | `/maxsim:quick` |
+| Optimize a metric | `/maxsim:improve` |
+| Fix all build/lint errors | `/maxsim:fix-loop` |
+| Hunt a bug autonomously | `/maxsim:debug-loop` |
+| Security audit | `/maxsim:security` |
 | Check progress | `/maxsim:progress` |
 | Change settings | `/maxsim:settings` |
 | See all commands | `/maxsim:help` |

--- a/templates/workflows/help.md
+++ b/templates/workflows/help.md
@@ -21,6 +21,10 @@ MAXSIM is a spec-driven development system for Claude Code. It structures work i
 | `/maxsim:quick` | Run a small ad-hoc task without phase ceremony |
 | `/maxsim:settings` | View and modify MaxsimCLI configuration |
 | `/maxsim:debug [desc]` | Investigate and fix a bug using GitHub Issues |
+| `/maxsim:improve [metric-command]` | Autonomous optimization loop against any metric |
+| `/maxsim:fix-loop [error-command]` | Autonomous error repair until zero errors remain |
+| `/maxsim:debug-loop [symptom]` | Autonomous bug hunting with hypothesis testing |
+| `/maxsim:security [scope]` | Security audit — STRIDE + OWASP + red-team (read-only) |
 | `/maxsim:help` | Show this command reference |
 
 ---
@@ -145,6 +149,74 @@ Investigate and fix a bug via GitHub Issues.
 
 ---
 
+### /maxsim:improve [metric-command]
+
+Autonomous optimization loop — make one atomic change per iteration, verify against a metric, keep or discard.
+
+- Configures metric command, guard command, direction, and iteration budget in Plan Mode
+- Runs the autoresearch 8-phase loop: Review → Ideate → Modify → Commit → Verify → Guard → Decide → Log
+- Stuck detection after 5 consecutive discards
+- Results tracked in `.claude/agent-memory/maxsim-learner/autoresearch-results.tsv`
+
+```
+/maxsim:improve npm run benchmark
+/maxsim:improve "wc -l src/**/*.ts"
+```
+
+---
+
+### /maxsim:fix-loop [error-command]
+
+Autonomous error repair — iteratively fix errors until zero remain.
+
+- Configures error command and optional guard command in Plan Mode
+- Loops: run command → parse errors → fix one error → verify → repeat
+- Skips resistant errors after 3 failed attempts, revisits later
+- Tracks progress with error counts per iteration
+
+```
+/maxsim:fix-loop npm run build
+/maxsim:fix-loop "tsc --noEmit"
+/maxsim:fix-loop npm run lint
+```
+
+---
+
+### /maxsim:debug-loop [symptom]
+
+Autonomous bug hunting using the scientific method.
+
+- Gathers symptom details and reproduction steps in Plan Mode
+- Loops: reproduce → hypothesize → test hypothesis → fix if confirmed → verify
+- Each hypothesis is tested independently; disproven hypotheses are discarded
+- Creates a GitHub Issue labeled `debug` to track the session
+
+```
+/maxsim:debug-loop
+/maxsim:debug-loop "API returns 500 on POST /users"
+```
+
+---
+
+### /maxsim:security [scope]
+
+Read-only security audit using STRIDE, OWASP Top 10, and red-team analysis.
+
+- No Plan Mode — purely read-only, no code modifications
+- Phase 1: Reconnaissance (tech stack, entry points, data flows, trust boundaries)
+- Phase 2: STRIDE threat modeling
+- Phase 3: OWASP Top 10 vulnerability check
+- Phase 4: Red-team attack surface analysis
+- Posts structured report as a GitHub Issue labeled `security-audit`
+
+```
+/maxsim:security
+/maxsim:security src/auth/
+/maxsim:security "api endpoints"
+```
+
+---
+
 ### /maxsim:help
 
 Show this command reference.
@@ -178,6 +250,10 @@ Show this command reference.
 | Quick ad-hoc task | `/maxsim:quick` |
 | Change settings | `/maxsim:settings` |
 | Debug a bug | `/maxsim:debug` |
+| Optimize a metric | `/maxsim:improve` |
+| Fix all errors | `/maxsim:fix-loop` |
+| Hunt a bug autonomously | `/maxsim:debug-loop` |
+| Security audit | `/maxsim:security` |
 | See this help | `/maxsim:help` |
 
 ---


### PR DESCRIPTION
## Summary

- Add `/maxsim:improve` command -- autoresearch 8-phase optimization loop with verify+guard pattern, stuck detection, and noise handling
- Add `/maxsim:fix-loop` command -- autonomous error repair loop that iteratively fixes errors until zero remain
- Add `/maxsim:debug-loop` command -- scientific method bug hunting with hypothesis testing
- Add `/maxsim:security` command -- read-only STRIDE + OWASP Top 10 + red-team security audit
- Update all "9 slash commands" references to "13 slash commands" across docs, website, CLAUDE.md generator, tests, help workflow, and using-maxsim skill
- Fix `.gitignore` to scope `improve.md` exclusion to root-only so the command template is tracked

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (325 tests, including updated "includes all 13 commands" test)
- [x] `npm run lint` passes (only pre-existing warnings)
- [ ] Verify each new command file has correct YAML frontmatter (name, description, argument-hint, allowed-tools)
- [ ] Verify security command uses read-only tools only (no Write, Edit, Agent, EnterPlanMode)
- [ ] Verify improve/fix-loop/debug-loop commands include EnterPlanMode/ExitPlanMode as specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)