### PR TITLE
fix(lint): replace string concatenation with template literal in statusline hook

### DIFF
--- a/packages/cli/src/hooks/maxsim-statusline.ts
+++ b/packages/cli/src/hooks/maxsim-statusline.ts
@@ -72,6 +72,6 @@ readStdinJson<StatusLineInput>((input) => {
     statusText = 'MAXSIM \u25ba Ready';
   }
 
-  process.stdout.write(statusText + '\n');
+  process.stdout.write(`${statusText}\n`);
   process.exit(0);
 });


### PR DESCRIPTION
## Summary

- Replaces `statusText + '\n'` with `` `${statusText}\n` `` in `packages/cli/src/hooks/maxsim-statusline.ts` (line 75)
- Resolves Biome `useTemplate` lint rule violation

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 322 unit tests pass (`npm test`)
- [x] Lint no longer flags this file for the `useTemplate` rule (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)