### PR TITLE
fix: remove unused IssueIds and BOARD_FIELDS from github/types.ts

### DIFF
--- a/packages/cli/src/github/index.ts
+++ b/packages/cli/src/github/index.ts
@@ -1,6 +1,6 @@
 // Types
 export type {
-  IssueIds, GhUser, GhLabel, GhMilestone, GhIssue, GhComment,
+  GhUser, GhLabel, GhMilestone, GhIssue, GhComment,
   GhProject, GhProjectField, GhFieldOption, GhProjectItem,
   MaxsimIssueMeta, MaxsimIssueState, MaxsimCommentMeta,
   LabelDef, RepoInfo, GhResult, GhResultCode,

--- a/packages/cli/src/github/types.ts
+++ b/packages/cli/src/github/types.ts
@@ -3,20 +3,6 @@
  * Covers Projects v2, Issues, Sub-Issues, Milestones, Labels, Comments.
  */
 
-// ── ID Types ──────────────────────────────────────────────────────────
-
-/**
- * GitHub uses TWO id systems:
- * - Node ID (Base64 string like "PVT_kwDO..."): used in ALL GraphQL operations
- * - Numeric ID (integer like 123456789): used in REST URL paths and some REST bodies
- * Issue `.number` (e.g., #42) is NEITHER — it's the human-readable reference.
- */
-interface IssueIds {
-  number: number;    // Human-readable: #42
-  id: number;        // Internal numeric ID (REST bodies)
-  nodeId: string;    // Base64 node ID (GraphQL)
-}
-
 // ── GitHub API Response Types ─────────────────────────────────────────
 
 export interface GhUser {
@@ -171,17 +157,6 @@ export const BOARD_COLUMNS = [
   { name: 'In Progress', color: 'YELLOW' },
   { name: 'In Review', color: 'ORANGE' },
   { name: 'Done', color: 'GREEN' },
-] as const;
-
-/** Custom fields to create on every MaxsimCLI project board. */
-const BOARD_FIELDS = [
-  { name: 'Priority', dataType: 'SINGLE_SELECT', options: ['P0 Critical', 'P1 High', 'P2 Medium', 'P3 Low'] },
-  { name: 'Phase', dataType: 'NUMBER' },
-  { name: 'Wave', dataType: 'NUMBER' },
-  { name: 'Estimate', dataType: 'NUMBER' },
-  { name: 'Type', dataType: 'SINGLE_SELECT' },
-  { name: 'Status', dataType: 'SINGLE_SELECT' },
-  { name: 'Iteration', dataType: 'ITERATION' },
 ] as const;
 
 // ── Repo Info ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Removes the unexported `IssueIds` interface (and its JSDoc block) from `packages/cli/src/github/types.ts` — it was never exported or referenced anywhere
- Removes the unexported `BOARD_FIELDS` constant from `packages/cli/src/github/types.ts` — it was never referenced anywhere
- Removes the `IssueIds` re-export from `packages/cli/src/github/index.ts`
- `BOARD_COLUMNS` is kept as it is actively exported and used

Both symbols were flagged by biome's `noUnusedVariables` rule.

## Test plan

- [x] `npm run build` — passes cleanly
- [x] `npm test` — 322 tests pass, 1 skipped (pre-existing)
- [x] `npm run lint` — no errors; pre-existing warnings/infos in unrelated files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)