### PR TITLE
fix: replace non-null assertions with type-safe narrowing in test files

### DIFF
--- a/packages/cli/tests/unit/github-milestones.test.ts
+++ b/packages/cli/tests/unit/github-milestones.test.ts
@@ -77,11 +77,11 @@ function makeRawMilestone(overrides: Partial<{
     title: overrides.title ?? 'v1.0',
     // Use `'description' in overrides` so that an explicit null is preserved
     // rather than replaced by the default via the `??` operator.
-    description: 'description' in overrides ? overrides.description! : 'First release',
+    description: 'description' in overrides ? (overrides.description as string | null) : 'First release',
     state: overrides.state ?? 'open',
     open_issues: overrides.open_issues ?? 3,
     closed_issues: overrides.closed_issues ?? 7,
-    due_on: 'due_on' in overrides ? overrides.due_on! : null,
+    due_on: 'due_on' in overrides ? (overrides.due_on as string | null) : null,
     created_at: overrides.created_at ?? '2026-01-01T00:00:00Z',
     updated_at: overrides.updated_at ?? '2026-01-02T00:00:00Z',
   };

--- a/packages/cli/tests/unit/github-projects.test.ts
+++ b/packages/cli/tests/unit/github-projects.test.ts
@@ -129,8 +129,8 @@ describe('createProject', () => {
 
     const calls = execFileSyncMock.mock.calls;
     const ghCall = calls.find((c) => c[0] === 'gh' && (c[1] as string[])?.[0] === 'project');
-    expect(ghCall).toBeDefined();
-    const ghArgs = ghCall![1] as string[];
+    if (!ghCall) throw new Error('Expected a gh project call');
+    const ghArgs = ghCall[1] as string[];
     expect(ghArgs).toContain('create');
     expect(ghArgs).toContain('--owner');
     expect(ghArgs).toContain('testorg');
@@ -342,8 +342,8 @@ describe('listProjectFields', () => {
 
     const calls = execFileSyncMock.mock.calls;
     const ghCall = calls.find((c) => c[0] === 'gh' && (c[1] as string[])?.[1] === 'field-list');
-    expect(ghCall).toBeDefined();
-    const ghArgs = ghCall![1] as string[];
+    if (!ghCall) throw new Error('Expected a gh field-list call');
+    const ghArgs = ghCall[1] as string[];
     expect(ghArgs).toContain('42');
     expect(ghArgs).toContain('testorg');
   });
@@ -439,8 +439,8 @@ describe('addItemToProject', () => {
 
     const calls = execFileSyncMock.mock.calls;
     const ghCall = calls.find((c) => c[0] === 'gh' && (c[1] as string[])?.[1] === 'item-add');
-    expect(ghCall).toBeDefined();
-    const ghArgs = ghCall![1] as string[];
+    if (!ghCall) throw new Error('Expected a gh item-add call');
+    const ghArgs = ghCall[1] as string[];
     expect(ghArgs).toContain('7');
     expect(ghArgs).toContain('testorg');
     expect(ghArgs).toContain('https://github.com/testorg/testrepo/issues/42');
@@ -489,8 +489,8 @@ describe('moveItemToStatus', () => {
 
     const calls = execFileSyncMock.mock.calls;
     const editCall = calls.find((c) => c[0] === 'gh' && (c[1] as string[])?.[1] === 'item-edit');
-    expect(editCall).toBeDefined();
-    const args = editCall![1] as string[];
+    if (!editCall) throw new Error('Expected a gh item-edit call');
+    const args = editCall[1] as string[];
     expect(args).toContain('--field-id');
     expect(args).toContain('PVTSSF_status');
     expect(args).toContain('--single-select-option-id');


### PR DESCRIPTION
## Summary

- Replaced 2 `!` non-null assertions in `github-milestones.test.ts` (lines 80, 84) with `as string | null` type casts inside the `makeRawMilestone` helper, where `in`-operator checks already guarantee the key exists but TypeScript cannot narrow `Partial<T>` through them.
- Replaced 4 `!` non-null assertions in `github-projects.test.ts` (lines 133, 346, 443, 493) with `if (!x) throw new Error(...)` guards, which both narrow the type and produce a clear failure message when the expected call is absent.

Fixes Biome's `noNonNullAssertion` lint rule. Test logic is unchanged — all 322 unit tests pass.

## Test plan

- [x] `npm test` — all 322 unit tests pass, 0 failures
- [x] `npm run lint` — no new diagnostics introduced in the changed files
- [x] Skip e2e (unit-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)