### PR TITLE
feat(github): add GitHub Discussions client (spec §5.3)

### DIFF
--- a/packages/cli/src/github/discussions.ts
+++ b/packages/cli/src/github/discussions.ts
@@ -1,0 +1,251 @@
+/**
+ * GitHub Discussions — create, list, and get discussions via GraphQL API.
+ * Uses `gh api graphql` through the ghJson/ghExec client wrappers.
+ */
+
+import { getRepoInfo, ghJson, ghExec } from './client.js';
+import type { GhDiscussion, GhResult, RepoInfo } from './types.js';
+
+// ── Internal GraphQL response shapes ──────────────────────────────────
+
+interface RawDiscussionCategory {
+  id: string;
+  slug: string;
+}
+
+interface RawDiscussion {
+  number: number;
+  id: string;
+  title: string;
+  body: string;
+  category: { name: string };
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function mapDiscussion(raw: RawDiscussion): GhDiscussion {
+  return {
+    number: raw.number,
+    nodeId: raw.id,
+    title: raw.title,
+    body: raw.body,
+    categoryName: raw.category?.name ?? '',
+    url: raw.url,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+function getCategoryId(
+  owner: string,
+  repo: string,
+  categorySlug: string,
+): GhResult<string> {
+  const query = `
+    query($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
+        discussionCategories(first: 25) {
+          nodes {
+            id
+            slug
+          }
+        }
+      }
+    }
+  `.trim();
+
+  const result = ghJson<{
+    data: {
+      repository: {
+        discussionCategories: { nodes: RawDiscussionCategory[] };
+      };
+    };
+  }>([
+    'api', 'graphql',
+    '-f', `query=${query}`,
+    '-f', `owner=${owner}`,
+    '-f', `repo=${repo}`,
+  ]);
+
+  if (!result.ok) return result;
+
+  const nodes = result.data?.data?.repository?.discussionCategories?.nodes ?? [];
+  const category = nodes.find((n) => n.slug === categorySlug);
+
+  if (!category) {
+    return {
+      ok: false,
+      error: `Discussion category with slug "${categorySlug}" not found`,
+      code: 'NOT_FOUND',
+    };
+  }
+
+  return { ok: true, data: category.id };
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+export function createDiscussion(
+  params: {
+    title: string;
+    body: string;
+    categorySlug: string;
+  },
+  repo?: RepoInfo,
+): GhResult<GhDiscussion> {
+  const { owner, repo: repoName } = repo ?? getRepoInfo();
+
+  const nodeIdResult = ghExec(['api', `repos/${owner}/${repoName}`, '-q', '.node_id']);
+  if (!nodeIdResult.ok) return nodeIdResult;
+
+  const categoryResult = getCategoryId(owner, repoName, params.categorySlug);
+  if (!categoryResult.ok) return categoryResult;
+
+  const mutation = `
+    mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+      createDiscussion(input: {
+        repositoryId: $repositoryId
+        categoryId: $categoryId
+        title: $title
+        body: $body
+      }) {
+        discussion {
+          number
+          id
+          title
+          body
+          category { name }
+          url
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  `.trim();
+
+  const result = ghJson<{
+    data: { createDiscussion: { discussion: RawDiscussion } };
+  }>([
+    'api', 'graphql',
+    '-f', `query=${mutation}`,
+    '-f', `repositoryId=${nodeIdResult.data}`,
+    '-f', `categoryId=${categoryResult.data}`,
+    '-f', `title=${params.title}`,
+    '-f', `body=${params.body}`,
+  ]);
+
+  if (!result.ok) return result;
+
+  const discussion = result.data?.data?.createDiscussion?.discussion;
+  if (!discussion) {
+    return { ok: false, error: 'createDiscussion mutation returned no discussion', code: 'UNKNOWN' };
+  }
+
+  return { ok: true, data: mapDiscussion(discussion) };
+}
+
+export function listDiscussions(
+  params: { categorySlug?: string; first?: number } = {},
+  repo?: RepoInfo,
+): GhResult<GhDiscussion[]> {
+  const { owner, repo: repoName } = repo ?? getRepoInfo();
+  const first = params.first ?? 20;
+
+  let categoryId: string | undefined;
+  if (params.categorySlug) {
+    const categoryResult = getCategoryId(owner, repoName, params.categorySlug);
+    if (!categoryResult.ok) return categoryResult;
+    categoryId = categoryResult.data;
+  }
+
+  const hasCategory = categoryId !== undefined;
+  const query = `
+    query($owner: String!, $repo: String!, $first: Int!${hasCategory ? ', $categoryId: ID!' : ''}) {
+      repository(owner: $owner, name: $repo) {
+        discussions(first: $first${hasCategory ? ', categoryId: $categoryId' : ''}) {
+          nodes {
+            number
+            id
+            title
+            body
+            category { name }
+            url
+            createdAt
+            updatedAt
+          }
+        }
+      }
+    }
+  `.trim();
+
+  const args = [
+    'api', 'graphql',
+    '-f', `query=${query}`,
+    '-f', `owner=${owner}`,
+    '-f', `repo=${repoName}`,
+    '-F', `first=${first}`,
+  ];
+
+  if (hasCategory) {
+    args.push('-f', `categoryId=${categoryId}`);
+  }
+
+  const result = ghJson<{
+    data: { repository: { discussions: { nodes: RawDiscussion[] } } };
+  }>(args);
+
+  if (!result.ok) return result;
+
+  const nodes = result.data?.data?.repository?.discussions?.nodes ?? [];
+  return { ok: true, data: nodes.map(mapDiscussion) };
+}
+
+export function getDiscussion(
+  discussionNumber: number,
+  repo?: RepoInfo,
+): GhResult<GhDiscussion> {
+  const { owner, repo: repoName } = repo ?? getRepoInfo();
+
+  const query = `
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        discussion(number: $number) {
+          number
+          id
+          title
+          body
+          category { name }
+          url
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  `.trim();
+
+  const result = ghJson<{
+    data: { repository: { discussion: RawDiscussion | null } };
+  }>([
+    'api', 'graphql',
+    '-f', `query=${query}`,
+    '-f', `owner=${owner}`,
+    '-f', `repo=${repoName}`,
+    '-F', `number=${discussionNumber}`,
+  ]);
+
+  if (!result.ok) return result;
+
+  const discussion = result.data?.data?.repository?.discussion;
+  if (!discussion) {
+    return {
+      ok: false,
+      error: `Discussion #${discussionNumber} not found`,
+      code: 'NOT_FOUND',
+    };
+  }
+
+  return { ok: true, data: mapDiscussion(discussion) };
+}

--- a/packages/cli/src/github/index.ts
+++ b/packages/cli/src/github/index.ts
@@ -1,6 +1,7 @@
 // Types
 export type {
   GhUser, GhLabel, GhMilestone, GhIssue, GhComment,
+  GhDiscussion,
   GhProject, GhProjectField, GhFieldOption, GhProjectItem,
   MaxsimIssueMeta, MaxsimIssueState, MaxsimCommentMeta,
   LabelDef, RepoInfo, GhResult, GhResultCode,
@@ -40,3 +41,6 @@ export {
 
 // Labels
 export { ensureLabels, getLabel, createLabel } from './labels.js';
+
+// Discussions
+export { createDiscussion, listDiscussions, getDiscussion } from './discussions.js';

--- a/packages/cli/src/github/types.ts
+++ b/packages/cli/src/github/types.ts
@@ -60,6 +60,17 @@ export interface GhComment {
   htmlUrl: string;
 }
 
+export interface GhDiscussion {
+  number: number;
+  nodeId: string;
+  title: string;
+  body: string;
+  categoryName: string;
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 // ── Projects v2 Types ─────────────────────────────────────────────────
 
 export interface GhProject {

--- a/packages/cli/tests/unit/github-discussions.test.ts
+++ b/packages/cli/tests/unit/github-discussions.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Unit tests for github/discussions.ts
+ *
+ * All calls to execFileSync are mocked at the node:child_process module level.
+ * The mock intercepts both `git` calls (getRepoInfo) and `gh` calls (ghJson/ghExec).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock node:child_process before any imports ──────────────────────────────
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  };
+});
+
+import * as childProcess from 'node:child_process';
+import { resetClient } from '../../src/github/client.js';
+import {
+  createDiscussion,
+  listDiscussions,
+  getDiscussion,
+} from '../../src/github/discussions.js';
+
+const execFileSyncMock = vi.mocked(childProcess.execFileSync);
+
+// ── Shared fixture data ─────────────────────────────────────────────────────
+
+const REPO_REMOTE_URL = 'git@github.com:testowner/testrepo.git';
+const REPO_NODE_ID = 'R_kgDOAbc123';
+
+const MOCK_CATEGORY = {
+  id: 'DIC_kwDOAbc123',
+  name: 'General',
+  slug: 'general',
+};
+
+const MOCK_DISCUSSION_RAW = {
+  number: 42,
+  id: 'D_kwDOAbc123',
+  title: 'Test Discussion',
+  body: 'Hello world',
+  category: { name: 'General' },
+  url: 'https://github.com/testowner/testrepo/discussions/42',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
+};
+
+const MOCK_DISCUSSION_MAPPED = {
+  number: 42,
+  nodeId: 'D_kwDOAbc123',
+  title: 'Test Discussion',
+  body: 'Hello world',
+  categoryName: 'General',
+  url: 'https://github.com/testowner/testrepo/discussions/42',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
+};
+
+// ── Helper: mock execFileSync call sequence ─────────────────────────────────
+
+/**
+ * Configure the mock so git/gh auth calls return expected defaults,
+ * and subsequent gh API calls return the supplied responses in order.
+ *
+ * Each element of `ghResponses` is either a string (raw stdout) or an Error
+ * to throw.
+ */
+function setupExecMock(...ghResponses: Array<string | Error>): void {
+  let apiCallIndex = 0;
+  execFileSyncMock.mockImplementation((_cmd: string, args?: readonly string[]) => {
+    const argList = args ?? [];
+
+    // git remote call used by getRepoInfo
+    if (_cmd === 'git' && argList[0] === 'remote') {
+      return REPO_REMOTE_URL;
+    }
+
+    // gh api /users/<owner> call used to detect org/user type inside getRepoInfo
+    if (_cmd === 'gh' && argList[0] === 'api' && String(argList[1]).startsWith('/users/')) {
+      return 'User';
+    }
+
+    // All other gh calls — dispatch from the response queue
+    const response = ghResponses[apiCallIndex++];
+    if (response instanceof Error) throw response;
+    return response ?? '';
+  });
+}
+
+/** Build the GraphQL response envelope for discussionCategories query. */
+function categoriesResponse(categories: typeof MOCK_CATEGORY[] = [MOCK_CATEGORY]): string {
+  return JSON.stringify({
+    data: {
+      repository: {
+        discussionCategories: {
+          nodes: categories,
+        },
+      },
+    },
+  });
+}
+
+/** Build the GraphQL response envelope for the createDiscussion mutation. */
+function createDiscussionResponse(discussion: typeof MOCK_DISCUSSION_RAW = MOCK_DISCUSSION_RAW): string {
+  return JSON.stringify({
+    data: {
+      createDiscussion: {
+        discussion,
+      },
+    },
+  });
+}
+
+/** Build the GraphQL response envelope for a discussions list query. */
+function listDiscussionsResponse(discussions: typeof MOCK_DISCUSSION_RAW[] = [MOCK_DISCUSSION_RAW]): string {
+  return JSON.stringify({
+    data: {
+      repository: {
+        discussions: {
+          nodes: discussions,
+        },
+      },
+    },
+  });
+}
+
+/** Build the GraphQL response envelope for a single discussion query. */
+function getDiscussionResponse(discussion: typeof MOCK_DISCUSSION_RAW | null = MOCK_DISCUSSION_RAW): string {
+  return JSON.stringify({
+    data: {
+      repository: {
+        discussion,
+      },
+    },
+  });
+}
+
+// ── Reset cached client state between tests ─────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetClient();
+});
+
+// ── createDiscussion ────────────────────────────────────────────────────────
+
+describe('createDiscussion', () => {
+  it('returns a mapped GhDiscussion on success', () => {
+    // Calls in order: getRepoNodeId, getCategoryId, createDiscussion mutation
+    setupExecMock(REPO_NODE_ID, categoriesResponse(), createDiscussionResponse());
+
+    const result = createDiscussion({
+      title: 'Test Discussion',
+      body: 'Hello world',
+      categorySlug: 'general',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toEqual(MOCK_DISCUSSION_MAPPED);
+  });
+
+  it('accepts an explicit repo argument', () => {
+    setupExecMock(REPO_NODE_ID, categoriesResponse(), createDiscussionResponse());
+
+    const result = createDiscussion(
+      { title: 'Test', body: 'Body', categorySlug: 'general' },
+      { owner: 'customowner', repo: 'customrepo', isOrg: false },
+    );
+
+    expect(result.ok).toBe(true);
+    // Verify gh was called with customowner/customrepo for the node ID lookup
+    const calls = execFileSyncMock.mock.calls;
+    const nodeIdCall = calls.find(
+      (c) => c[0] === 'gh' && (c[1] as string[])?.includes('repos/customowner/customrepo'),
+    );
+    expect(nodeIdCall).toBeDefined();
+  });
+
+  it('returns NOT_FOUND when category slug does not exist', () => {
+    setupExecMock(
+      REPO_NODE_ID,
+      categoriesResponse([{ id: 'DIC_other', name: 'Other', slug: 'other' }]),
+    );
+
+    const result = createDiscussion({
+      title: 'Test',
+      body: 'Body',
+      categorySlug: 'nonexistent',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('NOT_FOUND');
+    expect(result.error).toContain('nonexistent');
+  });
+
+  it('propagates error from getRepoNodeId', () => {
+    setupExecMock(new Error('gh: 404 Not Found'));
+
+    const result = createDiscussion({
+      title: 'Test',
+      body: 'Body',
+      categorySlug: 'general',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('NOT_FOUND');
+  });
+
+  it('propagates error from getCategoryId query', () => {
+    setupExecMock(REPO_NODE_ID, new Error('gh: 403 Forbidden'));
+
+    const result = createDiscussion({
+      title: 'Test',
+      body: 'Body',
+      categorySlug: 'general',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('FORBIDDEN');
+  });
+
+  it('returns UNKNOWN when mutation returns no discussion', () => {
+    setupExecMock(
+      REPO_NODE_ID,
+      categoriesResponse(),
+      JSON.stringify({ data: { createDiscussion: { discussion: null } } }),
+    );
+
+    const result = createDiscussion({
+      title: 'Test',
+      body: 'Body',
+      categorySlug: 'general',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('UNKNOWN');
+  });
+});
+
+// ── listDiscussions ─────────────────────────────────────────────────────────
+
+describe('listDiscussions', () => {
+  it('returns an array of mapped discussions', () => {
+    setupExecMock(listDiscussionsResponse());
+
+    const result = listDiscussions();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toEqual(MOCK_DISCUSSION_MAPPED);
+  });
+
+  it('returns an empty array when there are no discussions', () => {
+    setupExecMock(listDiscussionsResponse([]));
+
+    const result = listDiscussions();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toEqual([]);
+  });
+
+  it('filters by category slug when provided', () => {
+    // getCategoryId is called first, then the discussions query
+    setupExecMock(categoriesResponse(), listDiscussionsResponse());
+
+    const result = listDiscussions({ categorySlug: 'general' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toHaveLength(1);
+  });
+
+  it('returns NOT_FOUND when category slug does not exist', () => {
+    setupExecMock(categoriesResponse([]));
+
+    const result = listDiscussions({ categorySlug: 'missing' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('NOT_FOUND');
+  });
+
+  it('propagates API error', () => {
+    setupExecMock(new Error('gh: 401 Unauthorized'));
+
+    const result = listDiscussions();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('UNAUTHORIZED');
+  });
+
+  it('accepts explicit repo argument', () => {
+    setupExecMock(listDiscussionsResponse());
+
+    const result = listDiscussions(
+      { first: 5 },
+      { owner: 'customowner', repo: 'customrepo', isOrg: true },
+    );
+
+    expect(result.ok).toBe(true);
+    // Verify the gh call includes owner=customowner
+    const calls = execFileSyncMock.mock.calls;
+    const graphqlCall = calls.find(
+      (c) => c[0] === 'gh' && (c[1] as string[])?.includes('graphql'),
+    );
+    expect(graphqlCall).toBeDefined();
+    const ghArgs = graphqlCall?.[1] as string[];
+    expect(ghArgs).toContain('owner=customowner');
+  });
+});
+
+// ── getDiscussion ───────────────────────────────────────────────────────────
+
+describe('getDiscussion', () => {
+  it('returns a mapped GhDiscussion for a valid number', () => {
+    setupExecMock(getDiscussionResponse());
+
+    const result = getDiscussion(42);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toEqual(MOCK_DISCUSSION_MAPPED);
+  });
+
+  it('returns NOT_FOUND when discussion is null', () => {
+    setupExecMock(getDiscussionResponse(null));
+
+    const result = getDiscussion(99);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('NOT_FOUND');
+    expect(result.error).toContain('99');
+  });
+
+  it('propagates API error', () => {
+    setupExecMock(new Error('gh: 404 Not Found'));
+
+    const result = getDiscussion(42);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('NOT_FOUND');
+  });
+
+  it('accepts explicit repo argument', () => {
+    setupExecMock(getDiscussionResponse());
+
+    const result = getDiscussion(42, { owner: 'customowner', repo: 'customrepo', isOrg: false });
+
+    expect(result.ok).toBe(true);
+    const calls = execFileSyncMock.mock.calls;
+    const graphqlCall = calls.find(
+      (c) => c[0] === 'gh' && (c[1] as string[])?.includes('graphql'),
+    );
+    expect(graphqlCall).toBeDefined();
+    const ghArgs = graphqlCall?.[1] as string[];
+    expect(ghArgs).toContain('owner=customowner');
+  });
+
+  it('passes the discussion number as an integer flag', () => {
+    setupExecMock(getDiscussionResponse());
+
+    getDiscussion(42);
+
+    const calls = execFileSyncMock.mock.calls;
+    const graphqlCall = calls.find(
+      (c) => c[0] === 'gh' && (c[1] as string[])?.includes('graphql'),
+    );
+    expect(graphqlCall).toBeDefined();
+    const ghArgs = graphqlCall?.[1] as string[];
+    // -F passes typed value (integer) rather than -f (string)
+    const flagIndex = ghArgs.indexOf('-F');
+    expect(flagIndex).toBeGreaterThan(-1);
+    expect(ghArgs[flagIndex + 1]).toBe('number=42');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `packages/cli/src/github/discussions.ts` implementing `createDiscussion`, `listDiscussions`, and `getDiscussion` via `gh api graphql`
- Adds `GhDiscussion` type to `packages/cli/src/github/types.ts`
- Exports all new symbols from `packages/cli/src/github/index.ts`
- Adds 17 unit tests in `packages/cli/tests/unit/github-discussions.test.ts` covering success paths, error propagation, category filtering, and argument construction

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — all 339 tests pass (17 new)
- [x] `npm run lint` — no new warnings introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)