### PR TITLE
fix(github): distinguish relation directions in listIssueRelations

### DIFF
--- a/packages/cli/src/github/issues.ts
+++ b/packages/cli/src/github/issues.ts
@@ -377,22 +377,29 @@ export async function listIssueRelations(
       query ListLinkedIssues($owner: String!, $repo: String!, $number: Int!) {
         repository(owner: $owner, name: $repo) {
           issue(number: $number) {
-            linkedIssues(first: 50) {
-              nodes {
-                number
-              }
+            blockedBy: linkedIssues(first: 50, type: IS_BLOCKED_BY) {
+              nodes { number }
+            }
+            blocking: linkedIssues(first: 50, type: BLOCKS) {
+              nodes { number }
+            }
+            related: linkedIssues(first: 50, type: RELATED) {
+              nodes { number }
             }
           }
         }
       }
     `;
 
+    interface LinkedIssueNodes {
+      nodes: Array<{ number: number }>;
+    }
     interface GraphQLResponse {
       repository: {
         issue: {
-          linkedIssues: {
-            nodes: Array<{ number: number }>;
-          };
+          blockedBy: LinkedIssueNodes;
+          blocking: LinkedIssueNodes;
+          related: LinkedIssueNodes;
         } | null;
       };
     }
@@ -404,12 +411,19 @@ export async function listIssueRelations(
       number: issueNumber,
     });
 
-    const nodes = data?.repository?.issue?.linkedIssues?.nodes ?? [];
+    const issue = data?.repository?.issue;
+    if (!issue) return [];
 
-    return nodes.map((node) => ({
-      issueNumber,
-      relatedIssueNumber: node.number,
-      type: 'related' as const,
-    }));
+    const toRelations = (
+      nodes: Array<{ number: number }>,
+      type: GhIssueRelation['type'],
+    ): GhIssueRelation[] =>
+      nodes.map((node) => ({ issueNumber, relatedIssueNumber: node.number, type }));
+
+    return [
+      ...toRelations(issue.blockedBy?.nodes ?? [], 'blocked_by'),
+      ...toRelations(issue.blocking?.nodes ?? [], 'blocking'),
+      ...toRelations(issue.related?.nodes ?? [], 'related'),
+    ];
   });
 }

--- a/packages/cli/tests/unit/github-issues.test.ts
+++ b/packages/cli/tests/unit/github-issues.test.ts
@@ -1133,17 +1133,25 @@ describe('removeIssueRelation', () => {
 
 // ── listIssueRelations ────────────────────────────────────────────────────────
 
-describe('listIssueRelations', () => {
-  it('returns an array of GhIssueRelation objects from linkedIssues', async () => {
-    mockGraphql.mockResolvedValue({
-      repository: {
-        issue: {
-          linkedIssues: {
-            nodes: [{ number: 99 }, { number: 100 }],
-          },
-        },
+function makeRelationsResponse(opts: {
+  blockedBy?: number[];
+  blocking?: number[];
+  related?: number[];
+}) {
+  return {
+    repository: {
+      issue: {
+        blockedBy: { nodes: (opts.blockedBy ?? []).map((n) => ({ number: n })) },
+        blocking: { nodes: (opts.blocking ?? []).map((n) => ({ number: n })) },
+        related: { nodes: (opts.related ?? []).map((n) => ({ number: n })) },
       },
-    });
+    },
+  };
+}
+
+describe('listIssueRelations', () => {
+  it('returns related relations with type "related"', async () => {
+    mockGraphql.mockResolvedValue(makeRelationsResponse({ related: [99, 100] }));
 
     const result = await listIssueRelations(42);
 
@@ -1154,14 +1162,45 @@ describe('listIssueRelations', () => {
     expect(result.data[1]).toEqual({ issueNumber: 42, relatedIssueNumber: 100, type: 'related' });
   });
 
+  it('returns blocked_by relations with type "blocked_by"', async () => {
+    mockGraphql.mockResolvedValue(makeRelationsResponse({ blockedBy: [10] }));
+
+    const result = await listIssueRelations(42);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toEqual({ issueNumber: 42, relatedIssueNumber: 10, type: 'blocked_by' });
+  });
+
+  it('returns blocking relations with type "blocking"', async () => {
+    mockGraphql.mockResolvedValue(makeRelationsResponse({ blocking: [20] }));
+
+    const result = await listIssueRelations(42);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toEqual({ issueNumber: 42, relatedIssueNumber: 20, type: 'blocking' });
+  });
+
+  it('returns mixed relation types with correct directions', async () => {
+    mockGraphql.mockResolvedValue(
+      makeRelationsResponse({ blockedBy: [10], blocking: [20], related: [30] }),
+    );
+
+    const result = await listIssueRelations(42);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toHaveLength(3);
+    expect(result.data.find((r) => r.relatedIssueNumber === 10)?.type).toBe('blocked_by');
+    expect(result.data.find((r) => r.relatedIssueNumber === 20)?.type).toBe('blocking');
+    expect(result.data.find((r) => r.relatedIssueNumber === 30)?.type).toBe('related');
+  });
+
   it('returns empty array when issue has no linked issues', async () => {
-    mockGraphql.mockResolvedValue({
-      repository: {
-        issue: {
-          linkedIssues: { nodes: [] },
-        },
-      },
-    });
+    mockGraphql.mockResolvedValue(makeRelationsResponse({}));
 
     const result = await listIssueRelations(42);
 
@@ -1183,9 +1222,7 @@ describe('listIssueRelations', () => {
   });
 
   it('passes owner, repo, and issue number to graphql', async () => {
-    mockGraphql.mockResolvedValue({
-      repository: { issue: { linkedIssues: { nodes: [] } } },
-    });
+    mockGraphql.mockResolvedValue(makeRelationsResponse({}));
 
     await listIssueRelations(42);
 
@@ -1196,9 +1233,7 @@ describe('listIssueRelations', () => {
   });
 
   it('accepts an explicit repo override', async () => {
-    mockGraphql.mockResolvedValue({
-      repository: { issue: { linkedIssues: { nodes: [] } } },
-    });
+    mockGraphql.mockResolvedValue(makeRelationsResponse({}));
 
     await listIssueRelations(42, { owner: 'other-owner', repo: 'other-repo', isOrg: false });
 


### PR DESCRIPTION
## Summary

- Fixed `listIssueRelations` to correctly distinguish between `blocked_by`, `blocking`, and `related` relation directions
- Previous implementation queried `linkedIssues` without a type filter, returning all relations typed as `'related'`
- New implementation uses GraphQL field aliases with `type` filters (`IS_BLOCKED_BY`, `BLOCKS`, `RELATED`) in a single query to capture direction info

## Changes

- `packages/cli/src/github/issues.ts`: Rewrote the GraphQL query in `listIssueRelations` to use three aliased `linkedIssues` fields with type filters; added a `toRelations` helper to map each bucket to the correct `GhIssueRelation.type`
- `packages/cli/tests/unit/github-issues.test.ts`: Updated tests to use new response shape; added tests for `blocked_by`, `blocking`, and mixed-direction scenarios

## Test plan

- [x] All 415 existing tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Lint passes with no errors (`npm run lint`)
- [x] New tests cover `blocked_by`, `blocking`, `related`, and mixed relation types

🤖 Generated with [Claude Code](https://claude.com/claude-code)