### PR TITLE
feat(templates): HARD GATE heading on executor + fresh-agent retry instruction

### DIFF
--- a/templates/agents/executor.md
+++ b/templates/agents/executor.md
@@ -45,7 +45,7 @@ For each task in the plan:
 5. **Commit** -- stage task files individually, commit with conventional format: `{type}({scope}): {description}`
 6. **Next task** -- proceed to the next task in sequence
 
-## Pre-Commit Gate
+## HARD GATE -- Pre-Commit Verification
 
 Before every commit, verify the task's done criteria with evidence. Do NOT commit if any criterion fails. Fix first, re-verify, then commit.
 

--- a/templates/workflows/execute.md
+++ b/templates/workflows/execute.md
@@ -453,6 +453,12 @@ Agent(
 Re-read the phase issue to discover new plan comments with `gap_closure: true` in frontmatter.
 Execute them using the same wave logic (steps 6.1–6.8).
 
+When spawning executor agents for gap-closure plans, append the following to each agent prompt:
+
+```
+IMPORTANT: This is a fresh retry attempt. Do NOT reference or build upon any previous attempt's reasoning, code, or approach. Start from scratch using only the original task specification and current codebase state.
+```
+
 ### 9.4 Re-verify
 
 Spawn verifier again (step 8). Increment `attempt_count`.


### PR DESCRIPTION
## Summary

- Renames `## Pre-Commit Gate` in `templates/agents/executor.md` to `## HARD GATE -- Pre-Commit Verification`, matching the style of `verifier.md`'s `## HARD GATE -- Anti-Rationalization` heading
- Adds an explicit fresh-agent instruction to the gap-closure retry spawn in `templates/workflows/execute.md` (§9.3), directing retry executors to start from scratch rather than building on prior failed attempts

## Test plan

- [x] `npm test` — 412 tests pass, 0 failures
- [x] `npm run build` — build completes cleanly
- [x] `npm run lint` — 0 errors (pre-existing warnings only, unrelated to these changes)
- [x] Both template files remain well-formed markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)