### PR TITLE
feat(github): add update, delete, and reply to discussions module

### DIFF
--- a/packages/cli/src/github/discussions.ts
+++ b/packages/cli/src/github/discussions.ts
@@ -249,3 +249,112 @@ export function getDiscussion(
 
   return { ok: true, data: mapDiscussion(discussion) };
 }
+
+export function updateDiscussion(
+  id: string,
+  opts: { title?: string; body?: string },
+): GhResult<GhDiscussion> {
+  const mutation = `
+    mutation($discussionId: ID!, $title: String, $body: String) {
+      updateDiscussion(input: {
+        discussionId: $discussionId
+        title: $title
+        body: $body
+      }) {
+        discussion {
+          number
+          id
+          title
+          body
+          category { name }
+          url
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  `.trim();
+
+  const args = [
+    'api', 'graphql',
+    '-f', `query=${mutation}`,
+    '-f', `discussionId=${id}`,
+  ];
+
+  if (opts.title !== undefined) {
+    args.push('-f', `title=${opts.title}`);
+  }
+
+  if (opts.body !== undefined) {
+    args.push('-f', `body=${opts.body}`);
+  }
+
+  const result = ghJson<{
+    data: { updateDiscussion: { discussion: RawDiscussion } };
+  }>(args);
+
+  if (!result.ok) return result;
+
+  const discussion = result.data?.data?.updateDiscussion?.discussion;
+  if (!discussion) {
+    return { ok: false, error: 'updateDiscussion mutation returned no discussion', code: 'UNKNOWN' };
+  }
+
+  return { ok: true, data: mapDiscussion(discussion) };
+}
+
+export function deleteDiscussion(id: string): GhResult<void> {
+  const mutation = `
+    mutation($id: ID!) {
+      deleteDiscussion(input: { id: $id }) {
+        clientMutationId
+      }
+    }
+  `.trim();
+
+  const result = ghJson<unknown>([
+    'api', 'graphql',
+    '-f', `query=${mutation}`,
+    '-f', `id=${id}`,
+  ]);
+
+  if (!result.ok) return result;
+
+  return { ok: true, data: undefined };
+}
+
+export function addDiscussionReply(
+  discussionId: string,
+  body: string,
+): GhResult<{ id: string }> {
+  const mutation = `
+    mutation($discussionId: ID!, $body: String!) {
+      addDiscussionComment(input: {
+        discussionId: $discussionId
+        body: $body
+      }) {
+        comment {
+          id
+        }
+      }
+    }
+  `.trim();
+
+  const result = ghJson<{
+    data: { addDiscussionComment: { comment: { id: string } | null } };
+  }>([
+    'api', 'graphql',
+    '-f', `query=${mutation}`,
+    '-f', `discussionId=${discussionId}`,
+    '-f', `body=${body}`,
+  ]);
+
+  if (!result.ok) return result;
+
+  const comment = result.data?.data?.addDiscussionComment?.comment;
+  if (!comment) {
+    return { ok: false, error: 'addDiscussionComment mutation returned no comment', code: 'UNKNOWN' };
+  }
+
+  return { ok: true, data: { id: comment.id } };
+}

--- a/packages/cli/src/github/index.ts
+++ b/packages/cli/src/github/index.ts
@@ -44,7 +44,10 @@ export {
 export { ensureLabels, getLabel, createLabel } from './labels.js';
 
 // Discussions
-export { createDiscussion, listDiscussions, getDiscussion } from './discussions.js';
+export {
+  createDiscussion, listDiscussions, getDiscussion,
+  updateDiscussion, deleteDiscussion, addDiscussionReply,
+} from './discussions.js';
 
 // Wiki
 export { checkWikiEnabled, getWikiPage, createOrUpdateWikiPage, listWikiPages } from './wiki.js';

--- a/packages/cli/tests/unit/github-discussions.test.ts
+++ b/packages/cli/tests/unit/github-discussions.test.ts
@@ -23,6 +23,9 @@ import {
   createDiscussion,
   listDiscussions,
   getDiscussion,
+  updateDiscussion,
+  deleteDiscussion,
+  addDiscussionReply,
 } from '../../src/github/discussions.js';
 
 const execFileSyncMock = vi.mocked(childProcess.execFileSync);
@@ -385,5 +388,193 @@ describe('getDiscussion', () => {
     const flagIndex = ghArgs.indexOf('-F');
     expect(flagIndex).toBeGreaterThan(-1);
     expect(ghArgs[flagIndex + 1]).toBe('number=42');
+  });
+});
+
+// ── Helpers for new mutations ────────────────────────────────────────────────
+
+/** Build the GraphQL response for the updateDiscussion mutation. */
+function updateDiscussionResponse(discussion: typeof MOCK_DISCUSSION_RAW = MOCK_DISCUSSION_RAW): string {
+  return JSON.stringify({
+    data: {
+      updateDiscussion: {
+        discussion,
+      },
+    },
+  });
+}
+
+/** Build the GraphQL response for the deleteDiscussion mutation. */
+function deleteDiscussionResponse(): string {
+  return JSON.stringify({
+    data: {
+      deleteDiscussion: {
+        clientMutationId: null,
+      },
+    },
+  });
+}
+
+/** Build the GraphQL response for the addDiscussionComment mutation. */
+function addDiscussionCommentResponse(id = 'DC_kwDOAbc456'): string {
+  return JSON.stringify({
+    data: {
+      addDiscussionComment: {
+        comment: { id },
+      },
+    },
+  });
+}
+
+// ── updateDiscussion ─────────────────────────────────────────────────────────
+
+describe('updateDiscussion', () => {
+  it('returns a mapped GhDiscussion on success', () => {
+    setupExecMock(updateDiscussionResponse());
+
+    const result = updateDiscussion('D_kwDOAbc123', { title: 'Updated Title', body: 'Updated body' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toEqual(MOCK_DISCUSSION_MAPPED);
+  });
+
+  it('works when only title is provided', () => {
+    setupExecMock(updateDiscussionResponse());
+
+    const result = updateDiscussion('D_kwDOAbc123', { title: 'Only Title' });
+
+    expect(result.ok).toBe(true);
+    const calls = execFileSyncMock.mock.calls;
+    const graphqlCall = calls.find(
+      (c) => c[0] === 'gh' && (c[1] as string[])?.includes('graphql'),
+    );
+    expect(graphqlCall).toBeDefined();
+    const ghArgs = graphqlCall?.[1] as string[];
+    expect(ghArgs).toContain('title=Only Title');
+    expect(ghArgs).not.toContain('body=');
+  });
+
+  it('works when only body is provided', () => {
+    setupExecMock(updateDiscussionResponse());
+
+    const result = updateDiscussion('D_kwDOAbc123', { body: 'Only body' });
+
+    expect(result.ok).toBe(true);
+    const calls = execFileSyncMock.mock.calls;
+    const graphqlCall = calls.find(
+      (c) => c[0] === 'gh' && (c[1] as string[])?.includes('graphql'),
+    );
+    expect(graphqlCall).toBeDefined();
+    const ghArgs = graphqlCall?.[1] as string[];
+    expect(ghArgs).toContain('body=Only body');
+    expect(ghArgs).not.toContain('title=');
+  });
+
+  it('returns UNKNOWN when mutation returns no discussion', () => {
+    setupExecMock(JSON.stringify({ data: { updateDiscussion: { discussion: null } } }));
+
+    const result = updateDiscussion('D_kwDOAbc123', { title: 'Test' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('UNKNOWN');
+  });
+
+  it('propagates API error', () => {
+    setupExecMock(new Error('gh: 404 Not Found'));
+
+    const result = updateDiscussion('D_kwDOAbc123', { title: 'Test' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('NOT_FOUND');
+  });
+});
+
+// ── deleteDiscussion ─────────────────────────────────────────────────────────
+
+describe('deleteDiscussion', () => {
+  it('returns ok: true with no data on success', () => {
+    setupExecMock(deleteDiscussionResponse());
+
+    const result = deleteDiscussion('D_kwDOAbc123');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toBeUndefined();
+  });
+
+  it('passes the discussion id to the mutation', () => {
+    setupExecMock(deleteDiscussionResponse());
+
+    deleteDiscussion('D_kwDOAbc123');
+
+    const calls = execFileSyncMock.mock.calls;
+    const graphqlCall = calls.find(
+      (c) => c[0] === 'gh' && (c[1] as string[])?.includes('graphql'),
+    );
+    expect(graphqlCall).toBeDefined();
+    const ghArgs = graphqlCall?.[1] as string[];
+    expect(ghArgs).toContain('id=D_kwDOAbc123');
+  });
+
+  it('propagates API error', () => {
+    setupExecMock(new Error('gh: 403 Forbidden'));
+
+    const result = deleteDiscussion('D_kwDOAbc123');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('FORBIDDEN');
+  });
+});
+
+// ── addDiscussionReply ───────────────────────────────────────────────────────
+
+describe('addDiscussionReply', () => {
+  it('returns the comment id on success', () => {
+    setupExecMock(addDiscussionCommentResponse('DC_kwDOAbc456'));
+
+    const result = addDiscussionReply('D_kwDOAbc123', 'Great discussion!');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toEqual({ id: 'DC_kwDOAbc456' });
+  });
+
+  it('passes discussionId and body to the mutation', () => {
+    setupExecMock(addDiscussionCommentResponse());
+
+    addDiscussionReply('D_kwDOAbc123', 'Hello!');
+
+    const calls = execFileSyncMock.mock.calls;
+    const graphqlCall = calls.find(
+      (c) => c[0] === 'gh' && (c[1] as string[])?.includes('graphql'),
+    );
+    expect(graphqlCall).toBeDefined();
+    const ghArgs = graphqlCall?.[1] as string[];
+    expect(ghArgs).toContain('discussionId=D_kwDOAbc123');
+    expect(ghArgs).toContain('body=Hello!');
+  });
+
+  it('returns UNKNOWN when mutation returns no comment', () => {
+    setupExecMock(JSON.stringify({ data: { addDiscussionComment: { comment: null } } }));
+
+    const result = addDiscussionReply('D_kwDOAbc123', 'Hello');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('UNKNOWN');
+  });
+
+  it('propagates API error', () => {
+    setupExecMock(new Error('gh: 401 Unauthorized'));
+
+    const result = addDiscussionReply('D_kwDOAbc123', 'Hello');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('UNAUTHORIZED');
   });
 });


### PR DESCRIPTION
## Summary
- Adds `updateDiscussion` (GraphQL mutation) to modify discussion title/body
- Adds `deleteDiscussion` (GraphQL mutation) to remove discussions
- Adds `addDiscussionReply` (GraphQL mutation) to post replies
- Closes spec gap in PROJECT.md §5.3 (GitHub Discussions was read/create only)

## Test plan
- [x] Unit tests for all 3 new functions (success + error cases)
- [x] `npm run build` passes
- [x] `npm test` passes
- [x] `npm run lint` passes (warnings only, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)