### PR TITLE
fix(install): add Backlog column to generated CLAUDE.md

### DIFF
--- a/packages/cli/src/install/claudemd.ts
+++ b/packages/cli/src/install/claudemd.ts
@@ -41,7 +41,7 @@ Start with \`/maxsim:go\` — it will detect the project state and guide you.
 ### GitHub Integration
 
 All project planning lives on GitHub:
-- **Project Board**: Visual Kanban (To Do → In Progress → In Review → Done)
+- **Project Board**: Visual Kanban (Backlog → To Do → In Progress → In Review → Done)
 - **Issues**: Phases and tasks as GitHub Issues with sub-issues
 - **Milestones**: Roadmap milestones
 - **Comments**: Plans, research, and verification results as structured comments


### PR DESCRIPTION
## Summary

- The Project Board line in the generated `CLAUDE.md` was missing "Backlog" as the first Kanban column
- Updated `packages/cli/src/install/claudemd.ts` line 44 to match the 5-column spec (PROJECT.md §5.5) and the `BOARD_COLUMNS` constant in `packages/cli/src/github/types.ts`
- No test changes needed — `install.test.ts` has no assertions on the specific column text

## Test plan

- [x] `npm run build` — passes clean
- [x] `npm test` — 463 tests pass, 0 failures
- [x] `npm run lint` — only pre-existing warnings, none in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)