### PR TITLE
fix(hooks): add stop_hook_active guard to stop-sound hook

### DIFF
--- a/packages/cli/src/hooks/maxsim-stop-sound.ts
+++ b/packages/cli/src/hooks/maxsim-stop-sound.ts
@@ -11,6 +11,7 @@ import { readStdinJson, playSound, isWindows, isMac, bundledSound } from './shar
 interface StopInput {
   session_id?: string;
   stop_reason?: string;
+  stop_hook_active?: boolean;
   [key: string]: unknown;
 }
 
@@ -36,7 +37,10 @@ function playCompletion(): void {
   }
 }
 
-readStdinJson<StopInput>((_input) => {
+readStdinJson<StopInput>((input) => {
+  if (input.stop_hook_active === true) {
+    process.exit(0);
+  }
   playCompletion();
   process.exit(0);
 });


### PR DESCRIPTION
## Summary
- Adds `stop_hook_active?: boolean` to the `StopInput` interface in `maxsim-stop-sound.ts`
- Guards against infinite loops by exiting early when `stop_hook_active === true`
- Mirrors the identical pattern already used in `maxsim-capture-learnings.ts` (line 119)

## Test plan
- [x] `npm run build` — passes cleanly
- [x] `npm test` — 463 tests pass, 1 skipped (pre-existing)
- [x] `npm run lint` — no new errors or warnings introduced; all diagnostics are pre-existing in unrelated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)