### PR TITLE
fix(core): sync version.ts to 5.7.0 and add scripts to packages/cli/package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,11 @@
     "dist",
     "README.md"
   ],
+  "scripts": {
+    "build": "node scripts/inject-version.cjs && npx tsdown && node scripts/copy-assets.cjs",
+    "test": "npx vitest run",
+    "lint": "npx biome check ."
+  },
   "engines": {
     "node": ">=22.0.0"
   },

--- a/packages/cli/src/core/version.ts
+++ b/packages/cli/src/core/version.ts
@@ -1,2 +1,2 @@
 /** MaxsimCLI version — auto-injected from package.json at build time. */
-export const VERSION = '5.5.0';
+export const VERSION = '5.7.0';


### PR DESCRIPTION
## Summary

- Ran `inject-version.cjs` to update `VERSION` in `packages/cli/src/core/version.ts` from `5.5.0` to `5.7.0`, matching the current `package.json` version
- Added `scripts` block to `packages/cli/package.json` so `npm test`, `npm run build`, and `npm run lint` work when executed from inside the `packages/cli/` directory

## Test plan

- [x] `npm run build` from repo root passes
- [x] `npm test` from repo root passes (463 tests, 0 failures)
- [x] `npm run lint` from repo root passes (warnings/infos only, no errors)
- [x] `packages/cli/src/core/version.ts` contains `5.7.0`
- [x] `packages/cli/package.json` has a `scripts` block with `build`, `test`, and `lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)