### PR TITLE
feat(core): implement utils with path helpers and frontmatter parser

### DIFF
--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -24,3 +24,7 @@ export { loadConfig, saveConfig, resolveModel, getConfigPath } from './config.js
 
 // Version
 export { VERSION } from './version.js';
+
+// Utils
+export { claudeDir, maxsimDir, agentMemoryDir, configPath, parseFrontmatter } from './utils.js';
+export type { FrontmatterResult } from './utils.js';

--- a/packages/cli/src/core/utils.ts
+++ b/packages/cli/src/core/utils.ts
@@ -1,1 +1,73 @@
-// Reserved for future shared utilities.
+/**
+ * Shared path helpers and frontmatter utilities for MaxsimCLI.
+ */
+
+import * as path from 'node:path';
+
+/** Returns the path to the `.claude` directory within the given project. */
+export function claudeDir(projectDir: string): string {
+  return path.join(projectDir, '.claude');
+}
+
+/** Returns the path to the `.claude/maxsim` directory within the given project. */
+export function maxsimDir(projectDir: string): string {
+  return path.join(claudeDir(projectDir), 'maxsim');
+}
+
+/** Returns the path to the agent-memory learner directory within the given project. */
+export function agentMemoryDir(projectDir: string): string {
+  return path.join(claudeDir(projectDir), 'agent-memory', 'maxsim-learner');
+}
+
+/** Returns the path to the MaxsimCLI config file within the given project. */
+export function configPath(projectDir: string): string {
+  return path.join(maxsimDir(projectDir), 'config.json');
+}
+
+/** Result of parsing YAML frontmatter from a content string. */
+export interface FrontmatterResult {
+  attributes: Record<string, string>;
+  body: string;
+}
+
+/**
+ * Parses YAML frontmatter delimited by `---` from the beginning of a string.
+ * Only flat `key: value` lines are supported — no nested YAML.
+ * Returns `{ attributes: {}, body: content }` if no frontmatter is found.
+ */
+export function parseFrontmatter(content: string): FrontmatterResult {
+  const DELIMITER = '---';
+
+  if (!content.startsWith(DELIMITER)) {
+    return { attributes: {}, body: content };
+  }
+
+  const afterOpening = content.slice(DELIMITER.length);
+  // The opening delimiter must be followed by a newline (or end-of-string).
+  if (afterOpening.length > 0 && afterOpening[0] !== '\n' && afterOpening[0] !== '\r') {
+    return { attributes: {}, body: content };
+  }
+
+  const closingIndex = afterOpening.indexOf(`\n${DELIMITER}`);
+  if (closingIndex === -1) {
+    return { attributes: {}, body: content };
+  }
+
+  const frontmatterText = afterOpening.slice(0, closingIndex);
+  const afterClosing = afterOpening.slice(closingIndex + 1 + DELIMITER.length);
+  // Body starts after an optional newline following the closing delimiter.
+  const body = afterClosing.startsWith('\n') ? afterClosing.slice(1) : afterClosing;
+
+  const attributes: Record<string, string> = {};
+  for (const line of frontmatterText.split('\n')) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex === -1) continue;
+    const key = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim();
+    if (key.length > 0) {
+      attributes[key] = value;
+    }
+  }
+
+  return { attributes, body };
+}

--- a/packages/cli/tests/unit/utils.test.ts
+++ b/packages/cli/tests/unit/utils.test.ts
@@ -1,6 +1,76 @@
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
+import {
+  claudeDir,
+  maxsimDir,
+  agentMemoryDir,
+  configPath,
+  parseFrontmatter,
+} from '../../src/core/utils.js';
 
-// utils.ts currently exports no functions; tests will be added when new utilities are introduced.
-describe('utils', () => {
-  it.todo('add tests when utilities are implemented');
+describe('path helpers', () => {
+  const PROJECT = '/home/user/project';
+
+  it('claudeDir returns <projectDir>/.claude', () => {
+    expect(claudeDir(PROJECT)).toBe(path.join(PROJECT, '.claude'));
+  });
+
+  it('maxsimDir returns <projectDir>/.claude/maxsim', () => {
+    expect(maxsimDir(PROJECT)).toBe(path.join(PROJECT, '.claude', 'maxsim'));
+  });
+
+  it('agentMemoryDir returns <projectDir>/.claude/agent-memory/maxsim-learner', () => {
+    expect(agentMemoryDir(PROJECT)).toBe(
+      path.join(PROJECT, '.claude', 'agent-memory', 'maxsim-learner'),
+    );
+  });
+
+  it('configPath returns <projectDir>/.claude/maxsim/config.json', () => {
+    expect(configPath(PROJECT)).toBe(
+      path.join(PROJECT, '.claude', 'maxsim', 'config.json'),
+    );
+  });
+});
+
+describe('parseFrontmatter', () => {
+  it('extracts key-value attributes and body from valid frontmatter', () => {
+    const content = `---\ntitle: Hello World\nauthor: Alice\n---\nBody text here.`;
+    const result = parseFrontmatter(content);
+    expect(result.attributes).toEqual({ title: 'Hello World', author: 'Alice' });
+    expect(result.body).toBe('Body text here.');
+  });
+
+  it('returns empty attributes and full content when no frontmatter is present', () => {
+    const content = 'Just plain text, no frontmatter.';
+    const result = parseFrontmatter(content);
+    expect(result.attributes).toEqual({});
+    expect(result.body).toBe(content);
+  });
+
+  it('returns empty attributes and full content for empty string', () => {
+    const result = parseFrontmatter('');
+    expect(result.attributes).toEqual({});
+    expect(result.body).toBe('');
+  });
+
+  it('handles frontmatter with no body', () => {
+    const content = `---\nkey: value\n---\n`;
+    const result = parseFrontmatter(content);
+    expect(result.attributes).toEqual({ key: 'value' });
+    expect(result.body).toBe('');
+  });
+
+  it('handles frontmatter where value contains a colon', () => {
+    const content = `---\nurl: https://example.com\n---\nbody`;
+    const result = parseFrontmatter(content);
+    expect(result.attributes.url).toBe('https://example.com');
+    expect(result.body).toBe('body');
+  });
+
+  it('treats content starting with --- but missing closing delimiter as no frontmatter', () => {
+    const content = `---\ntitle: Unterminated`;
+    const result = parseFrontmatter(content);
+    expect(result.attributes).toEqual({});
+    expect(result.body).toBe(content);
+  });
 });


### PR DESCRIPTION
## Summary

- Implements `claudeDir`, `maxsimDir`, `agentMemoryDir`, and `configPath` path helpers in `packages/cli/src/core/utils.ts`; each helper composes from the previous to eliminate repeated literals
- Implements `parseFrontmatter` for flat `key: value` YAML frontmatter extraction with correct edge-case handling (no frontmatter, empty input, unterminated blocks, values containing colons)
- Re-exports all new functions and the `FrontmatterResult` interface from `packages/cli/src/core/index.ts`
- Replaces the `it.todo` stub in `utils.test.ts` with 10 comprehensive unit tests covering all helpers and parser edge cases

## Test plan

- [x] `npm run build` — clean build, no TypeScript errors
- [x] `npm test` — all 473 tests pass (10 new tests in `utils.test.ts`)
- [x] `npm run lint` — only pre-existing warnings/infos; no new issues introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)