### PR TITLE
docs: update USER-GUIDE and README for v6 completeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Project config lives in `.claude/maxsim/config.json`, created during `/maxsim:in
 
 | Setting | Type | Default | What it does |
 |---------|------|---------|-------------|
-| `version` | `string` | `"5.2.2"` | Config schema version |
+| `version` | `string` | `"6.0.0"` | Config schema version |
 | `execution.model_profile` | `'quality' \| 'balanced' \| 'budget'` | `'balanced'` | Model tier for all agents |
 | `execution.parallelism.max_agents_per_wave` | `number` | `3` | Cap on concurrent agents per wave |
 | `execution.parallelism.max_retries` | `number` | `3` | Max retries per failed plan |
@@ -298,7 +298,7 @@ Project config lives in `.claude/maxsim/config.json`, created during `/maxsim:in
 
 ```json
 {
-  "version": "5.2.2",
+  "version": "6.0.0",
   "execution": {
     "model_profile": "balanced",
     "parallelism": {
@@ -387,7 +387,7 @@ Each parallel plan gets a worktree at `.maxsim-worktrees/{planId}/` on its own b
 
 ### When It Activates
 
-Parallel execution kicks in when a wave has at least `parallelization.min_plans_for_parallel` plans (default 2). `execution.parallelism.max_agents_per_wave` caps concurrent agents per wave (default 3). `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set automatically in `settings.json` during installation.
+`execution.parallelism.max_agents_per_wave` caps concurrent agents per wave (default 3). `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set automatically in `settings.json` during installation.
 
 Before running in parallel, MAXSIM checks that plans do not modify the same files. If there is a conflict, it falls back to sequential mode.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -57,7 +57,7 @@ You never need to remember where you were. `/maxsim:go` always knows.
 
 ## Commands
 
-MaxsimCLI provides 9 slash commands. `/maxsim:go` is the primary interface — use the others when you want explicit control over a specific step.
+MaxsimCLI provides 13 slash commands. `/maxsim:go` is the primary interface — use the others when you want explicit control over a specific step.
 
 | Command | Description | Example |
 |---------|-------------|---------|
@@ -70,6 +70,10 @@ MaxsimCLI provides 9 slash commands. `/maxsim:go` is the primary interface — u
 | `/maxsim:progress` | **Show project status.** Reads the GitHub Project Board and displays a summary of what is done, what is in progress, and what to do next. | `/maxsim:progress` |
 | `/maxsim:settings` | **Configure MaxsimCLI.** Change model profiles, verification settings, parallelism, and other options. Writes to `.claude/maxsim/config.json`. | `/maxsim:settings` |
 | `/maxsim:help` | **Show available commands.** Quick reference for all commands. | `/maxsim:help` |
+| `/maxsim:improve [metric]` | **Autonomous optimization loop.** Iteratively modifies the codebase, verifies the result, and keeps or discards changes based on whether the target metric improves. | `/maxsim:improve performance` |
+| `/maxsim:fix-loop [cmd]` | **Autonomous error repair.** Runs the given command, diagnoses failures, applies fixes, and repeats until zero errors remain. | `/maxsim:fix-loop "npm test"` |
+| `/maxsim:debug-loop [symptom]` | **Autonomous bug hunting.** Applies the scientific method with hypothesis testing — form hypotheses, design experiments, verify, and repeat until the root cause is confirmed and fixed. | `/maxsim:debug-loop "login fails on mobile"` |
+| `/maxsim:security [scope]` | **Security audit.** Runs a read-only STRIDE + OWASP + red-team analysis across the specified scope and produces a prioritised finding report. | `/maxsim:security src/` |
 
 ### When to use explicit commands vs `/maxsim:go`
 
@@ -94,7 +98,7 @@ Init → Plan → Execute → Verify
 
 `/maxsim:init` runs once per project. It:
 
-1. Scans your existing codebase using 30+ parallel Research agents (brownfield support)
+1. Scans your existing codebase using parallel Research agents — count scaled by model profile and project size — (brownfield support)
 2. Interviews you: project name, goals, tech stack, conventions, testing strategy, acceptance criteria
 3. Creates your GitHub repository if none exists
 4. Sets up the GitHub Project Board (Kanban: To Do → In Progress → In Review → Done)
@@ -310,7 +314,7 @@ MaxsimCLI uses 4 specialized agent types that work together to plan, build, rese
 |-------|------|-------------|
 | **Planner** | Planning | Creates phase plans and task breakdowns. Operates in read-only Plan Mode — it cannot write code. Reads GitHub Issues and produces sub-issue task breakdowns. |
 | **Executor** | Implementation | Writes code. Each executor works in an isolated git worktree on its own branch. Commits atomically using conventional commit format. |
-| **Researcher** | Investigation | Reads the codebase, searches the web, investigates dependencies. Used during init (30+ agents scanning in parallel) and during planning (domain research). |
+| **Researcher** | Investigation | Reads the codebase, searches the web, investigates dependencies. Used during init (parallel agents, count scaled by model profile and project size) and during planning (domain research). |
 | **Verifier** | Quality Control | Reviews completed work. Runs tests, checks build, runs lint, reviews code for security and quality issues, and produces evidence blocks. |
 
 ### Parallel Execution with Worktrees

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -276,7 +276,7 @@ Project config lives in `.claude/maxsim/config.json`, created during `/maxsim:in
 
 | Setting | Type | Default | What it does |
 |---------|------|---------|-------------|
-| `version` | `string` | `"5.2.2"` | Config schema version |
+| `version` | `string` | `"6.0.0"` | Config schema version |
 | `execution.model_profile` | `'quality' \| 'balanced' \| 'budget'` | `'balanced'` | Model tier for all agents |
 | `execution.parallelism.max_agents_per_wave` | `number` | `3` | Cap on concurrent agents per wave |
 | `execution.parallelism.max_retries` | `number` | `3` | Max retries per failed plan |
@@ -298,7 +298,7 @@ Project config lives in `.claude/maxsim/config.json`, created during `/maxsim:in
 
 ```json
 {
-  "version": "5.2.2",
+  "version": "6.0.0",
   "execution": {
     "model_profile": "balanced",
     "parallelism": {
@@ -387,7 +387,7 @@ Each parallel plan gets a worktree at `.maxsim-worktrees/{planId}/` on its own b
 
 ### When It Activates
 
-Parallel execution kicks in when a wave has at least `parallelization.min_plans_for_parallel` plans (default 2). `execution.parallelism.max_agents_per_wave` caps concurrent agents per wave (default 3). `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set automatically in `settings.json` during installation.
+`execution.parallelism.max_agents_per_wave` caps concurrent agents per wave (default 3). `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set automatically in `settings.json` during installation.
 
 Before running in parallel, MAXSIM checks that plans do not modify the same files. If there is a conflict, it falls back to sequential mode.
 


### PR DESCRIPTION
## Summary

- Add 4 missing commands to `docs/USER-GUIDE.md` command table: `/maxsim:improve`, `/maxsim:fix-loop`, `/maxsim:debug-loop`, `/maxsim:security` (with descriptions and examples matching the actual codebase)
- Replace fixed "30+" agent count with profile-based scaling language in two places in `USER-GUIDE.md`
- Bump config schema `version` default from `"5.2.2"` to `"6.0.0"` in `README.md` (reference table and config example)
- Remove non-existent `parallelization.min_plans_for_parallel` key from the "When It Activates" section in `README.md`
- Apply same README fixes to `packages/cli/README.md` (kept in sync by the build's copy-assets script)

## Test plan

- [x] `npm run build` — passes (markdown-only changes, no TypeScript affected)
- [x] `npm test` — 463 tests pass, 1 skipped
- [x] `npm run lint` — 9 pre-existing warnings, 28 pre-existing infos; no new issues introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)