### PR TITLE
fix(workflows): add verifier step to quick and TSV logging to verify-phase

### DIFF
--- a/templates/commands/maxsim/quick.md
+++ b/templates/commands/maxsim/quick.md
@@ -25,6 +25,8 @@ Follow @.claude/maxsim/workflows/quick.md end-to-end.
 3. Create a GitHub Issue labeled `type:quick` for the task
 4. Spawn a planner Agent (quick mode) to produce a concise implementation plan
 5. Spawn executor Agent(s) to implement the plan
-6. Commit with atomic message referencing the GitHub Issue
-7. Close the GitHub Issue with completion summary
+6. Spawn a verifier Agent to check the result (tests pass, build succeeds, lint clean)
+7. If verification fails, spawn a fix agent (max 2 retries)
+8. Commit with atomic message referencing the GitHub Issue
+9. Close the GitHub Issue with completion summary
 </process>

--- a/templates/workflows/verify-phase.md
+++ b/templates/workflows/verify-phase.md
@@ -405,6 +405,28 @@ Return to orchestrator:
 - If gaps_found: gap list and recommended fix plan names
 - If human_needed: items requiring human testing
 
+## Step 10 — Log Verification Metrics
+
+Append a row to `.claude/agent-memory/maxsim-learner/autoresearch-results.tsv`:
+
+```tsv
+{iteration}	{commit_hash}	{checks_passed}/{checks_total}	{delta}	{guard_result}	{status}	Phase {N} verification: {PASS|FAIL}
+```
+
+Where:
+- `iteration` = sequential counter (read last line of TSV, increment)
+- `commit_hash` = current HEAD or `-` if no new commit
+- `checks_passed` / `checks_total` = number of automated checks that passed vs total run
+- `delta` = change in score vs previous verification row, e.g. `+2` or `-1`; use `0` for first entry
+- `guard_result` = `pass` if regression guard passed, `fail` otherwise
+- `status` = `keep` if overall PASS, `discard` if overall FAIL
+
+If the TSV file does not exist, create it with the header line:
+```
+# metric_direction: higher_is_better
+iteration	commit	metric	delta	guard	status	description
+```
+
 </process>
 
 <success_criteria>
@@ -425,4 +447,5 @@ Return to orchestrator:
 - [ ] Rework attempted up to 2 times if guard fails after verify passes
 - [ ] Board transition executed: Done + closed on pass, In Progress on fail
 - [ ] Results returned to orchestrator with status, score, and gap details
+- [ ] Verification metrics appended to `.claude/agent-memory/maxsim-learner/autoresearch-results.tsv` (TSV created with header if missing)
 </success_criteria>


### PR DESCRIPTION
## Summary

- Closes spec gap in `quick.md` where the `<objective>` promised a verifier after execution but the `<process>` had no verifier step; adds step 6 (spawn verifier Agent), step 7 (fix agent with 2-retry cap), and renumbers commit/close to steps 8–9
- Adds Step 10 to `verify-phase.md` to append per-run metrics rows to `.claude/agent-memory/maxsim-learner/autoresearch-results.tsv`, with header creation on first use and full documentation for all TSV columns (including `delta` and `checks_passed/checks_total` which were missing in the original spec)

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 463 tests pass, 1 skipped (pre-existing)
- [x] `npm run lint` — 9 warnings / 28 infos, all pre-existing; no errors; no new issues introduced
- [ ] E2E skipped — template-only changes with no runtime code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)