### PR TITLE
feat(install): implement manifest for installed file tracking

### DIFF
--- a/packages/cli/src/install/manifest.ts
+++ b/packages/cli/src/install/manifest.ts
@@ -1,0 +1,69 @@
+/**
+ * Manifest utilities for tracking files installed by MaxsimCLI.
+ *
+ * The manifest is stored at `.claude/maxsim/manifest.json` and contains
+ * a JSON array of paths relative to the project directory.  It enables
+ * a clean, targeted uninstall without guessing which files belong to us.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const MANIFEST_FILE = 'manifest.json';
+
+/** Get the manifest file path for the given project directory. */
+export function getManifestPath(projectDir: string): string {
+  return path.join(projectDir, '.claude', 'maxsim', MANIFEST_FILE);
+}
+
+/**
+ * Write the list of installed file paths (relative to projectDir) to the
+ * manifest.  Creates the parent directory if it does not exist.
+ */
+export function writeManifest(projectDir: string, files: string[]): void {
+  const manifestPath = getManifestPath(projectDir);
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(manifestPath, `${JSON.stringify(files, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Read the manifest and return the list of recorded file paths.
+ * Returns an empty array when the manifest does not exist or contains
+ * invalid JSON.
+ */
+export function readManifest(projectDir: string): string[] {
+  const manifestPath = getManifestPath(projectDir);
+  if (!fs.existsSync(manifestPath)) return [];
+  try {
+    const raw = fs.readFileSync(manifestPath, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Remove every file listed in the manifest, then remove the manifest itself.
+ * Files that have already been deleted are silently skipped.
+ *
+ * @returns The number of files that were actually deleted.
+ */
+export function removeManifested(projectDir: string): number {
+  const files = readManifest(projectDir);
+  let removed = 0;
+  for (const rel of files) {
+    try {
+      fs.unlinkSync(path.join(projectDir, rel));
+      removed++;
+    } catch {
+      // file already gone — skip
+    }
+  }
+  try {
+    fs.unlinkSync(getManifestPath(projectDir));
+  } catch {
+    // manifest already gone — skip
+  }
+  return removed;
+}

--- a/packages/cli/tests/unit/manifest.test.ts
+++ b/packages/cli/tests/unit/manifest.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  getManifestPath,
+  writeManifest,
+  readManifest,
+  removeManifested,
+} from '../../src/install/manifest.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maxsim-manifest-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('getManifestPath', () => {
+  it('returns path under .claude/maxsim/manifest.json', () => {
+    const p = getManifestPath('/some/project');
+    expect(p).toBe(path.join('/some/project', '.claude', 'maxsim', 'manifest.json'));
+  });
+});
+
+describe('writeManifest', () => {
+  it('creates the manifest file with correct JSON content', () => {
+    const files = ['.claude/maxsim/config.json', '.claude/commands/maxsim/go.md'];
+    writeManifest(tmpDir, files);
+
+    const manifestPath = getManifestPath(tmpDir);
+    expect(fs.existsSync(manifestPath)).toBe(true);
+
+    const raw = fs.readFileSync(manifestPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed).toEqual(files);
+  });
+
+  it('creates parent directories when they do not exist', () => {
+    writeManifest(tmpDir, ['some/file.txt']);
+    expect(fs.existsSync(getManifestPath(tmpDir))).toBe(true);
+  });
+
+  it('writes an empty array correctly', () => {
+    writeManifest(tmpDir, []);
+    const raw = fs.readFileSync(getManifestPath(tmpDir), 'utf8');
+    expect(JSON.parse(raw)).toEqual([]);
+  });
+});
+
+describe('readManifest', () => {
+  it('returns the file list written by writeManifest', () => {
+    const files = ['a/b.md', 'c/d.json'];
+    writeManifest(tmpDir, files);
+    expect(readManifest(tmpDir)).toEqual(files);
+  });
+
+  it('returns an empty array when no manifest exists', () => {
+    expect(readManifest(tmpDir)).toEqual([]);
+  });
+
+  it('returns an empty array when the manifest contains corrupt JSON', () => {
+    const manifestPath = getManifestPath(tmpDir);
+    const dir = path.dirname(manifestPath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(manifestPath, 'not valid json{{{', 'utf8');
+
+    expect(readManifest(tmpDir)).toEqual([]);
+  });
+
+  it('returns an empty array when the manifest contains a non-array value', () => {
+    const manifestPath = getManifestPath(tmpDir);
+    const dir = path.dirname(manifestPath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(manifestPath, JSON.stringify({ key: 'value' }), 'utf8');
+
+    expect(readManifest(tmpDir)).toEqual([]);
+  });
+});
+
+describe('removeManifested', () => {
+  it('removes all files listed in the manifest and returns the count', () => {
+    const subDir = path.join(tmpDir, 'tracked');
+    fs.mkdirSync(subDir, { recursive: true });
+    fs.writeFileSync(path.join(subDir, 'a.md'), 'content-a');
+    fs.writeFileSync(path.join(subDir, 'b.md'), 'content-b');
+
+    writeManifest(tmpDir, ['tracked/a.md', 'tracked/b.md']);
+
+    const count = removeManifested(tmpDir);
+    expect(count).toBe(2);
+    expect(fs.existsSync(path.join(subDir, 'a.md'))).toBe(false);
+    expect(fs.existsSync(path.join(subDir, 'b.md'))).toBe(false);
+  });
+
+  it('removes the manifest file itself after cleaning up tracked files', () => {
+    writeManifest(tmpDir, []);
+    const manifestPath = getManifestPath(tmpDir);
+    expect(fs.existsSync(manifestPath)).toBe(true);
+
+    removeManifested(tmpDir);
+    expect(fs.existsSync(manifestPath)).toBe(false);
+  });
+
+  it('handles already-deleted files gracefully and does not count them', () => {
+    writeManifest(tmpDir, ['nonexistent/file.txt']);
+    const count = removeManifested(tmpDir);
+    expect(count).toBe(0);
+  });
+
+  it('returns 0 and does nothing when no manifest exists', () => {
+    const count = removeManifested(tmpDir);
+    expect(count).toBe(0);
+  });
+
+  it('only counts files that actually existed', () => {
+    const subDir = path.join(tmpDir, 'mixed');
+    fs.mkdirSync(subDir, { recursive: true });
+    fs.writeFileSync(path.join(subDir, 'real.md'), 'hello');
+
+    writeManifest(tmpDir, ['mixed/real.md', 'mixed/ghost.md']);
+
+    const count = removeManifested(tmpDir);
+    expect(count).toBe(1);
+    expect(fs.existsSync(path.join(subDir, 'real.md'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `packages/cli/src/install/manifest.ts` with four exports: `getManifestPath`, `writeManifest`, `readManifest`, and `removeManifested`
- The manifest stores a JSON array of relative paths at `.claude/maxsim/manifest.json`, enabling a clean targeted uninstall
- Add `packages/cli/tests/unit/manifest.test.ts` with 13 unit tests covering all functions and edge cases (missing file, corrupt JSON, non-array JSON, already-deleted files)

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 476 tests pass (13 new manifest tests included)
- [x] `npm run lint` — exits 0 (no new warnings or errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)