### PR TITLE
fix(stuck-detection): include crashes in stuck detection trigger condition

### DIFF
--- a/templates/commands/maxsim/improve.md
+++ b/templates/commands/maxsim/improve.md
@@ -49,7 +49,7 @@ Run the 8-phase autoresearch loop, one iteration at a time:
 8. **Log** — append iteration result to the TSV file (date, iteration, approach, metric-value, outcome, commit-hash, notes)
 
 **Stuck Detection:**
-After 5 consecutive discards:
+After 5 consecutive discards or crashes:
 1. Re-read ALL in-scope files (full context reload)
 2. Re-read original goal and review entire TSV log for patterns
 3. Try combining 2-3 successful past changes

--- a/templates/skills/autoresearch/references/loop-protocol.md
+++ b/templates/skills/autoresearch/references/loop-protocol.md
@@ -159,7 +159,7 @@ Keeps: X | Discards: Y | Crashes: Z | Skipped: W
 Best iteration: #{n} — {description}
 ```
 
-### When Stuck (>5 consecutive discards)
+### When Stuck (5 consecutive discards or crashes (status=discard or status=crash))
 
 1. Re-read all in-scope files from scratch.
 2. Re-read the original goal/direction.

--- a/templates/workflows/help.md
+++ b/templates/workflows/help.md
@@ -155,7 +155,7 @@ Autonomous optimization loop — make one atomic change per iteration, verify ag
 
 - Configures metric command, guard command, direction, and iteration budget in Plan Mode
 - Runs the autoresearch 8-phase loop: Review → Ideate → Modify → Commit → Verify → Guard → Decide → Log
-- Stuck detection after 5 consecutive discards
+- Stuck detection after 5 consecutive discards/crashes
 - Results tracked in `.claude/agent-memory/maxsim-learner/autoresearch-results.tsv`
 
 ```


### PR DESCRIPTION
## Summary

- Updates `templates/commands/maxsim/improve.md` to trigger stuck detection after "5 consecutive discards or crashes" (was "5 consecutive discards")
- Updates `templates/skills/autoresearch/references/loop-protocol.md` to include both `status=discard` and `status=crash` in the stuck condition, and fixes the threshold from `>5` to `5` (equal to, not greater than) per PROJECT.md §11.5
- Updates `templates/workflows/help.md` to say "5 consecutive discards/crashes" (was "5 consecutive discards")

## Test plan

- [x] Build passes: `npm run build`
- [x] All 486 unit tests pass: `npm test`
- [x] Lint passes with warnings only (no errors): `npm run lint`
- [x] Changes are minimal and targeted — only 3 lines changed across 3 markdown template files

🤖 Generated with [Claude Code](https://claude.com/claude-code)