### PR TITLE
fix(templates): convert HARD-GATE markdown headings to XML tags

### DIFF
--- a/templates/agents/executor.md
+++ b/templates/agents/executor.md
@@ -45,11 +45,13 @@ For each task in the plan:
 5. **Commit** -- stage task files individually, commit with conventional format: `{type}({scope}): {description}`
 6. **Next task** -- proceed to the next task in sequence
 
-## HARD GATE -- Pre-Commit Verification
+<HARD-GATE name="pre-commit-verification">
 
 Before every commit, verify the task's done criteria with evidence. Do NOT commit if any criterion fails. Fix first, re-verify, then commit.
 
 If you have not run the verification command in THIS turn, you cannot commit.
+
+</HARD-GATE>
 
 ## Deviation Rules
 

--- a/templates/agents/verifier.md
+++ b/templates/agents/verifier.md
@@ -53,7 +53,7 @@ Cover these areas when relevant to scope:
 - **Code review** -- evaluate correctness, quality, and security in touched files
 - **Evidence posting** -- results are returned to the orchestrator for GitHub posting
 
-## HARD GATE -- Anti-Rationalization
+<HARD-GATE name="anti-rationalization">
 
 Do NOT pass a criterion by arguing it is "close enough", "minor issue", or "will fix later".
 Either evidence passes or it fails. No middle ground.
@@ -67,6 +67,8 @@ FORBIDDEN PHRASES -- if you catch yourself using these, STOP and gather real evi
 - "it's reasonable to assume..."
 
 If you have not run the verification command in THIS turn, you cannot claim it passes.
+
+</HARD-GATE>
 
 ## Retry on Failure
 

--- a/templates/rules/verification-protocol.md
+++ b/templates/rules/verification-protocol.md
@@ -2,13 +2,15 @@
 
 Evidence before claims, always. No exceptions.
 
-## HARD GATE
+<HARD-GATE name="verification-protocol">
 
 **No completion claims without fresh verification evidence.**
 
 This gate is non-negotiable. There is no advisory mode, no config override, no escape hatch. Either evidence passes or it fails. No middle ground. Partial success is failure. "Good enough" is not enough.
 
 Do NOT pass this gate by arguing it's "close enough", "minor issue", or "will fix later".
+
+</HARD-GATE>
 
 ## THIS-Turn Requirement
 


### PR DESCRIPTION
## Summary

- Replaces `## HARD GATE --` markdown heading syntax with `<HARD-GATE name="...">...</HARD-GATE>` XML tags in three template files
- Closes audit gap per PROJECT.md §11.6 which specifies `<HARD-GATE>` XML tags for non-negotiable verification rules
- Content inside each tag is identical to the original — purely a structural markup change

## Files changed

- `templates/agents/executor.md` — `pre-commit-verification` gate
- `templates/agents/verifier.md` — `anti-rationalization` gate
- `templates/rules/verification-protocol.md` — `verification-protocol` gate

## Test plan

- [x] Build passes: `npm run build` exits cleanly
- [x] All 489 unit tests pass: `npm test`
- [x] Lint: warnings only (pre-existing), no errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)