### PR TITLE
feat(init): offer to create GitHub repo interactively on REMOTE_FAIL

### DIFF
--- a/templates/workflows/init-existing.md
+++ b/templates/workflows/init-existing.md
@@ -31,19 +31,25 @@ Stop. Do not proceed.
 
 **If REMOTE_FAIL:**
 
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- MAXSIM ► NO GITHUB REMOTE FOUND
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Use `AskUserQuestion` to ask:
 
-MAXSIM requires a GitHub remote to track phases as Issues.
+"No GitHub remote found. Would you like me to create a private GitHub repository for this project?"
 
-Fix: git remote add origin <url>
+- **If yes:** Determine the project name from the directory name or `package.json` name field. Run:
+  ```bash
+  gh repo create {project_name} --private --source=. --remote=origin --push
+  ```
+  Verify the remote was created: `git remote get-url origin`
+  If creation fails, show the error and display the manual setup instructions below.
 
-Then re-run /maxsim:init.
-```
-
-Stop. Do not proceed.
+- **If no:** Display:
+  ```
+  To set up manually:
+    Create a new repo:   gh repo create --private
+    Link existing repo:  git remote add origin <url>
+  Then re-run /maxsim:init.
+  ```
+  Stop. Do not proceed.
 
 Call `EnterPlanMode` immediately after verifying prerequisites. All scanning and GitHub setup happens within Plan Mode. Call `ExitPlanMode` only after the user approves the complete initialization plan.
 

--- a/templates/workflows/new-project.md
+++ b/templates/workflows/new-project.md
@@ -31,21 +31,25 @@ Stop. Do not proceed.
 
 **If REMOTE_FAIL:**
 
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- MAXSIM ► NO GITHUB REMOTE FOUND
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Use `AskUserQuestion` to ask:
 
-MAXSIM requires a GitHub remote to track phases as Issues.
+"No GitHub remote found. Would you like me to create a private GitHub repository for this project?"
 
-Options:
-  Create a new repo:   gh repo create --private
-  Link existing repo:  git remote add origin <url>
+- **If yes:** Determine the project name from the directory name or `package.json` name field. Run:
+  ```bash
+  gh repo create {project_name} --private --source=. --remote=origin --push
+  ```
+  Verify the remote was created: `git remote get-url origin`
+  If creation fails, show the error and display the manual setup instructions below.
 
-Then re-run /maxsim:init.
-```
-
-Stop. Do not proceed.
+- **If no:** Display:
+  ```
+  To set up manually:
+    Create a new repo:   gh repo create --private
+    Link existing repo:  git remote add origin <url>
+  Then re-run /maxsim:init.
+  ```
+  Stop. Do not proceed.
 
 Call `EnterPlanMode` immediately after verifying prerequisites. All scanning and GitHub setup happens within Plan Mode. Call `ExitPlanMode` only after the user approves the complete initialization plan.
 


### PR DESCRIPTION
## Summary

- Replaces the hard-stop `REMOTE_FAIL` block in both `templates/workflows/new-project.md` and `templates/workflows/init-existing.md` with an interactive `AskUserQuestion` offer
- When no GitHub remote is found, the agent now asks the user if they want to create a private repo via `gh repo create {project_name} --private --source=. --remote=origin --push`
- On success, verifies the remote with `git remote get-url origin`; on failure, falls back to manual setup instructions
- If the user declines, displays the manual setup instructions and stops (same UX as before, just not the only path)
- Fixed `{project-name}` placeholder inconsistency to `{project_name}` to match the convention used throughout both files

## Test plan

- [ ] Build passes: `cd packages/cli && npm run build`
- [ ] All 489 unit tests pass: `npm test`
- [ ] Lint clean (warnings only, no errors): `npm run lint`
- [ ] Manually verify `new-project.md` Phase 1 REMOTE_FAIL block matches spec
- [ ] Manually verify `init-existing.md` Phase 1 REMOTE_FAIL block matches spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)