### PR TITLE
fix: add overdue detection to progress and clarify debug detection in go workflow

### DIFF
--- a/templates/workflows/go.md
+++ b/templates/workflows/go.md
@@ -110,6 +110,8 @@ Wait for user response before continuing.
 
 **Problem 2: Open bug issues**
 
+Detection rule: If open issues labeled `type:bug` exist → propose `/maxsim:debug` to investigate and fix them.
+
 If `gh issue list --label "type:bug"` returned open issues:
 
 ```
@@ -120,7 +122,7 @@ Bugs:
   #{number} — {title}
   ...
 Impact: Active bugs may affect current phase execution
-Resolution: Address bugs or route to /maxsim:debug
+Resolution: Issues labeled type:bug trigger /maxsim:debug — run it to investigate and fix them
 
 Options:
 1. Route to /maxsim:debug

--- a/templates/workflows/progress.md
+++ b/templates/workflows/progress.md
@@ -104,6 +104,19 @@ Executed but not verified:
 - Phase [N] — [Title] (Issue #NNN): tasks complete, verification pending
 ```
 
+**Overdue milestones** — query milestones with due dates and compare against today's date:
+
+```bash
+gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.due_on != null) | {title, due_on, open_issues}'
+```
+
+For each milestone returned, compare `due_on` (ISO 8601 date string) against today's date. If `due_on` is in the past and `open_issues > 0`, it is overdue. Display:
+
+```
+Overdue milestones:
+- [milestone title]: due [due_on date], [open_issues] open issue(s) remaining
+```
+
 **Overdue or blocked tasks** — phases whose milestone due date has passed, or phases with open issues labeled "type:blocker":
 
 ```
@@ -162,6 +175,13 @@ All phases complete! Ready to wrap up the milestone.
 ## Blockers to Resolve First
 
 - #N: [title] — resolve before continuing
+```
+
+**If overdue milestones exist:** Prepend to next-action section:
+```
+## Overdue Milestones
+
+- [milestone title]: due [due_on date], [open_issues] open issue(s) remaining — close or reschedule before continuing
 ```
 
 </process>


### PR DESCRIPTION
## Summary

- Added overdue milestone detection step to `templates/workflows/progress.md` (Step 4): queries milestones with due dates via `gh api`, compares `due_on` against today, and surfaces overdue milestones (with open issue count) in both the gap detection section and the recommendation section.
- Clarified the debug auto-detection rule in `templates/workflows/go.md` (Problem 2): added an explicit detection rule statement making it clear that `type:bug` labeled issues trigger the `/maxsim:debug` command suggestion, and updated the Resolution text in the displayed block to match.

## Test plan

- [x] `npm run build` passes (no errors)
- [x] `npm test` passes (486/486 tests)
- [x] `npm run lint` passes (warnings only, all pre-existing)

Generated with [Claude Code](https://claude.com/claude-code)