### PR TITLE
fix: sync forbidden phrases to canonical 10 across verification protocol and verifier agent

### DIFF
--- a/templates/agents/verifier.md
+++ b/templates/agents/verifier.md
@@ -60,11 +60,15 @@ Either evidence passes or it fails. No middle ground.
 
 FORBIDDEN PHRASES -- if you catch yourself using these, STOP and gather real evidence:
 - "should work"
-- "probably passes"
-- "I'm confident that..."
-- "based on my analysis..."
-- "the logic suggests..."
-- "it's reasonable to assume..."
+- "I already checked"
+- "tests were passing before"
+- "this is obviously correct"
+- "I think it's fine"
+- "the logic is sound"
+- "nothing changed in that area"
+- "it worked in my local run"
+- "we can verify later"
+- "this is low risk"
 
 If you have not run the verification command in THIS turn, you cannot claim it passes.
 

--- a/templates/rules/verification-protocol.md
+++ b/templates/rules/verification-protocol.md
@@ -38,11 +38,15 @@ If VERDICT is FAIL: do NOT commit. Fix the issue, re-run verification, produce a
 If you catch yourself using any of these, STOP immediately. You are rationalizing instead of verifying:
 
 - "should work"
-- "probably passes"
-- "I'm confident that..."
-- "based on my analysis..."
-- "the logic suggests..."
-- "it's reasonable to assume..."
+- "I already checked"
+- "tests were passing before"
+- "this is obviously correct"
+- "I think it's fine"
+- "the logic is sound"
+- "nothing changed in that area"
+- "it worked in my local run"
+- "we can verify later"
+- "this is low risk"
 
 These phrases indicate reasoning without evidence. Replace them with a verification command and its actual output.
 


### PR DESCRIPTION
## Summary

- `templates/rules/verification-protocol.md` and `templates/agents/verifier.md` each had a 6-phrase forbidden-phrase list that was out of sync with the authoritative 10-phrase list in `templates/skills/verification/SKILL.md`.
- Replaced both lists with the canonical 10 phrases; removed non-canonical phrases ("probably passes", "I'm confident that...", "based on my analysis...", "the logic suggests...", "it's reasonable to assume...").
- Existing formatting conventions in each file were preserved.

## Test plan

- [x] `npm run build` passes (exit 0)
- [x] `npm test` passes (506/506 tests)
- [x] `npm run lint` passes (no errors; pre-existing warnings only, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)