### PR TITLE
feat(executor): add Co-Authored-By trailer to atomic commit format

### DIFF
--- a/templates/workflows/execute-plan.md
+++ b/templates/workflows/execute-plan.md
@@ -109,9 +109,16 @@ Stage only the specific files changed by this task (NEVER `git add .` or `git ad
 
 ```bash
 git add {specific_files_changed_by_this_task}
-git commit -m "{type}({phase_number}-{plan_id}): {task_description_as_commit_message}"
+git commit -m "$(cat <<'EOF'
+{type}({phase_number}-{plan_id}): {task_description_as_commit_message}
+
+{co_author}
+EOF
+)"
 TASK_COMMIT=$(git rev-parse HEAD)
 ```
+
+`{co_author}` is the value of `automation.co_author` from `.claude/maxsim/config.json` (default: `Co-Authored-By: Claude <noreply@anthropic.com>`).
 
 Commit type conventions:
 - `feat` — new feature or capability
@@ -243,6 +250,7 @@ Do not add text after the RESULT line.
 Before returning RESULT: PASS, confirm ALL of the following:
 - [ ] All tasks in the plan were executed
 - [ ] Each task has exactly one atomic commit with a conventional commit message
+- [ ] Each commit includes the `Co-Authored-By` trailer from `automation.co_author` in config
 - [ ] No task was committed with `git add .` or `git add -A`
 - [ ] Tests were run and pass (or no test runner detected)
 - [ ] No TODOs, stubs, or placeholder content introduced


### PR DESCRIPTION
## Summary

- Update step 3d of `execute-plan.md` to use a heredoc `git commit` format that appends the `Co-Authored-By` trailer from `automation.co_author` in config (default: `Co-Authored-By: Claude <noreply@anthropic.com>`)
- Add a verification checklist item confirming each commit includes the `Co-Authored-By` trailer

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 506 unit tests pass (`npm test`)
- [x] Lint passes with no new warnings (`npm run lint`)
- [x] Template change is minimal and follows existing `{placeholder}` convention throughout the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)