### PR TITLE
feat: add argument-hint field to no-arg command frontmatter

### DIFF
--- a/templates/commands/maxsim/go.md
+++ b/templates/commands/maxsim/go.md
@@ -1,6 +1,7 @@
 ---
 name: maxsim:go
 description: Auto-detect project state and execute the right action
+argument-hint: ""
 allowed-tools: [Read, Bash, Grep, Glob, Agent, AskUserQuestion, EnterPlanMode, ExitPlanMode]
 ---
 

--- a/templates/commands/maxsim/help.md
+++ b/templates/commands/maxsim/help.md
@@ -1,6 +1,7 @@
 ---
 name: maxsim:help
 description: Show available MaxsimCLI commands and usage
+argument-hint: ""
 allowed-tools: [Read]
 ---
 

--- a/templates/commands/maxsim/progress.md
+++ b/templates/commands/maxsim/progress.md
@@ -1,6 +1,7 @@
 ---
 name: maxsim:progress
 description: Show project status from GitHub Project Board with next-action recommendation
+argument-hint: ""
 allowed-tools: [Read, Bash, Grep, Glob]
 ---
 

--- a/templates/commands/maxsim/settings.md
+++ b/templates/commands/maxsim/settings.md
@@ -1,6 +1,7 @@
 ---
 name: maxsim:settings
 description: View and modify MaxsimCLI configuration
+argument-hint: ""
 allowed-tools: [Read, Write, Edit, Bash, AskUserQuestion, EnterPlanMode, ExitPlanMode]
 ---
 


### PR DESCRIPTION
## Summary

- Adds `argument-hint: ""` to the YAML frontmatter of `go.md`, `help.md`, `progress.md`, and `settings.md`
- These 4 no-argument commands were missing the field that all 9 other commands already had
- Closes the spec audit gap: all 13 MaxsimCLI commands now consistently carry `argument-hint`

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 506 unit tests pass (`npm test`)
- [x] Lint passes with exit code 0 (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)