### PR TITLE
feat(config): implement small-project agent scaling (PROJECT.md §7.4)

### DIFF
--- a/packages/cli/src/core/config.ts
+++ b/packages/cli/src/core/config.ts
@@ -11,6 +11,7 @@ import {
   type AgentType,
   DEFAULT_CONFIG,
   MODEL_PROFILES,
+  PARALLELISM_LIMITS,
 } from './types.js';
 
 /** Returns the path to the MaxsimCLI config file. */
@@ -78,6 +79,17 @@ export function saveConfig(projectDir: string, config: MaxsimConfig): void {
   }
 
   fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+}
+
+/** Resolve max agents for a profile, applying the small-project scaling rule from PROJECT.md §7.4. */
+export function resolveMaxAgents(
+  profile: ModelProfile,
+  projectFileCount: number
+): number {
+  const limits = PARALLELISM_LIMITS[profile];
+  if (projectFileCount < 10) return Math.min(5, limits.max_agents);
+  if (projectFileCount < 25) return Math.min(Math.floor(limits.max_agents / 2), limits.typical_range[1]);
+  return limits.max_agents;
 }
 
 /** Resolve the model for a given profile and agent type, with optional per-agent overrides. */

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -20,7 +20,7 @@ export {
 } from './types.js';
 
 // Config
-export { loadConfig, saveConfig, resolveModel, getConfigPath } from './config.js';
+export { loadConfig, saveConfig, resolveModel, resolveMaxAgents, getConfigPath } from './config.js';
 
 // Version
 export { VERSION } from './version.js';

--- a/packages/cli/tests/unit/config.test.ts
+++ b/packages/cli/tests/unit/config.test.ts
@@ -6,9 +6,10 @@ import {
   loadConfig,
   saveConfig,
   resolveModel,
+  resolveMaxAgents,
   getConfigPath,
 } from '../../src/core/config.js';
-import { Model, ModelProfile, AgentType, DEFAULT_CONFIG } from '../../src/core/types.js';
+import { Model, ModelProfile, AgentType, DEFAULT_CONFIG, PARALLELISM_LIMITS } from '../../src/core/types.js';
 
 let tmpDir: string;
 
@@ -111,5 +112,49 @@ describe('resolveModel', () => {
 
   it('empty overrides object falls back to profile', () => {
     expect(resolveModel(ModelProfile.BALANCED, AgentType.EXECUTOR, {})).toBe(Model.SONNET);
+  });
+});
+
+describe('resolveMaxAgents', () => {
+  it('small project (<10 files) caps at 5 for quality profile', () => {
+    expect(resolveMaxAgents(ModelProfile.QUALITY, 5)).toBe(5);
+  });
+
+  it('small project (<10 files) caps at 5 for balanced profile', () => {
+    expect(resolveMaxAgents(ModelProfile.BALANCED, 0)).toBe(5);
+  });
+
+  it('small project (<10 files) caps at 5 for budget profile', () => {
+    expect(resolveMaxAgents(ModelProfile.BUDGET, 9)).toBe(5);
+  });
+
+  it('medium project (<25 files) caps at half of profile max for quality profile', () => {
+    const limits = PARALLELISM_LIMITS[ModelProfile.QUALITY];
+    const expected = Math.min(Math.floor(limits.max_agents / 2), limits.typical_range[1]);
+    expect(resolveMaxAgents(ModelProfile.QUALITY, 10)).toBe(expected);
+  });
+
+  it('medium project (<25 files) caps at half of profile max for balanced profile', () => {
+    const limits = PARALLELISM_LIMITS[ModelProfile.BALANCED];
+    const expected = Math.min(Math.floor(limits.max_agents / 2), limits.typical_range[1]);
+    expect(resolveMaxAgents(ModelProfile.BALANCED, 24)).toBe(expected);
+  });
+
+  it('medium project (<25 files) caps at half of profile max for budget profile', () => {
+    const limits = PARALLELISM_LIMITS[ModelProfile.BUDGET];
+    const expected = Math.min(Math.floor(limits.max_agents / 2), limits.typical_range[1]);
+    expect(resolveMaxAgents(ModelProfile.BUDGET, 15)).toBe(expected);
+  });
+
+  it('large project (>=25 files) uses full profile max for quality profile', () => {
+    expect(resolveMaxAgents(ModelProfile.QUALITY, 25)).toBe(PARALLELISM_LIMITS[ModelProfile.QUALITY].max_agents);
+  });
+
+  it('large project (>=25 files) uses full profile max for balanced profile', () => {
+    expect(resolveMaxAgents(ModelProfile.BALANCED, 100)).toBe(PARALLELISM_LIMITS[ModelProfile.BALANCED].max_agents);
+  });
+
+  it('large project (>=25 files) uses full profile max for budget profile', () => {
+    expect(resolveMaxAgents(ModelProfile.BUDGET, 50)).toBe(PARALLELISM_LIMITS[ModelProfile.BUDGET].max_agents);
   });
 });


### PR DESCRIPTION
## Summary

- Add `resolveMaxAgents(profile, projectFileCount)` to `packages/cli/src/core/config.ts` implementing the small-project scaling rule from PROJECT.md §7.4
- Small projects (<10 files) cap at 5 agents regardless of profile; medium projects (<25 files) cap at half the profile max; large projects use the full profile max
- Re-export `resolveMaxAgents` from `packages/cli/src/core/index.ts`
- Add 9 unit tests covering all three size tiers across all three profiles (quality, balanced, budget)

## Test plan

- [ ] `npm run build` passes with no errors
- [ ] `npm test` passes — 515 tests across 17 test files, including 21 tests in config.test.ts (9 new)
- [ ] `npm run lint` shows no errors (only pre-existing warnings in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)