### PR TITLE
docs(website): remove v5 remnants and rename dashboard docs to v6 names

### DIFF
--- a/packages/website/src/content/docs/commands-phases.md
+++ b/packages/website/src/content/docs/commands-phases.md
@@ -10,7 +10,7 @@ Phase lifecycle is managed through two commands: `/maxsim:plan` for planning and
 
 `/maxsim:plan` walks through three sequential stages to produce an executable plan:
 
-{% doctable headers=["Stage", "What Happens"] rows=[["Discussion", "Adaptive questioning to gather context — writes CONTEXT.md"], ["Research", "Studies the codebase and domain to inform planning decisions"], ["Planning", "Creates task breakdowns with wave assignments, type annotations, and verification criteria"]] %}
+{% doctable headers=["Stage", "What Happens"] rows=[["Discussion", "Adaptive questioning to gather context — posts context as a GitHub Issue comment"], ["Research", "Studies the codebase and domain to inform planning decisions"], ["Planning", "Creates task breakdowns with wave assignments, type annotations, and verification criteria"]] %}
 {% /doctable %}
 
 {% codeblock language="bash" %}

--- a/packages/website/src/content/docs/quick-tasks.md
+++ b/packages/website/src/content/docs/quick-tasks.md
@@ -22,5 +22,5 @@ The `--todo` flag integrates with GitHub Issues. It lets you create, view, and r
 When to use quick vs execute-phase: use quick for tasks you could describe in one sentence that have no dependencies on other planned work. Use execute-phase when the task is part of a planned phase, has multiple sub-tasks, or needs the plan-checker's validation.
 
 {% callout type="note" %}
-Even in quick mode, the executor still commits after each task, updates STATE.md, and follows the deviation rules. It's "quick" because it skips optional planning agents, not because it cuts corners on execution quality.
+Even in quick mode, the executor still commits after each task, updates the GitHub Issue status, and follows the deviation rules. It's "quick" because it skips optional planning agents, not because it cuts corners on execution quality.
 {% /callout %}

--- a/packages/website/src/content/docs/review-gates.md
+++ b/packages/website/src/content/docs/review-gates.md
@@ -1,5 +1,5 @@
 ---
-id: dashboard-network
+id: review-gates
 title: Review Gates
 group: Advanced
 ---

--- a/packages/website/src/content/docs/skills-workflows.md
+++ b/packages/website/src/content/docs/skills-workflows.md
@@ -1,5 +1,5 @@
 ---
-id: dashboard-overview
+id: skills-workflows
 title: Skills & Workflows
 group: Advanced
 ---

--- a/packages/website/src/content/docs/workflow-toggles.md
+++ b/packages/website/src/content/docs/workflow-toggles.md
@@ -37,5 +37,5 @@ The `review` object controls what the verifier checks when it runs. Each review 
 {% /codeblock %}
 
 {% callout type="warn" %}
-Disabling the verifier means broken items won't automatically generate fix phases. You'll need to run /maxsim:verify-work manually and check results yourself. Recommended only for throwaway or prototype phases.
+Disabling the verifier means broken items won't automatically generate fix phases. Re-enable the verifier to restore automatic verification through /maxsim:execute. Recommended only for throwaway or prototype phases.
 {% /callout %}

--- a/packages/website/src/content/docs/worktree-mode.md
+++ b/packages/website/src/content/docs/worktree-mode.md
@@ -1,5 +1,5 @@
 ---
-id: dashboard-features
+id: worktree-mode
 title: Worktree Mode
 group: Advanced
 ---

--- a/packages/website/src/pages/DocsPage.tsx
+++ b/packages/website/src/pages/DocsPage.tsx
@@ -24,9 +24,9 @@ import planPhaseMd from "../content/docs/plan-phase.md?raw";
 import executePhaseMd from "../content/docs/execute-phase.md?raw";
 import verifyWorkMd from "../content/docs/verify-work.md?raw";
 import milestonesMd from "../content/docs/milestones.md?raw";
-import dashboardOverviewMd from "../content/docs/dashboard-overview.md?raw";
-import dashboardFeaturesMd from "../content/docs/dashboard-features.md?raw";
-import dashboardNetworkMd from "../content/docs/dashboard-network.md?raw";
+import skillsWorkflowsMd from "../content/docs/skills-workflows.md?raw";
+import worktreeModeMd from "../content/docs/worktree-mode.md?raw";
+import reviewGatesMd from "../content/docs/review-gates.md?raw";
 import commandsCoreMd from "../content/docs/commands-core.md?raw";
 import commandsPhasesMd from "../content/docs/commands-phases.md?raw";
 import commandsMilestoneMd from "../content/docs/commands-milestone.md?raw";
@@ -73,9 +73,9 @@ const PARSED_DOCS: ParsedDoc[] = [
   executePhaseMd,
   verifyWorkMd,
   milestonesMd,
-  dashboardOverviewMd,
-  dashboardFeaturesMd,
-  dashboardNetworkMd,
+  skillsWorkflowsMd,
+  worktreeModeMd,
+  reviewGatesMd,
   commandsCoreMd,
   commandsPhasesMd,
   commandsMilestoneMd,


### PR DESCRIPTION
## Summary

- Renamed 3 stale `dashboard-*` doc files to v6-accurate names (`skills-workflows.md`, `worktree-mode.md`, `review-gates.md`) using `git mv`
- Updated `id:` frontmatter fields in each renamed file to match the new filename
- Fixed 3 content inaccuracies:
  - `quick-tasks.md`: replaced `updates STATE.md` with `updates the GitHub Issue status`
  - `commands-phases.md`: replaced `writes CONTEXT.md` with `posts context as a GitHub Issue comment`
  - `workflow-toggles.md`: replaced non-existent `/maxsim:verify-work` reference with correct `/maxsim:execute` description
- Updated `DocsPage.tsx` imports and PARSED_DOCS array to use the new file names and variable names

## Test plan

- [x] `npm run build` passes in `packages/cli`
- [x] `npm test` passes — 506 tests across 17 files
- [x] `npm run lint` passes — no errors (pre-existing warnings only, unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)