### PR TITLE
feat: ensure .gitignore covers agent-memory files on install

### DIFF
--- a/packages/cli/src/install/index.ts
+++ b/packages/cli/src/install/index.ts
@@ -19,6 +19,18 @@ import { VERSION } from '../core/version.js';
 export { checkGhAuth } from './gh-auth.js';
 import { checkGhAuth } from './gh-auth.js';
 
+export function ensureGitignoreEntries(projectDir: string, entries: string[]): void {
+  const gitignorePath = path.join(projectDir, '.gitignore');
+  let existing = '';
+  try { existing = fs.readFileSync(gitignorePath, 'utf8'); } catch { /* file doesn't exist yet */ }
+  const lines = existing.split('\n');
+  const missing = entries.filter(e => !lines.includes(e));
+  if (missing.length === 0) return;
+  const addition = (existing.length > 0 && !existing.endsWith('\n') ? '\n' : '') +
+    '# MaxsimCLI\n' + missing.join('\n') + '\n';
+  fs.writeFileSync(gitignorePath, existing + addition, 'utf8');
+}
+
 export function checkNodeVersion(minMajor = 22): void {
   const major = parseInt(process.versions.node.split('.')[0], 10);
   if (major < minMajor) {
@@ -114,6 +126,7 @@ async function runInstall(projectDir: string, quiet: boolean): Promise<void> {
 
   // 1b. Create agent-memory directory
   fs.mkdirSync(path.join(projectDir, '.claude', 'agent-memory', 'maxsim-learner'), { recursive: true });
+  ensureGitignoreEntries(projectDir, ['.claude/agent-memory/', 'autoresearch-results.tsv']);
 
   // 2. Copy CLI binary
   const cliBinSrc = path.resolve(__dirname, 'cli.cjs');

--- a/packages/cli/tests/unit/install.test.ts
+++ b/packages/cli/tests/unit/install.test.ts
@@ -13,7 +13,7 @@ import { copyDir, removeDir } from '../../src/install/copy.js';
 import { generateClaudeMd, writeClaudeMd } from '../../src/install/claudemd.js';
 import { uninstall } from '../../src/install/uninstall.js';
 import { checkGhAuth } from '../../src/install/gh-auth.js';
-import { checkNodeVersion } from '../../src/install/index.js';
+import { checkNodeVersion, ensureGitignoreEntries } from '../../src/install/index.js';
 
 const mockExecFileSync = execFileSync as ReturnType<typeof vi.fn>;
 
@@ -208,5 +208,42 @@ describe('uninstall', () => {
 
     uninstall(tmpDir);
     expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(true);
+  });
+});
+
+describe('ensureGitignoreEntries', () => {
+  it('adds entries to an empty .gitignore', () => {
+    const gitignorePath = path.join(tmpDir, '.gitignore');
+    fs.writeFileSync(gitignorePath, '', 'utf8');
+
+    ensureGitignoreEntries(tmpDir, ['.claude/agent-memory/', 'autoresearch-results.tsv']);
+
+    const content = fs.readFileSync(gitignorePath, 'utf8');
+    expect(content).toContain('.claude/agent-memory/');
+    expect(content).toContain('autoresearch-results.tsv');
+    expect(content).toContain('# MaxsimCLI');
+  });
+
+  it('skips entries already present in .gitignore', () => {
+    const gitignorePath = path.join(tmpDir, '.gitignore');
+    fs.writeFileSync(gitignorePath, '.claude/agent-memory/\nautoresearch-results.tsv\n', 'utf8');
+
+    ensureGitignoreEntries(tmpDir, ['.claude/agent-memory/', 'autoresearch-results.tsv']);
+
+    const content = fs.readFileSync(gitignorePath, 'utf8');
+    expect(content).toBe('.claude/agent-memory/\nautoresearch-results.tsv\n');
+  });
+
+  it('creates .gitignore if it does not exist', () => {
+    const gitignorePath = path.join(tmpDir, '.gitignore');
+    expect(fs.existsSync(gitignorePath)).toBe(false);
+
+    ensureGitignoreEntries(tmpDir, ['.claude/agent-memory/', 'autoresearch-results.tsv']);
+
+    expect(fs.existsSync(gitignorePath)).toBe(true);
+    const content = fs.readFileSync(gitignorePath, 'utf8');
+    expect(content).toContain('.claude/agent-memory/');
+    expect(content).toContain('autoresearch-results.tsv');
+    expect(content).toContain('# MaxsimCLI');
   });
 });


### PR DESCRIPTION
## Summary

- Add `ensureGitignoreEntries(projectDir, entries)` helper to `packages/cli/src/install/index.ts` that reads (or creates) `.gitignore`, appends missing entries under a `# MaxsimCLI` header, and writes the file only when changes are needed
- Call the helper immediately after the agent-memory directory is created, ensuring `.claude/agent-memory/` and `autoresearch-results.tsv` are always gitignored after installation
- Use try/catch instead of existsSync + readFileSync to avoid TOCTOU race condition

## Test plan

- [ ] `ensureGitignoreEntries` adds entries to an empty `.gitignore`
- [ ] `ensureGitignoreEntries` skips entries already present (no duplicate lines)
- [ ] `ensureGitignoreEntries` creates `.gitignore` if it does not exist
- [ ] All 509 existing tests continue to pass (`npm run build && npm test && npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)