### PR TITLE
docs: add Plan Mode context headers to sub-workflows

### DIFF
--- a/templates/workflows/execute-plan.md
+++ b/templates/workflows/execute-plan.md
@@ -4,6 +4,8 @@ Template prompt for individual plan execution by a spawned executor agent. This 
 Executor agents run in isolated git worktrees. Each agent executes all tasks in one plan, commits atomically per task, updates the GitHub board, and posts a summary comment on the phase issue.
 </purpose>
 
+> **Execution Context:** This is the executor agent's task prompt, spawned by the parent `/maxsim:execute` orchestrator (`workflows/execute.md`). It runs in its own isolated git worktree after Plan Mode has been exited and execution is underway.
+
 <agent_type>executor</agent_type>
 <isolation>worktree</isolation>
 

--- a/templates/workflows/plan-create.md
+++ b/templates/workflows/plan-create.md
@@ -11,6 +11,8 @@ verifying, and publishing plans to GitHub.
 GitHub Issues is the sole source of truth. No local PLAN.md files are written.
 </purpose>
 
+> **Plan Mode Context:** This sub-workflow runs within Plan Mode established by the parent `/maxsim:plan` orchestrator (`workflows/plan.md`). Do not call `EnterPlanMode` or `ExitPlanMode` — the parent handles the Plan Mode lifecycle.
+
 <critical_rules>
 - Tool name is `Agent` (NOT `Task`)
 - Agent spawning: Agent(prompt, subagent_type, model, isolation, run_in_background)

--- a/templates/workflows/plan-discuss.md
+++ b/templates/workflows/plan-discuss.md
@@ -15,6 +15,8 @@ builder. Your job is to capture decisions that will guide research and planning,
 figure out implementation yourself.
 </purpose>
 
+> **Plan Mode Context:** This sub-workflow runs within Plan Mode established by the parent `/maxsim:plan` orchestrator (`workflows/plan.md`). Do not call `EnterPlanMode` or `ExitPlanMode` — the parent handles the Plan Mode lifecycle.
+
 <critical_rules>
 - Tool name is `Agent` (NOT `Task`)
 - Context is posted to GitHub as a comment with <!-- maxsim:type=context -->

--- a/templates/workflows/plan-research.md
+++ b/templates/workflows/plan-research.md
@@ -11,6 +11,8 @@ research and posting the output to GitHub.
 GitHub Issues is the sole source of truth. No local RESEARCH.md file is written.
 </purpose>
 
+> **Plan Mode Context:** This sub-workflow runs within Plan Mode established by the parent `/maxsim:plan` orchestrator (`workflows/plan.md`). Do not call `EnterPlanMode` or `ExitPlanMode` — the parent handles the Plan Mode lifecycle.
+
 <critical_rules>
 - Tool name is `Agent` (NOT `Task`)
 - Agent spawning: Agent(prompt, subagent_type, model, isolation, run_in_background)

--- a/templates/workflows/verify-phase.md
+++ b/templates/workflows/verify-phase.md
@@ -4,6 +4,8 @@ Verify that a completed phase achieved its GOAL — not just that tasks were mar
 Task completion does not equal goal achievement. This workflow checks the codebase against observable, testable criteria.
 </purpose>
 
+> **Execution Context:** This sub-workflow is spawned as a verifier agent by the parent `/maxsim:execute` orchestrator (`workflows/execute.md`). It runs after Plan Mode has been exited and execution is underway.
+
 <core_principle>
 Verify goal achievement, not task completion. A task "create chat component" can be marked done when the component is a placeholder. The task is done — the goal "working chat interface" is not.
 


### PR DESCRIPTION
## Summary
- Add documentation headers to 5 sub-workflow files clarifying their Plan Mode execution context
- `plan-create.md`, `plan-research.md`, `plan-discuss.md` note they run within Plan Mode from parent orchestrator
- `verify-phase.md`, `execute-plan.md` note they run after Plan Mode has been exited

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (506 tests)
- [x] `npm run lint` passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)