### PR TITLE
test(templates): add unit tests validating shipped template files

### DIFF
--- a/packages/cli/tests/unit/templates.test.ts
+++ b/packages/cli/tests/unit/templates.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { parseFrontmatter } from '../../src/core/utils.js';
+
+const TEMPLATES_DIR = path.resolve(__dirname, '../../dist/assets/templates');
+
+const PLANNING_WRITE_PATTERNS = [
+  /create\s+\.planning/i,
+  /write\s+to\s+\.planning/i,
+  /mkdir\s+\.planning/i,
+];
+
+describe('command templates', () => {
+  const commandsDir = path.join(TEMPLATES_DIR, 'commands', 'maxsim');
+  const commandFiles = fs.readdirSync(commandsDir).filter((f) => f.endsWith('.md'));
+
+  it('exactly 13 .md files exist', () => {
+    expect(commandFiles).toHaveLength(13);
+  });
+
+  it('each file has frontmatter with name, description, and argument-hint', () => {
+    for (const file of commandFiles) {
+      const content = fs.readFileSync(path.join(commandsDir, file), 'utf-8');
+      const { attributes } = parseFrontmatter(content);
+      expect(attributes.name, `${file}: missing name`).toBeDefined();
+      expect(attributes.description, `${file}: missing description`).toBeDefined();
+      expect(attributes['argument-hint'], `${file}: missing argument-hint`).toBeDefined();
+    }
+  });
+
+  it('each name starts with maxsim:', () => {
+    for (const file of commandFiles) {
+      const content = fs.readFileSync(path.join(commandsDir, file), 'utf-8');
+      const { attributes } = parseFrontmatter(content);
+      expect(attributes.name, `${file}: name should start with maxsim:`).toMatch(/^maxsim:/);
+    }
+  });
+
+  it('no command file uses Task( as a tool invocation pattern', () => {
+    for (const file of commandFiles) {
+      const content = fs.readFileSync(path.join(commandsDir, file), 'utf-8');
+      expect(content, `${file}: should not use Task( — use Agent instead`).not.toContain('Task(');
+    }
+  });
+});
+
+describe('agent templates', () => {
+  const agentsDir = path.join(TEMPLATES_DIR, 'agents');
+  const allAgentMd = fs.readdirSync(agentsDir).filter((f) => f.endsWith('.md'));
+  const agentFiles = allAgentMd.filter((f) => f !== 'AGENTS.md');
+
+  it('exactly 4 agent .md files exist plus AGENTS.md', () => {
+    expect(agentFiles).toHaveLength(4);
+    expect(allAgentMd).toContain('AGENTS.md');
+  });
+
+  it('each agent .md has frontmatter with name and tools', () => {
+    for (const file of agentFiles) {
+      const content = fs.readFileSync(path.join(agentsDir, file), 'utf-8');
+      const { attributes } = parseFrontmatter(content);
+      expect(attributes.name, `${file}: missing name`).toBeDefined();
+      expect(attributes.tools, `${file}: missing tools`).toBeDefined();
+    }
+  });
+});
+
+describe('skill templates', () => {
+  const skillsDir = path.join(TEMPLATES_DIR, 'skills');
+  const skillDirs = fs.readdirSync(skillsDir, { withFileTypes: true }).filter((e) => e.isDirectory());
+
+  it('exactly 15 subdirectories exist', () => {
+    expect(skillDirs).toHaveLength(15);
+  });
+
+  it('each subdirectory contains a SKILL.md file', () => {
+    for (const dir of skillDirs) {
+      const skillMd = path.join(skillsDir, dir.name, 'SKILL.md');
+      expect(fs.existsSync(skillMd), `${dir.name}: missing SKILL.md`).toBe(true);
+    }
+  });
+
+  it('each SKILL.md has frontmatter with name and description', () => {
+    for (const dir of skillDirs) {
+      const content = fs.readFileSync(path.join(skillsDir, dir.name, 'SKILL.md'), 'utf-8');
+      const { attributes } = parseFrontmatter(content);
+      expect(attributes.name, `${dir.name}/SKILL.md: missing name`).toBeDefined();
+      expect(attributes.description, `${dir.name}/SKILL.md: missing description`).toBeDefined();
+    }
+  });
+});
+
+describe('workflow templates', () => {
+  const workflowsDir = path.join(TEMPLATES_DIR, 'workflows');
+  const workflowFiles = fs.readdirSync(workflowsDir).filter((f) => f.endsWith('.md'));
+
+  it('at least 10 .md files exist', () => {
+    expect(workflowFiles.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('no workflow uses .planning/ as a write or create target', () => {
+    for (const file of workflowFiles) {
+      const content = fs.readFileSync(path.join(workflowsDir, file), 'utf-8');
+      for (const pattern of PLANNING_WRITE_PATTERNS) {
+        expect(
+          pattern.test(content),
+          `${file}: contains a write/create reference to .planning/ (use GitHub Issues instead)`,
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/templates/commands/maxsim/go.md
+++ b/templates/commands/maxsim/go.md
@@ -1,6 +1,7 @@
 ---
 name: maxsim:go
 description: Auto-detect project state and execute the right action
+argument-hint: ""
 allowed-tools: [Read, Bash, Grep, Glob, Agent, AskUserQuestion, EnterPlanMode, ExitPlanMode]
 ---
 

--- a/templates/commands/maxsim/help.md
+++ b/templates/commands/maxsim/help.md
@@ -1,6 +1,7 @@
 ---
 name: maxsim:help
 description: Show available MaxsimCLI commands and usage
+argument-hint: ""
 allowed-tools: [Read]
 ---
 

--- a/templates/commands/maxsim/progress.md
+++ b/templates/commands/maxsim/progress.md
@@ -1,6 +1,7 @@
 ---
 name: maxsim:progress
 description: Show project status from GitHub Project Board with next-action recommendation
+argument-hint: ""
 allowed-tools: [Read, Bash, Grep, Glob]
 ---
 

--- a/templates/commands/maxsim/settings.md
+++ b/templates/commands/maxsim/settings.md
@@ -1,6 +1,7 @@
 ---
 name: maxsim:settings
 description: View and modify MaxsimCLI configuration
+argument-hint: ""
 allowed-tools: [Read, Write, Edit, Bash, AskUserQuestion, EnterPlanMode, ExitPlanMode]
 ---
 


### PR DESCRIPTION
## Summary

- Adds `packages/cli/tests/unit/templates.test.ts` with 11 tests covering all four template categories (commands, agents, skills, workflows)
- Validates command templates: exactly 13 files, `name`/`description`/`argument-hint` frontmatter, `maxsim:` name prefix, no `Task(` usage
- Validates agent templates: exactly 4 agent files + `AGENTS.md`, `name` and `tools` frontmatter
- Validates skill templates: exactly 15 subdirectories, each with `SKILL.md` having `name` and `description` frontmatter
- Validates workflow templates: at least 10 files, no `.planning/` write/create targets
- Adds `argument-hint: ""` to four command templates that were missing it (`go`, `help`, `progress`, `settings`)

## Test plan

- [x] `npm run build && npm test` — all 517 tests pass (11 new)
- [x] `npm run lint` — exits 0, no issues in new file

🤖 Generated with [Claude Code](https://claude.com/claude-code)