### PR TITLE
expand init command steps 1-3 with full workflow detail

### DIFF
--- a/templates/commands/maxsim/init.md
+++ b/templates/commands/maxsim/init.md
@@ -21,9 +21,9 @@ GitHub is the sole source of truth. Init creates GitHub Milestones and Issues �
 <process>
 Follow @.claude/maxsim/workflows/init.md end-to-end.
 
-1. Scan repo structure (language, framework, existing CI)
-2. Interview user: project goal, scope, constraints, success criteria
-3. Create GitHub Milestone for this project/version
+1. Scan repo in parallel — spawn Research agents to analyze architecture, frameworks, CI/CD, tests, dependencies, and documentation
+2. Interview user: project name, description, goals, tech stack, conventions, testing strategy, deployment, acceptance criteria, no-gos, risks
+3. GitHub Setup — ensure standard labels, create Project Board (Kanban), create Milestone, offer repo creation if needed
 4. Write CLAUDE.md with project context and MaxsimCLI config
 5. Optionally generate Roadmap as GitHub Issues (phases)
 6. Confirm setup and suggest `/maxsim:go` as next step


### PR DESCRIPTION
## Summary

- Expands Step 1 to describe parallel repo scanning via Research agents (architecture, frameworks, CI/CD, tests, dependencies, docs)
- Expands Step 2 to enumerate all interview topics (name, description, goals, tech stack, conventions, testing strategy, deployment, acceptance criteria, no-gos, risks)
- Expands Step 3 to cover the full GitHub setup sequence (standard labels, Project Board/Kanban, Milestone, optional repo creation)

Closes audit gaps §6.1-6.3 items 2-4, bringing them to 100%.

## Test plan

- [x] `npm run build` passes cleanly
- [x] `npm test` — 529 tests across 18 files, all green
- [x] `npm run lint` — no new errors or warnings introduced (pre-existing warnings only)
- [ ] E2E skipped (template-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)