### PR TITLE
feat(go): add Step 6 report-results to /maxsim:go process

### DIFF
--- a/templates/commands/maxsim/go.md
+++ b/templates/commands/maxsim/go.md
@@ -28,4 +28,5 @@ Follow @.claude/maxsim/workflows/go.md end-to-end.
 3. Enter Plan Mode — show detection reasoning and proposed action
 4. Wait for user approval (Ctrl+C cancels)
 5. Execute approved action by spawning the appropriate Agent
+6. Report the result — print a completion summary or surface the error with a recovery suggestion
 </process>


### PR DESCRIPTION
## Summary

- Adds Step 6 to the `<process>` block in `templates/commands/maxsim/go.md`
- Step 6 instructs the agent to print a completion summary or surface the error with a recovery suggestion after executing the approved action
- Closes audit gap §6.1-6.3, bringing coverage from 0% to 100%

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 529 unit tests pass (`npm test`)
- [x] Lint reports no new issues (`npm run lint`) — pre-existing warnings only
- [x] Template-only change; no e2e testing required

🤖 Generated with [Claude Code](https://claude.com/claude-code)