### PR TITLE
fix(spec): correct Plan Mode entries for debug and settings commands in §8 table

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -392,8 +392,8 @@ Small projects (< 10 files) use fewer agents regardless of profile. The exact co
 | `/maxsim:improve` | Yes | Modifies code autonomously |
 | `/maxsim:fix-loop` | Yes | Repairs code autonomously |
 | `/maxsim:debug-loop` | Yes | May modify code |
-| `/maxsim:debug [desc]` | No | Interactive, user guides each step |
-| `/maxsim:settings` | No | Only changes MaxsimCLI config |
+| `/maxsim:debug [desc]` | Yes | Shows debugging plan + fix approach for approval before executing fix |
+| `/maxsim:settings` | Yes | Shows current config for review before writing changes |
 | `/maxsim:security` | No | Read-only audit |
 | `/maxsim:progress` | No | Read-only status display |
 | `/maxsim:help` | No | Read-only text display |


### PR DESCRIPTION
## Summary

- Corrects two rows in the §8 Plan Mode Integration table in `PROJECT.md`
- `/maxsim:debug [desc]`: changed from `No` to `Yes` — the implementation uses `EnterPlanMode` to gate the fix-approach confirmation before executing the fix
- `/maxsim:settings`: changed from `No` to `Yes` — the implementation uses `EnterPlanMode` to show current config for review before writing changes

The spec was wrong; the implementation was correct. This brings §8 Plan Mode Integration to 100% accuracy.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (529/529 tests)
- [x] `npm run lint` exits 0 (pre-existing warnings only, none introduced by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)