### PR TITLE
feat(settings): add per-agent model override support to settings workflow

### DIFF
--- a/templates/commands/maxsim/settings.md
+++ b/templates/commands/maxsim/settings.md
@@ -25,6 +25,7 @@ Follow @.claude/maxsim/workflows/settings.md end-to-end.
    - Verifier enabled/disabled
    - Auto-advance between stages
    - Branching strategy (per-phase / per-task / none)
+   - Per-agent model overrides (override individual agent models beyond profile defaults)
 4. Merge answers and write updated config
 5. Display confirmation of saved settings
 </process>

--- a/templates/workflows/settings.md
+++ b/templates/workflows/settings.md
@@ -118,9 +118,24 @@ AskUserQuestion([
       { label: "Phase", description: "Create branch for each phase." },
       { label: "Milestone", description: "Create branch for the entire milestone." }
     ]
+  },
+  {
+    question: "Override models for individual agent types?",
+    header: "Model Overrides",
+    multiSelect: false,
+    options: [
+      { label: "No overrides (use profile defaults)", description: "All agents use models from the selected profile." },
+      { label: "Custom overrides", description: "Set individual models per agent type (planner/executor/researcher/verifier)." }
+    ]
   }
 ])
 ```
+
+**If "Custom overrides" selected**, use additional `AskUserQuestion` calls for each agent type:
+- Planner: haiku / sonnet / opus (default from profile)
+- Executor: haiku / sonnet / opus (default from profile)
+- Researcher: haiku / sonnet / opus (default from profile)
+- Verifier: haiku / sonnet / opus (default from profile)
 
 ---
 
@@ -144,6 +159,11 @@ node .claude/maxsim/bin/maxsim-tools.cjs config-set automation.auto_commit_on_su
 node .claude/maxsim/bin/maxsim-tools.cjs config-set automation.conventional_commits [true/false]
 node .claude/maxsim/bin/maxsim-tools.cjs config-set automation.co_author "[value]"
 node .claude/maxsim/bin/maxsim-tools.cjs config-set hooks.enabled [true/false]
+# Per-agent model overrides (only if custom overrides selected)
+node .claude/maxsim/bin/maxsim-tools.cjs config-set execution.model_overrides.planner "[haiku/sonnet/opus]"
+node .claude/maxsim/bin/maxsim-tools.cjs config-set execution.model_overrides.executor "[haiku/sonnet/opus]"
+node .claude/maxsim/bin/maxsim-tools.cjs config-set execution.model_overrides.researcher "[haiku/sonnet/opus]"
+node .claude/maxsim/bin/maxsim-tools.cjs config-set execution.model_overrides.verifier "[haiku/sonnet/opus]"
 ```
 
 ---
@@ -190,7 +210,7 @@ Re-run /maxsim:settings anytime to change these.
 
 <success_criteria>
 - [ ] Current config loaded and displayed
-- [ ] User presented with all 7 settings
+- [ ] User presented with all 8 settings
 - [ ] Config updated via maxsim-tools config-set commands
 - [ ] User offered to save as global defaults
 - [ ] Confirmation displayed after save


### PR DESCRIPTION
## Summary

- Adds an 8th question to the settings UI (`templates/workflows/settings.md`) for per-agent model overrides, consistent with the existing `question`/`header` field naming convention used by all other questions
- Adds four `config-set` commands to Step 3 to persist `execution.model_overrides.{planner,executor,researcher,verifier}` when custom overrides are selected
- Updates `templates/commands/maxsim/settings.md` process list to enumerate per-agent model overrides as a configurable item
- Fixes `null` placeholder to use valid model string values only (`haiku/sonnet/opus`), matching the `Partial<Record<AgentType, Model>>` type which uses key absence (not `null`) to indicate no override

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 529 unit tests pass (`npm test`)
- [x] Lint passes with no new errors (`npm run lint`) — pre-existing warnings are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)