### PR TITLE
fix(skill): remove non-standard version field from autoresearch frontmatter

### DIFF
--- a/templates/skills/autoresearch/SKILL.md
+++ b/templates/skills/autoresearch/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: autoresearch
 description: Autonomous optimization loop with reference workflows. Powers /maxsim:improve, /maxsim:fix-loop, /maxsim:debug-loop, /maxsim:security. Used when running autonomous optimization, error repair, bug hunting, or security audit loops.
-version: 1.0.0
 ---
 
 # Autonomous Optimization Loop


### PR DESCRIPTION
## Summary

- Removes the `version: 1.0.0` line from `templates/skills/autoresearch/SKILL.md` frontmatter
- `version` is not a valid Claude Code skill frontmatter field; only `name` and `description` are spec-compliant
- No other skill in the repo uses `version` as a top-level frontmatter key — this brings autoresearch into conformance with §9.1 Skill Format

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 529 unit tests pass (`npm test`)
- [x] Lint passes with no errors (`npm run lint` — only pre-existing warnings/infos unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)