### PR TITLE
Fix PARTIAL audit items in template command files

### DIFF
--- a/templates/commands/maxsim/debug.md
+++ b/templates/commands/maxsim/debug.md
@@ -18,6 +18,8 @@ GitHub is the sole source of truth. Check for open Issues labeled `debug` to det
 </context>
 
 <process>
+Plan Mode: Use EnterPlanMode when presenting symptom analysis and proposed diagnosis. Call ExitPlanMode before spawning the executor Agent for the fix.
+
 Follow @.claude/maxsim/workflows/debug.md end-to-end. Invoke the `systematic-debugging` skill at step 3 to drive the reproduce-hypothesize-isolate-verify-fix cycle.
 
 1. Check GitHub for open Issues labeled `debug` (active sessions)

--- a/templates/commands/maxsim/go.md
+++ b/templates/commands/maxsim/go.md
@@ -25,7 +25,7 @@ Follow @.claude/maxsim/workflows/go.md end-to-end.
 
 1. Read GitHub Project Board state via `gh` CLI
 2. Detect what's next using the priority list above
-3. Enter Plan Mode — show detection reasoning and proposed action
+3. Enter Plan Mode via EnterPlanMode — show detection reasoning and proposed action
 4. Wait for user approval (Ctrl+C cancels)
 5. Execute approved action by spawning the appropriate Agent
 6. Report the result — print a completion summary or surface the error with a recovery suggestion

--- a/templates/commands/maxsim/init.md
+++ b/templates/commands/maxsim/init.md
@@ -19,11 +19,13 @@ GitHub is the sole source of truth. Init creates GitHub Milestones and Issues �
 </context>
 
 <process>
+Plan Mode: Call EnterPlanMode before presenting setup proposals to the user. Call ExitPlanMode after user approves.
+
 Follow @.claude/maxsim/workflows/init.md end-to-end.
 
 1. Scan repo in parallel — spawn Research agents to analyze architecture, frameworks, CI/CD, tests, dependencies, and documentation
 2. Interview user: project name, description, goals, tech stack, conventions, testing strategy, deployment, acceptance criteria, no-gos, risks
-3. GitHub Setup — ensure standard labels, create Project Board (Kanban), create Milestone, offer repo creation if needed
+3. GitHub Setup — ensure standard labels (6 labels in 2 namespaces: type: and maxsim:), create Project Board (Kanban), create Milestone, offer repo creation if needed
 4. Write CLAUDE.md with project context and MaxsimCLI config
 5. Optionally generate Roadmap as GitHub Issues (phases)
 6. Confirm setup and suggest `/maxsim:go` as next step

--- a/templates/commands/maxsim/plan.md
+++ b/templates/commands/maxsim/plan.md
@@ -24,6 +24,8 @@ Re-entry: If phase is already planned, show status and offer options (view, re-p
 </context>
 
 <process>
+Plan Mode: This command uses EnterPlanMode during the Discussion and Planning stages. Call ExitPlanMode before executing the approved plan.
+
 Follow @.claude/maxsim/workflows/plan.md end-to-end.
 
 1. Detect current stage from GitHub Issue labels on the phase Issue

--- a/templates/commands/maxsim/security.md
+++ b/templates/commands/maxsim/security.md
@@ -2,7 +2,7 @@
 name: maxsim:security
 description: Security audit — STRIDE + OWASP Top 10 + red-team analysis (read-only)
 argument-hint: "[scope]"
-allowed-tools: [Read, Bash, Grep, Glob, WebSearch, WebFetch]
+allowed-tools: [Read, Bash, Grep, Glob, Agent, WebSearch, WebFetch]
 ---
 
 <objective>


### PR DESCRIPTION
## Summary
- **go.md**: Added explicit `EnterPlanMode` tool mention in step 3
- **init.md**: Added Plan Mode note at start of process section; specified 6 labels in 2 namespaces for GitHub Setup step
- **plan.md**: Added Plan Mode note documenting EnterPlanMode/ExitPlanMode usage during Discussion and Planning stages
- **debug.md**: Added Plan Mode note for symptom analysis and diagnosis presentation
- **security.md**: Added `Agent` to `allowed-tools` list
- **settings.md**: Verified auto-advance is already mentioned in the objective (no change needed)

## Test plan
- [x] All changes are markdown template files with no runtime behavior — visual review only
- [x] Verified each file reads correctly after edits
- [x] Confirmed settings.md already includes auto-advance reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)