### PR TITLE
docs: remove v5 PLAN.md artifacts and complete README command table

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Removes MAXSIM files from `.claude/`. Your own skills, agents, and Claude Code c
 | `/maxsim:quick <description>` | Quick task — create a GitHub Issue and execute in simplified flow |
 | `/maxsim:progress` | Show project status from GitHub Project Board with next-action recommendation |
 | `/maxsim:debug` | Systematic debugging with reproduce-hypothesize-isolate-verify-fix cycle |
+| `/maxsim:debug-loop [symptom]` | Autonomous bug hunting with hypothesis testing |
+| `/maxsim:fix-loop [error-command]` | Autonomous error repair until zero errors remain |
+| `/maxsim:improve [metric-command]` | Autonomous optimization loop against any metric |
+| `/maxsim:security [scope]` | Security audit — STRIDE + OWASP + red-team (read-only) |
 | `/maxsim:settings` | View and modify MaxsimCLI configuration |
 | `/maxsim:help` | Show available MaxsimCLI commands and usage |
 
@@ -210,7 +214,7 @@ Phase numbers are flexible. Integer (`01`, `02`), letter suffixes for parallel t
 | Agent | Role | What it does |
 |-------|------|-------------|
 | Executor | Builds things | Reads plans, makes code changes, commits atomically, handles deviations |
-| Planner | Creates plans | Turns research into structured PLAN.md files with tasks, waves, and dependencies |
+| Planner | Creates plans | Turns research into structured plan comments on GitHub Issues with tasks, waves, and dependencies |
 | Researcher | Investigates | Explores the codebase, gathers technical context, can use Brave Search |
 | Verifier | Checks results | Validates plan structure, artifacts, requirement evidence, commit integrity |
 

--- a/packages/website/src/components/sections/Hero.tsx
+++ b/packages/website/src/components/sections/Hero.tsx
@@ -10,7 +10,7 @@ const TERMINAL_LINES = [
   { prompt: false, text: "Planning phase 02-Auth-System...", delay: 0.6 },
   { prompt: false, text: "Spawning researcher agent (claude-sonnet-4-20250514)", delay: 1.0 },
   { prompt: false, text: "Research complete. 4 decisions captured.", delay: 1.6 },
-  { prompt: false, text: "Generating 02-01-PLAN.md (12 tasks)", delay: 2.1 },
+  { prompt: false, text: "Publishing plan to GitHub Issue #2 (12 tasks)", delay: 2.1 },
   { prompt: false, text: "Phase plan verified. Ready to execute.", delay: 2.7, accent: true },
 ];
 

--- a/packages/website/src/content/docs/commands-phases.md
+++ b/packages/website/src/content/docs/commands-phases.md
@@ -17,11 +17,11 @@ Phase lifecycle is managed through two commands: `/maxsim:plan` for planning and
 /maxsim:plan
 {% /codeblock %}
 
-Each PLAN.md is a structured document with frontmatter (phase, plan number, type, wave, dependencies), an objective, task breakdown with type annotations, verification criteria, and success conditions.
+Each plan is a structured GitHub Issue comment with frontmatter (phase, plan number, type, wave, dependencies), an objective, task breakdown with type annotations, verification criteria, and success conditions.
 
 ### Execution with `/maxsim:execute`
 
-`/maxsim:execute` reads all PLAN.md files for a phase, groups them by wave, and runs each wave's plans in parallel using isolated worktrees. Auto-verify runs after execution completes. Gap closure is handled automatically.
+`/maxsim:execute` reads all plan comments from the phase GitHub Issue, groups them by wave, and runs each wave's plans in parallel using isolated worktrees. Auto-verify runs after execution completes. Gap closure is handled automatically.
 
 {% codeblock language="bash" %}
 /maxsim:execute

--- a/packages/website/src/content/docs/gap-closure.md
+++ b/packages/website/src/content/docs/gap-closure.md
@@ -4,7 +4,7 @@ title: Gap Closure
 group: Advanced
 ---
 
-When verification finds broken items, it creates focused fix phases automatically. If phase 1 has two broken items, they become phases 1.1 and 1.2. Each has its own PLAN.md and is executed independently.
+When verification finds broken items, it creates focused fix phases automatically. If phase 1 has two broken items, they become phases 1.1 and 1.2. Each has its own plan comment (posted as a GitHub Issue comment with `gap_closure: true` in frontmatter) and is executed independently.
 
 Gap closure is handled as part of the execute workflow. After verification identifies gaps, run `/maxsim:execute` to close them.
 


### PR DESCRIPTION
## Summary
- Replaced all `PLAN.md` references with GitHub Issue comment equivalents in website docs (`commands-phases.md`, `gap-closure.md`)
- Updated Hero terminal animation to show "Publishing plan to GitHub Issue #2" instead of "Generating 02-01-PLAN.md"
- Added 4 missing commands (`debug-loop`, `fix-loop`, `improve`, `security`) to the README command table
- Fixed stale `PLAN.md` reference in the README Agents table (Planner row)

## Test plan
- [ ] Verify website docs render correctly with updated text
- [ ] Verify Hero terminal animation displays the new GitHub-first message
- [ ] Verify README command table is properly formatted with all 13 commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)