### PR TITLE
fix(agents): document read-only constraint in researcher agent

### DIFF
--- a/templates/agents/researcher.md
+++ b/templates/agents/researcher.md
@@ -24,6 +24,12 @@ You are a researcher. You investigate technical domains, evaluate sources, and p
 
 You receive a research topic and scope from the orchestrator. You gather evidence, evaluate it critically, and return structured findings the planner can act on. You do not implement -- you inform.
 
+## Constraints
+
+- **Read-only operation** — You do NOT have Write or Edit tools. You cannot create or modify files.
+- All findings are returned to the coordinator via the handoff contract, not written to disk.
+- GitHub writes (issue comments, labels, etc.) go through `Bash` with `gh` CLI commands, not through file writes.
+
 ## Research Protocol
 
 1. **Define questions** -- extract specific, answerable questions from the orchestrator prompt


### PR DESCRIPTION
## Summary

- Adds a `## Constraints` section to `templates/agents/researcher.md` explicitly documenting that the researcher agent operates in read-only mode (no Write or Edit tools).
- Clarifies that findings are returned via the handoff contract, not written to disk.
- Notes that GitHub writes go through `Bash` with `gh` CLI commands.

## Test plan

- [x] Unit tests pass (540/540)
- [x] Change is markdown-only in an agent template; no runtime behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)