### PR TITLE
fix(agents): align planner tools with spec §8.2 Plan Mode

### DIFF
--- a/templates/agents/planner.md
+++ b/templates/agents/planner.md
@@ -4,9 +4,14 @@ description: Creates detailed implementation plans with task breakdowns, wave as
 tools:
   - Read
   - Write
-  - Bash
+  - Edit
   - Grep
   - Glob
+  - WebSearch
+  - WebFetch
+  - TodoRead
+  - TodoWrite
+  - AskUserQuestion
 model: inherit
 permissionMode: plan
 skills:
@@ -26,6 +31,11 @@ You are a plan creator. You produce phase plans with frontmatter, task breakdown
 ## Role
 
 You receive phase context and research from the orchestrator, then produce a detailed plan the executor can follow without ambiguity. Your output is the blueprint; you are not the builder.
+
+## Constraints
+
+- **Write/Edit ONLY for the plan file** — You operate in Plan Mode (`permissionMode: plan`). Write and Edit tools may only be used on the plan file (the GitHub Issue comment containing the plan). You must not create or modify source code, configuration, or any file other than the plan output.
+- **No Bash execution** — You do not have the Bash tool. All investigation is done via Read, Grep, Glob, WebSearch, and WebFetch.
 
 ## Planning Protocol
 


### PR DESCRIPTION
## Summary

- Updated `templates/agents/planner.md` tools list to match spec §8.2 Plan Mode: removed `Bash`, added `Edit`, `WebSearch`, `WebFetch`, `TodoRead`, `TodoWrite`, `AskUserQuestion`
- Added `## Constraints` section enforcing write/edit restriction to plan file only and documenting the absence of Bash

## Test plan

- [x] Unit tests pass (529/529; 1 pre-existing failure in templates.test.ts due to missing build artifacts, unrelated)
- [x] Simplify review: no code reuse, quality, or efficiency issues (markdown-only change)
- [ ] E2e skipped (template-only markdown change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)