### PR TITLE
fix(commands): add explicit EnterPlanMode/ExitPlanMode to execute, quick, settings

### DIFF
--- a/templates/commands/maxsim/execute.md
+++ b/templates/commands/maxsim/execute.md
@@ -22,10 +22,13 @@ Re-entry: If phase is already executed and verified, show status and offer optio
 <process>
 Follow @.claude/maxsim/workflows/execute.md end-to-end.
 
-1. Detect phase state from GitHub Project Board (already done / partially executed / ready)
-2. Group task Issues by wave — re-evaluate wave composition before each spawn against current GitHub state, execute parallel Agents within each wave, sequential across waves
-3. Each Agent updates its GitHub Issue label on start and completion
-4. After all tasks complete, spawn a verifier Agent to check acceptance criteria
-5. On verification failure, auto-retry with gap-closure context (max 3 retries, 4 total attempts)
-6. On final failure, report what failed and surface options to user
+1. **Plan Mode:** Call `EnterPlanMode` before any execution
+2. Detect phase state from GitHub Project Board (already done / partially executed / ready)
+3. Group task Issues by wave — re-evaluate wave composition before each spawn against current GitHub state. Present the execution plan to the user for review.
+4. Exit Plan Mode via `ExitPlanMode` — user reviews and approves the execution plan
+5. Execute parallel Agents within each wave, sequential across waves
+6. Each Agent updates its GitHub Issue label on start and completion
+7. After all tasks complete, spawn a verifier Agent to check acceptance criteria
+8. On verification failure, auto-retry with gap-closure context (max 3 retries, 4 total attempts)
+9. On final failure, report what failed and surface options to user
 </process>

--- a/templates/commands/maxsim/quick.md
+++ b/templates/commands/maxsim/quick.md
@@ -20,13 +20,15 @@ Quick tasks are tracked as GitHub Issues (label: `type:quick`) — separate from
 <process>
 Follow @.claude/maxsim/workflows/quick.md end-to-end.
 
-1. Get task description from $ARGUMENTS or via AskUserQuestion
-2. Clarify scope if ambiguous (one focused question)
-3. Create a GitHub Issue labeled `type:quick` for the task
-4. Spawn a planner Agent (quick mode) to produce a concise implementation plan
-5. Spawn executor Agent(s) to implement the plan
-6. Spawn a verifier Agent to check the result (tests pass, build succeeds, lint clean)
-7. If verification fails, spawn a fix agent (max 2 retries)
-8. Commit with atomic message referencing the GitHub Issue
-9. Close the GitHub Issue with completion summary
+1. **Plan Mode:** Call `EnterPlanMode` before any planning or execution
+2. Get task description from $ARGUMENTS or via AskUserQuestion
+3. Clarify scope if ambiguous (one focused question)
+4. Create a GitHub Issue labeled `type:quick` for the task
+5. Spawn a planner Agent (quick mode) to produce a concise implementation plan
+6. Present the plan to user — Exit Plan Mode via `ExitPlanMode`
+7. Spawn executor Agent(s) to implement the plan
+8. Spawn a verifier Agent to check the result (tests pass, build succeeds, lint clean)
+9. If verification fails, spawn a fix agent (max 2 retries)
+10. Commit with atomic message referencing the GitHub Issue
+11. Close the GitHub Issue with completion summary
 </process>

--- a/templates/commands/maxsim/settings.md
+++ b/templates/commands/maxsim/settings.md
@@ -16,9 +16,10 @@ Configuration is stored in `.claude/maxsim/config.json` (project-level). Present
 <process>
 Follow @.claude/maxsim/workflows/settings.md end-to-end.
 
-1. Read current config from CLAUDE.md and `.claude/maxsim/config.json`
-2. Display current settings with descriptions
-3. Use AskUserQuestion to interactively configure:
+1. **Plan Mode:** Call `EnterPlanMode` before presenting settings
+2. Read current config from CLAUDE.md and `.claude/maxsim/config.json`
+3. Display current settings with descriptions
+4. Use AskUserQuestion to interactively configure:
    - Model profile (with per-tier model assignment details)
    - Research stage enabled/disabled
    - Plan-checker enabled/disabled
@@ -26,6 +27,8 @@ Follow @.claude/maxsim/workflows/settings.md end-to-end.
    - Auto-advance between stages
    - Branching strategy (per-phase / per-task / none)
    - Per-agent model overrides (override individual agent models beyond profile defaults)
-4. Merge answers and write updated config
-5. Display confirmation of saved settings
+5. Present proposed configuration changes for review
+6. Exit Plan Mode via `ExitPlanMode` — user reviews and approves changes
+7. Merge answers and write updated config
+8. Display confirmation of saved settings
 </process>


### PR DESCRIPTION
## Summary
- Added explicit `EnterPlanMode` / `ExitPlanMode` steps to the `<process>` blocks of `execute.md`, `quick.md`, and `settings.md` command templates
- Each command now enters Plan Mode before doing work and exits it after presenting results for user review/approval
- Follows the same pattern already established in `go.md`

## Test plan
- [x] All 540 unit tests pass
- [x] E2E skipped (template-only markdown changes, no runtime behavior affected)
- [x] Verified step numbering is sequential and correct in all three files

🤖 Generated with [Claude Code](https://claude.com/claude-code)