### PR TITLE
fix(autoresearch): add GitHub Issue escalation as step 7 in stuck detection

### DIFF
--- a/templates/skills/autoresearch/references/loop-protocol.md
+++ b/templates/skills/autoresearch/references/loop-protocol.md
@@ -168,6 +168,7 @@ Best iteration: #{n} — {description}
 4. Try combining 2-3 previously successful changes.
 5. Try the opposite of what has not been working.
 6. Try a radical architectural change.
+7. **Escalate** — If still stuck after all above: create a diagnostic GitHub Issue (`gh issue create --label "type:bug" --label "maxsim:auto" --title "Stuck: [scope] after [N] consecutive failures" --body "[full context: iterations attempted, approaches tried, current metric value, TSV log summary, suspected blockers]"`) and escalate to the user. Do not continue the loop — wait for human guidance.
 
 ## Crash Recovery
 


### PR DESCRIPTION
## Summary
- Adds step 7 to the "When Stuck" section of the autoresearch loop protocol
- The new step instructs the agent to create a diagnostic GitHub Issue and escalate to the user when all 6 existing recovery steps have been exhausted
- Prevents infinite stuck loops by requiring human guidance after escalation

## Test plan
- [x] Verified markdown formatting matches existing numbered steps
- [x] Unit tests pass (529/529; 1 pre-existing build-artifact failure unrelated to this change)
- [x] E2E skipped (template-only markdown change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)