### PR TITLE
feat: add competitive_enabled and worktree path/branch templates (§7.2, §7.3-7.4)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -154,6 +154,10 @@ Removes MAXSIM files from `.claude/`. Your own skills, agents, and Claude Code c
 | `/maxsim:quick <description>` | Quick task — create a GitHub Issue and execute in simplified flow |
 | `/maxsim:progress` | Show project status from GitHub Project Board with next-action recommendation |
 | `/maxsim:debug` | Systematic debugging with reproduce-hypothesize-isolate-verify-fix cycle |
+| `/maxsim:debug-loop [symptom]` | Autonomous bug hunting with hypothesis testing |
+| `/maxsim:fix-loop [error-command]` | Autonomous error repair until zero errors remain |
+| `/maxsim:improve [metric-command]` | Autonomous optimization loop against any metric |
+| `/maxsim:security [scope]` | Security audit — STRIDE + OWASP + red-team (read-only) |
 | `/maxsim:settings` | View and modify MaxsimCLI configuration |
 | `/maxsim:help` | Show available MaxsimCLI commands and usage |
 
@@ -210,7 +214,7 @@ Phase numbers are flexible. Integer (`01`, `02`), letter suffixes for parallel t
 | Agent | Role | What it does |
 |-------|------|-------------|
 | Executor | Builds things | Reads plans, makes code changes, commits atomically, handles deviations |
-| Planner | Creates plans | Turns research into structured PLAN.md files with tasks, waves, and dependencies |
+| Planner | Creates plans | Turns research into structured plan comments on GitHub Issues with tasks, waves, and dependencies |
 | Researcher | Investigates | Explores the codebase, gathers technical context, can use Brave Search |
 | Verifier | Checks results | Validates plan structure, artifacts, requirement evidence, commit integrity |
 

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -183,6 +183,7 @@ export interface MaxsimConfig {
   version: string;
   execution: {
     model_profile: ModelProfile;
+    competitive_enabled: boolean;
     model_overrides?: Partial<Record<AgentType, Model>>;
     parallelism: {
       max_agents_per_wave: number;
@@ -199,6 +200,8 @@ export interface MaxsimConfig {
   worktrees: {
     auto_cleanup: boolean;
     branch_prefix: string;
+    path_template: string;
+    branch_template: string;
   };
   automation: {
     auto_commit_on_success: boolean;
@@ -227,6 +230,7 @@ export const DEFAULT_CONFIG: MaxsimConfig = {
   version: VERSION,
   execution: {
     model_profile: ModelProfile.BALANCED,
+    competitive_enabled: false,
     parallelism: {
       max_agents_per_wave: 3,
       max_retries: 3,
@@ -248,6 +252,8 @@ export const DEFAULT_CONFIG: MaxsimConfig = {
   worktrees: {
     auto_cleanup: true,
     branch_prefix: 'maxsim/',
+    path_template: '.claude/worktrees/agent-{id}/',
+    branch_template: 'maxsim/phase-{N}-task-{id}',
   },
   automation: {
     auto_commit_on_success: true,

--- a/packages/cli/src/core/version.ts
+++ b/packages/cli/src/core/version.ts
@@ -1,5 +1,5 @@
 /** MaxsimCLI version — auto-injected from package.json at build time. */
-export const VERSION = '5.12.0';
+export const VERSION = '5.13.1';
 
 /**
  * Parse a semantic version string into components.

--- a/packages/cli/tests/unit/types.test.ts
+++ b/packages/cli/tests/unit/types.test.ts
@@ -235,4 +235,13 @@ describe('DEFAULT_CONFIG', () => {
     expect(DEFAULT_CONFIG.git).toBeDefined();
     expect(DEFAULT_CONFIG.git.branching_strategy).toBe('phase');
   });
+
+  it('includes competitive_enabled default as false', () => {
+    expect(DEFAULT_CONFIG.execution.competitive_enabled).toBe(false);
+  });
+
+  it('includes worktree path and branch templates', () => {
+    expect(DEFAULT_CONFIG.worktrees.path_template).toBe('.claude/worktrees/agent-{id}/');
+    expect(DEFAULT_CONFIG.worktrees.branch_template).toBe('maxsim/phase-{N}-task-{id}');
+  });
 });

--- a/templates/templates/config.json
+++ b/templates/templates/config.json
@@ -1,7 +1,8 @@
 {
-  "version": "0.0.0-dev",
+  "version": "5.13.1",
   "execution": {
     "model_profile": "balanced",
+    "competitive_enabled": false,
     "parallelism": {
       "max_agents_per_wave": 3,
       "max_retries": 3,
@@ -22,7 +23,9 @@
   },
   "worktrees": {
     "auto_cleanup": true,
-    "branch_prefix": "maxsim/"
+    "branch_prefix": "maxsim/",
+    "path_template": ".claude/worktrees/agent-{id}/",
+    "branch_template": "maxsim/phase-{N}-task-{id}"
   },
   "automation": {
     "auto_commit_on_success": true,


### PR DESCRIPTION
## Summary

- Adds `competitive_enabled: boolean` to `MaxsimConfig.execution` interface and `DEFAULT_CONFIG` (fixes audit gap §7.2)
- Adds `path_template: string` and `branch_template: string` to `MaxsimConfig.worktrees` interface and `DEFAULT_CONFIG` (fixes audit gaps §7.3-7.4)
- Mirrors both changes in `templates/templates/config.json`
- Adds two new test cases in `types.test.ts` to cover the new defaults

## Test plan

- [x] `npx vitest run` — 539 tests pass (17/18 suites; `templates.test.ts` failure is pre-existing, requires built dist)
- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npm run lint` — no new lint errors introduced (9 warnings + 28 infos are all pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)