### PR TITLE
docs(execute): add tier selection and isolation parameter info

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -154,6 +154,10 @@ Removes MAXSIM files from `.claude/`. Your own skills, agents, and Claude Code c
 | `/maxsim:quick <description>` | Quick task — create a GitHub Issue and execute in simplified flow |
 | `/maxsim:progress` | Show project status from GitHub Project Board with next-action recommendation |
 | `/maxsim:debug` | Systematic debugging with reproduce-hypothesize-isolate-verify-fix cycle |
+| `/maxsim:debug-loop [symptom]` | Autonomous bug hunting with hypothesis testing |
+| `/maxsim:fix-loop [error-command]` | Autonomous error repair until zero errors remain |
+| `/maxsim:improve [metric-command]` | Autonomous optimization loop against any metric |
+| `/maxsim:security [scope]` | Security audit — STRIDE + OWASP + red-team (read-only) |
 | `/maxsim:settings` | View and modify MaxsimCLI configuration |
 | `/maxsim:help` | Show available MaxsimCLI commands and usage |
 
@@ -210,7 +214,7 @@ Phase numbers are flexible. Integer (`01`, `02`), letter suffixes for parallel t
 | Agent | Role | What it does |
 |-------|------|-------------|
 | Executor | Builds things | Reads plans, makes code changes, commits atomically, handles deviations |
-| Planner | Creates plans | Turns research into structured PLAN.md files with tasks, waves, and dependencies |
+| Planner | Creates plans | Turns research into structured plan comments on GitHub Issues with tasks, waves, and dependencies |
 | Researcher | Investigates | Explores the codebase, gathers technical context, can use Brave Search |
 | Verifier | Checks results | Validates plan structure, artifacts, requirement evidence, commit integrity |
 

--- a/packages/cli/src/core/version.ts
+++ b/packages/cli/src/core/version.ts
@@ -1,5 +1,5 @@
 /** MaxsimCLI version — auto-injected from package.json at build time. */
-export const VERSION = '5.12.0';
+export const VERSION = '5.13.1';
 
 /**
  * Parse a semantic version string into components.

--- a/templates/commands/maxsim/execute.md
+++ b/templates/commands/maxsim/execute.md
@@ -27,6 +27,9 @@ Follow @.claude/maxsim/workflows/execute.md end-to-end.
 3. Group task Issues by wave — re-evaluate wave composition before each spawn against current GitHub state. Present the execution plan to the user for review.
 4. Exit Plan Mode via `ExitPlanMode` — user reviews and approves the execution plan
 5. Execute parallel Agents within each wave, sequential across waves
+   - Tier 1 (default): each Agent uses `isolation: "worktree"` and `run_in_background: true`
+   - Tier 2 (opt-in, `competition_strategy: deep`): Agent Teams with `SendMessage` debate — requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+   - Graceful degradation: if Tier 2 is unavailable, falls back to Tier 1 automatically
 6. Each Agent updates its GitHub Issue label on start and completion
 7. After all tasks complete, spawn a verifier Agent to check acceptance criteria
 8. On verification failure, auto-retry with gap-closure context (max 3 retries, 4 total attempts)

--- a/templates/templates/config.json
+++ b/templates/templates/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0-dev",
+  "version": "5.13.1",
   "execution": {
     "model_profile": "balanced",
     "parallelism": {


### PR DESCRIPTION
## Summary

- Adds three sub-bullets under step 5 of `templates/commands/maxsim/execute.md` documenting Tier 1 worktree isolation defaults, Tier 2 deep competition strategy opt-in, and graceful degradation fallback
- Brings the §7.2 Parallelism Strategy audit closer to 100% by documenting `isolation: "worktree"`, `run_in_background: true`, `competition_strategy: deep`, and `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` requirements
- Build artifacts (README.md, version.ts, config.json) updated by build scripts

## Test plan

- [x] `npx vitest run` — 548 tests pass (18 test files)
- [x] `npm run build` — TypeScript compiles and assets copy cleanly
- [x] `npm run lint` — Biome passes (no errors; pre-existing warnings/infos in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)