### PR TITLE
fix(fix-loop): add explicit rejection/revision loop to Plan Mode (§8 audit gap)

### DIFF
--- a/templates/commands/maxsim/fix-loop.md
+++ b/templates/commands/maxsim/fix-loop.md
@@ -31,8 +31,12 @@ Invoke the `autoresearch` skill (fix workflow) to drive the repair loop. Invoke 
    - **Iteration budget** — max fix attempts before stopping (default: 30)
    - **Scope** — which files/directories are in-scope for modification (default: auto-detect from errors)
 3. Run the error command once to establish the baseline error count
-4. Show the proposed loop configuration, baseline error count, and confirm with user
-5. Exit Plan Mode via ExitPlanMode
+4. Show the proposed loop configuration, baseline error count, and ask user to confirm
+5. **Handle user response:**
+   - **If user approves:** proceed to step 6
+   - **If user requests changes:** return to step 2 to re-gather the modified parameters (stay in Plan Mode). If the error command changed, re-run it for a new baseline (step 3). Re-show the revised configuration and confirm again.
+   - **If user cancels:** Exit Plan Mode via ExitPlanMode and stop — do not start the fix loop.
+6. Exit Plan Mode via ExitPlanMode
 
 **Phase 2 — Fix Loop**
 


### PR DESCRIPTION
## Summary

- Adds an explicit step 5 "Handle user response" block to Phase 1 (Plan Mode) of `fix-loop.md`
- Covers three paths: approve (proceed), request changes (loop back to step 2 with optional baseline re-run), and cancel (ExitPlanMode and stop)
- Closes the §8 audit gap where no rejection/revision path existed after showing the proposed configuration

## Test plan

- [x] All 18 unit test suites pass (550 tests) after `npm run build && npm test`
- [x] Simplify review found no issues — change is clean prose only
- [x] Template structure and frontmatter unchanged; `exactly 13 .md files exist` test continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)